### PR TITLE
Fix attribute checks

### DIFF
--- a/src/graphs.py
+++ b/src/graphs.py
@@ -50,8 +50,8 @@ def open_project(self, path):
     try:
         new_plot_settings, new_datadict, _version = \
             file_io.load_project(path)
-        self.plot_settings = new_plot_settings
         utilities.set_attributes(new_plot_settings, self.plot_settings)
+        self.plot_settings = new_plot_settings
         self.datadict = {}
         for _key, item in new_datadict.items():
             new_item = Item(self, item.xdata, item.ydata)

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from gi.repository import Gdk
 
 import numpy
+import pickle
 
 
 def remove_unused_config_keys(config, template):
@@ -210,9 +211,12 @@ def set_attributes(new_object, template):
     for attribute in template.__dict__:
         if not hasattr(new_object, attribute):
             setattr(new_object, attribute, getattr(template, attribute))
+    delete_attributes = []
     for attribute in new_object.__dict__:
         if not hasattr(template, attribute):
-            delattr(new_object, attribute)
+            delete_attributes.append(attribute)
+    for attribute in delete_attributes:
+        delattr(new_object, attribute)
 
 
 def shorten_label(label, max_length=20):


### PR DESCRIPTION
Fixes two bugs with the attribute checks: 

- When loadigng the plot_settigns in a project, in the old code, it first defines self.plot_settings as to be equal to new_plot_settings, and then compares this with new_plot_settings. So it just compared with itself and never notices if attributes are out of sync
- In the set_attributes function in utilities looping through the dictionary, it deletes attributes during the iteration. This gives an error as dictionaries (and lists) are not allowed to change size. (This is because they're ordered nowadays). The solution is to make a list of which attributes to delete, and then iterate through that. (I was hoping for a cleaner solution, but that's also the solution that is suggested pretty much everywhere)

This is basically a fix I had when testing stuff this morning. 

I noticed that there's some other problems when loading old projects. Basically Pickle (the module being used to save projects) is dependent on having the same modules being loaded. We changed name for the data sets from Data to Item. So when it loads an old project, it looks for the data module, and then spits out an error. I did manage to fix this. But you have to hard-code a function that checks if the old name is used, and then replaces it with a new name. See this thread: https://stackoverflow.com/questions/2121874/python-pickling-after-changing-a-modules-directory/2121918#2121918 

However, those older projects where never part of any release, and it would require a number of manual fixes that are bit ugly. So compatibility is not broken. But it is good to know in case we do change module names at one point between releases. 
