### PR TITLE
Add dpi option in figure export

### DIFF
--- a/data/config.json
+++ b/data/config.json
@@ -4,6 +4,7 @@
 "addequation_step_size": "0.01",
 "addequation_x_start": "0",
 "addequation_x_stop": "10",
+"export_figure_dpi": "100",
 "export_figure_filetype": "svg",
 "export_figure_transparent": true,
 "guess_headers": true,

--- a/data/ui/export_figure.blp
+++ b/data/ui/export_figure.blp
@@ -32,6 +32,22 @@ template ExportFigureWindow : Adw.Window {
           model: StringList {};
         }
 
+      Adw.ActionRow {
+        title: _("Figure dpi");
+        subtitle: _("Set the resolution of the figure in dots per inch ");
+
+        SpinButton export_figure_dpi {
+          valign: center;
+          numeric: true;
+          value: 100;
+          wrap: true;
+          adjustment: Adjustment {
+            step-increment: 1;
+            upper: 999;
+          };
+        }
+      }
+
         Adw.ActionRow {
           title: _("Transparent Background");
           subtitle: _("Export using a transparent background.");

--- a/data/ui/export_figure.blp
+++ b/data/ui/export_figure.blp
@@ -33,8 +33,8 @@ template ExportFigureWindow : Adw.Window {
         }
 
       Adw.ActionRow {
-        title: _("Figure dpi");
-        subtitle: _("Set the resolution of the figure in dots per inch ");
+        title: _("Graph dpi");
+        subtitle: _("Set the resolution of the graph in dots per inch ");
 
         SpinButton export_figure_dpi {
           valign: center;

--- a/data/ui/preferences.blp
+++ b/data/ui/preferences.blp
@@ -116,7 +116,7 @@ template PreferencesWindow : Adw.PreferencesWindow {
 
       Adw.ActionRow {
         title: _("Figure dpi");
-        subtitle: _("Set the resolution of the figure in dots per inch ");
+        subtitle: _("Set the default resolution of the figure in dots per inch ");
 
         SpinButton export_figure_dpi {
           valign: center;

--- a/data/ui/preferences.blp
+++ b/data/ui/preferences.blp
@@ -115,6 +115,22 @@ template PreferencesWindow : Adw.PreferencesWindow {
       }
 
       Adw.ActionRow {
+        title: _("Figure dpi");
+        subtitle: _("Set the resolution of the figure in dots per inch ");
+
+        SpinButton export_figure_dpi {
+          valign: center;
+          numeric: true;
+          value: 100;
+          wrap: true;
+          adjustment: Adjustment {
+            step-increment: 1;
+            upper: 999;
+          };
+        }
+      }
+
+      Adw.ActionRow {
         title: _("Transparent Background");
         subtitle: _("Use a transparent background for the saved plots");
         activatable-widget: export_figure_transparent;

--- a/data/ui/preferences.blp
+++ b/data/ui/preferences.blp
@@ -115,8 +115,8 @@ template PreferencesWindow : Adw.PreferencesWindow {
       }
 
       Adw.ActionRow {
-        title: _("Figure dpi");
-        subtitle: _("Set the default resolution of the figure in dots per inch ");
+        title: _("Graph dpi");
+        subtitle: _("Set the default resolution of the graph in dots per inch ");
 
         SpinButton export_figure_dpi {
           valign: center;

--- a/src/export_figure.py
+++ b/src/export_figure.py
@@ -29,7 +29,7 @@ class ExportFigureWindow(Adw.Window):
         for name, formats in items:
             file_formats.append(name)
             if self.parent.preferences.config["export_figure_filetype"] in \
-                formats:
+                    formats:
                 default_format = name
         utilities.populate_chooser(self.file_format, file_formats)
         if default_format is not None:

--- a/src/export_figure.py
+++ b/src/export_figure.py
@@ -12,6 +12,7 @@ class ExportFigureWindow(Adw.Window):
     confirm_button = Gtk.Template.Child()
     file_format = Gtk.Template.Child()
     transparent_switch = Gtk.Template.Child()
+    export_figure_dpi = Gtk.Template.Child()
 
     def __init__(self, parent):
         super().__init__()
@@ -21,11 +22,14 @@ class ExportFigureWindow(Adw.Window):
         self.transparent_switch.set_active(
             self.parent.preferences.config["export_figure_transparent"])
         items = self.parent.canvas.get_supported_filetypes_grouped().items()
+        self.export_figure_dpi.set_value(
+            int(self.parent.preferences.config["export_figure_dpi"]))
         file_formats = []
         default_format = None
         for name, formats in items:
             file_formats.append(name)
-            if self.parent.preferences.config["savefig_filetype"] in formats:
+            if self.parent.preferences.config["export_figure_filetype"] in \
+                formats:
                 default_format = name
         utilities.populate_chooser(self.file_format, file_formats)
         if default_format is not None:
@@ -33,6 +37,7 @@ class ExportFigureWindow(Adw.Window):
         self.present()
 
     def on_accept(self, _):
+        dpi = int(self.export_figure_dpi.get_value())
         fmt = self.file_format.get_selected_item().get_string()
         file_suffix = None
         items = self.parent.canvas.get_supported_filetypes_grouped().items()
@@ -45,17 +50,17 @@ class ExportFigureWindow(Adw.Window):
         dialog.set_initial_name(f"{filename}.{file_suffix}")
         dialog.set_accept_label("Export")
         dialog.save(
-            self.parent.main_window, None, self.on_figure_save_response,
+            self.parent.main_window, None, self.on_figure_save_response, dpi,
             file_suffix, transparent)
         self.destroy()
 
     def on_figure_save_response(
-            self, dialog, response, file_suffix, transparent):
+            self, dialog, response, dpi, file_suffix, transparent):
         try:
             path = dialog.save_finish(response).get_path()
             if path is not None:
                 self.parent.canvas.figure.savefig(
-                    path, format=file_suffix, transparent=transparent)
+                    path, dpi=dpi, format=file_suffix, transparent=transparent)
                 self.parent.main_window.add_toast("Exported Figure")
         except GLib.GError:
             pass

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -68,6 +68,7 @@ class PreferencesWindow(Adw.PreferencesWindow):
     addequation_x_start = Gtk.Template.Child()
     addequation_x_stop = Gtk.Template.Child()
     addequation_step_size = Gtk.Template.Child()
+    export_figure_dpi = Gtk.Template.Child()
     export_figure_filetype = Gtk.Template.Child()
     export_figure_transparent = Gtk.Template.Child()
     action_center_data = Gtk.Template.Child()
@@ -112,6 +113,7 @@ class PreferencesWindow(Adw.PreferencesWindow):
         self.addequation_x_stop.set_text(str(config["addequation_x_stop"]))
         self.addequation_step_size.set_text(
             str(config["addequation_step_size"]))
+        self.export_figure_dpi.set_value(int(config["export_figure_dpi"]))
         utilities.set_chooser(
             self.export_figure_filetype, config["export_figure_filetype"])
         self.export_figure_transparent.set_active(
@@ -158,6 +160,7 @@ class PreferencesWindow(Adw.PreferencesWindow):
         config["addequation_x_start"] = self.addequation_x_start.get_text()
         config["addequation_x_stop"] = self.addequation_x_stop.get_text()
         config["addequation_step_size"] = self.addequation_step_size.get_text()
+        config["export_figure_dpi"] = int(self.export_figure_dpi.get_value())
         config["export_figure_filetype"] = \
             self.export_figure_filetype.get_selected_item().get_string()
         config["export_figure_transparent"] = \


### PR DESCRIPTION
Adds the option to set the dpi (dots per inch) for a figure when exporting, can be a relevant setting for raster images (non-svg).
Works quite well for me. Have set the maximum setting to 999 dpi, but perhaps it should have no maximum at all. 