### PR TITLE
Rework clipboard

### DIFF
--- a/data/config.json
+++ b/data/config.json
@@ -4,6 +4,7 @@
 "addequation_step_size": "0.01",
 "addequation_x_start": "0",
 "addequation_x_stop": "10",
+"clipboard_length": "15",
 "export_figure_dpi": "100",
 "export_figure_filetype": "svg",
 "export_figure_transparent": true,

--- a/data/ui/preferences.blp
+++ b/data/ui/preferences.blp
@@ -158,6 +158,22 @@ template PreferencesWindow : Adw.PreferencesWindow {
       title: _("Other");
       description: _("Other general settings");
 
+      Adw.ActionRow {
+        title: _("Clipboard length");
+        subtitle: _("Choose how many states are stored in the clipboard");
+
+        SpinButton clipboard_length {
+          valign: center;
+          numeric: true;
+          value: 15;
+          wrap: true;
+          adjustment: Adjustment {
+            step-increment: 1;
+            upper: 999;
+          };
+        }
+      }
+
       Adw.ComboRow other_handle_duplicates {
         title: _("Handle duplicate entries");
         subtitle: _("Choose how to handle duplicate entries to be loaded");

--- a/src/clipboard.py
+++ b/src/clipboard.py
@@ -21,7 +21,7 @@ def add(self):
     self.clipboard_pos = -1
     self.datadict_clipboard.append(copy.deepcopy(self.datadict))
     if len(self.datadict_clipboard) > \
-            self.preferences.config["clipboard_length"] + 1:
+            int(self.preferences.config["clipboard_length"]) + 1:
         self.datadict_clipboard = \
             self.datadict_clipboard[1:]
 

--- a/src/clipboard.py
+++ b/src/clipboard.py
@@ -36,7 +36,9 @@ def undo(self):
     if self.clipboard_pos < -1:
         self.main_window.redo_button.set_sensitive(True)
     graphs.reload(self)
+    graphs.check_open_data(self)
     ui.reload_item_menu(self)
+
 
 
 def redo(self):
@@ -53,4 +55,5 @@ def redo(self):
     if self.clipboard_pos >= -1:
         self.main_window.redo_button.set_sensitive(False)
     graphs.reload(self)
+    graphs.check_open_data(self)
     ui.reload_item_menu(self)

--- a/src/clipboard.py
+++ b/src/clipboard.py
@@ -1,15 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
-from graphs import graphs
-
-
-def reset(self):
-    for _key, item in self.datadict.items():
-        item.xdata_clipboard = [item.xdata.copy()]
-        item.ydata_clipboard = [item.ydata.copy()]
-        item.clipboard_pos = -1
-    win = self.main_window
-    win.redo_button.set_sensitive(False)
-    win.undo_button.set_sensitive(False)
+from graphs import graphs, ui
+import copy
 
 
 def add(self):
@@ -17,24 +8,17 @@ def add(self):
     Add data to the clipboard, is performed whenever an action is performed.
     Appends the latest state to the clipboard.
     """
-    undo_button = self.main_window.undo_button
-    undo_button.set_sensitive(True)
+    self.main_window.undo_button.set_sensitive(True)
 
     # If a couple of redo"s were performed previously, it deletes the clipboard
     # data that is located after the current clipboard position and disables
     # the redo button
-    for _key, item in self.datadict.items():
-        delete_lists = - item.clipboard_pos - 1
-        for _index in range(delete_lists):
-            del item.xdata_clipboard[-1]
-            del item.ydata_clipboard[-1]
-        if delete_lists != 0:
-            redo_button = self.main_window.redo_button
-            redo_button.set_sensitive(False)
-
-        item.clipboard_pos = -1
-        item.xdata_clipboard.append(item.xdata.copy())
-        item.ydata_clipboard.append(item.ydata.copy())
+    if self.clipboard_pos != -1:
+        self.datadict_clipboard = \
+            self.datadict_clipboard[:self.clipboard_pos+1]
+    self.clipboard_pos = -1
+    self.datadict_clipboard.append(copy.deepcopy(self.datadict))
+    self.main_window.redo_button.set_sensitive(False)
 
 
 def undo(self):
@@ -42,17 +26,17 @@ def undo(self):
     Undo an action, moves the clipboard position backwards by one and changes
     the dataset to the state before the previous action was performed
     """
-    undo_button = self.main_window.undo_button
-    redo_button = self.main_window.redo_button
-    for _key, item in self.datadict.items():
-        if abs(item.clipboard_pos) < len(item.xdata_clipboard):
-            item.clipboard_pos -= 1
-            redo_button.set_sensitive(True)
-            item.xdata = item.xdata_clipboard[item.clipboard_pos].copy()
-            item.ydata = item.ydata_clipboard[item.clipboard_pos].copy()
-    if abs(item.clipboard_pos) >= len(item.xdata_clipboard):
-        undo_button.set_sensitive(False)
-    graphs.refresh(self, set_limits=True)
+    if abs(self.clipboard_pos) < len(self.datadict_clipboard):
+        self.clipboard_pos -= 1
+        self.datadict = \
+            copy.deepcopy(self.datadict_clipboard[self.clipboard_pos])
+
+    if abs(self.clipboard_pos) >= len(self.datadict_clipboard):
+        self.main_window.undo_button.set_sensitive(False)
+    if self.clipboard_pos < -1:
+        self.main_window.redo_button.set_sensitive(True)
+    graphs.reload(self)
+    ui.reload_item_menu(self)
 
 
 def redo(self):
@@ -60,14 +44,13 @@ def redo(self):
     Redo an action, moves the clipboard position forwards by one and changes
     the dataset to the state before the previous action was undone
     """
-    undo_button = self.main_window.undo_button
-    redo_button = self.main_window.redo_button
-    for _key, item in self.datadict.items():
-        if item.clipboard_pos < -1:
-            undo_button.set_sensitive(True)
-            item.clipboard_pos += 1
-            item.xdata = item.xdata_clipboard[item.clipboard_pos].copy()
-            item.ydata = item.ydata_clipboard[item.clipboard_pos].copy()
-    if item.clipboard_pos >= -1:
-        redo_button.set_sensitive(False)
-    graphs.refresh(self, set_limits=True)
+    if self.clipboard_pos < -1:
+        self.clipboard_pos += 1
+        self.datadict = \
+            copy.deepcopy(self.datadict_clipboard[self.clipboard_pos])
+        self.main_window.undo_button.set_sensitive(True)
+
+    if self.clipboard_pos >= -1:
+        self.main_window.redo_button.set_sensitive(False)
+    graphs.reload(self)
+    ui.reload_item_menu(self)

--- a/src/clipboard.py
+++ b/src/clipboard.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
-from graphs import graphs, ui
 import copy
+
+from graphs import graphs, ui
 
 
 def add(self):
@@ -15,7 +16,7 @@ def add(self):
     # the redo button
     if self.clipboard_pos != -1:
         self.datadict_clipboard = \
-            self.datadict_clipboard[:self.clipboard_pos+1]
+            self.datadict_clipboard[:self.clipboard_pos + 1]
     self.clipboard_pos = -1
     self.datadict_clipboard.append(copy.deepcopy(self.datadict))
     self.main_window.redo_button.set_sensitive(False)

--- a/src/clipboard.py
+++ b/src/clipboard.py
@@ -17,8 +17,14 @@ def add(self):
     if self.clipboard_pos != -1:
         self.datadict_clipboard = \
             self.datadict_clipboard[:self.clipboard_pos + 1]
+
     self.clipboard_pos = -1
     self.datadict_clipboard.append(copy.deepcopy(self.datadict))
+    if len(self.datadict_clipboard) > \
+            self.preferences.config["clipboard_length"] + 1:
+        self.datadict_clipboard = \
+            self.datadict_clipboard[1:]
+
     self.main_window.redo_button.set_sensitive(False)
 
 

--- a/src/edit_item.py
+++ b/src/edit_item.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 from gi.repository import Adw, Gtk
 
-from graphs import graphs, utilities, ui
+from graphs import graphs, ui, utilities
 
 from matplotlib.lines import Line2D
 

--- a/src/edit_item.py
+++ b/src/edit_item.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 from gi.repository import Adw, Gtk
 
-from graphs import graphs, utilities
+from graphs import graphs, utilities, ui
 
 from matplotlib.lines import Line2D
 
@@ -78,4 +78,5 @@ class EditItemWindow(Adw.PreferencesWindow):
 
         self.parent.item_menu[self.item.key].get_child().label.set_text(
             utilities.shorten_label(self.item.name))
+        ui.reload_item_menu(self)
         graphs.refresh(self.parent, set_limits=True)

--- a/src/edit_item.py
+++ b/src/edit_item.py
@@ -75,8 +75,5 @@ class EditItemWindow(Adw.PreferencesWindow):
         self.item.markerstyle = utilities.get_dict_by_value(
             self.marker_dict, self.markers.get_selected_item().get_string())
         self.item.markersize = self.markersize.get_value()
-
-        self.parent.item_menu[self.item.key].get_child().label.set_text(
-            utilities.shorten_label(self.item.name))
-        ui.reload_item_menu(self)
+        ui.reload_item_menu(self.parent)
         graphs.refresh(self.parent, set_limits=True)

--- a/src/graphs.py
+++ b/src/graphs.py
@@ -111,7 +111,11 @@ def delete_item(self, key, give_toast=False):
     if give_toast:
         self.main_window.add_toast(f"Deleted {name}")
     clipboard.add(self)
+    check_open_data(self)
+
+def check_open_data(self):
     if self.datadict:
+        self.main_window.item_list.set_visible(True)
         refresh(self, set_limits=True)
         ui.enable_data_dependent_buttons(
             self, utilities.get_selected_keys(self))
@@ -119,7 +123,6 @@ def delete_item(self, key, give_toast=False):
         reload(self)
         self.main_window.item_list.set_visible(False)
         ui.enable_data_dependent_buttons(self, False)
-
 
 def reload(self):
     """Completely reload the plot of the graph"""

--- a/src/graphs.py
+++ b/src/graphs.py
@@ -2,7 +2,6 @@
 import logging
 from pathlib import Path
 from pickle import UnpicklingError
-import copy
 
 from graphs import clipboard, file_io, plotting_tools, ui, utilities
 from graphs.canvas import Canvas
@@ -112,6 +111,7 @@ def delete_item(self, key, give_toast=False):
         self.main_window.add_toast(f"Deleted {name}")
     clipboard.add(self)
     check_open_data(self)
+
 
 def check_open_data(self):
     if self.datadict:

--- a/src/item.py
+++ b/src/item.py
@@ -17,9 +17,6 @@ class Item:
         self.color = plotting_tools.get_next_color(parent)
         self.xdata = xdata
         self.ydata = ydata
-        self.clipboard_pos = -1
-        self.xdata_clipboard = [self.xdata.copy()]
-        self.ydata_clipboard = [self.ydata.copy()]
         self.linestyle = pyplot.rcParams["lines.linestyle"]
         self.linewidth = float(pyplot.rcParams["lines.linewidth"])
         self.markerstyle = pyplot.rcParams["lines.marker"]

--- a/src/item_box.py
+++ b/src/item_box.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 from gi.repository import GLib, Gdk, Gtk
 
-from graphs import graphs, ui, utilities, clipboard
+from graphs import clipboard, graphs, ui, utilities
 from graphs.edit_item import EditItemWindow
 
 

--- a/src/item_box.py
+++ b/src/item_box.py
@@ -47,11 +47,7 @@ class ItemBox(Gtk.Box):
         self.parent.datadict
         self.parent.datadict = utilities.change_key_position(
             self.parent.datadict, drop_target.key, value)
-        self.parent.item_menu = utilities.change_key_position(
-            self.parent.item_menu, drop_target.key, value)
-        for _key, item in self.parent.item_menu.items():
-            self.parent.main_window.list_box.remove(item)
-            self.parent.main_window.list_box.append(item)
+        ui.reload_item_menu(self.parent)
         graphs.reload(self.parent)
 
     def on_dnd_prepare(self, drag_source, x, y):

--- a/src/item_box.py
+++ b/src/item_box.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 from gi.repository import GLib, Gdk, Gtk
 
-from graphs import graphs, ui, utilities
+from graphs import graphs, ui, utilities, clipboard
 from graphs.edit_item import EditItemWindow
 
 
@@ -48,6 +48,7 @@ class ItemBox(Gtk.Box):
         self.parent.datadict = utilities.change_key_position(
             self.parent.datadict, drop_target.key, value)
         ui.reload_item_menu(self.parent)
+        clipboard.add(self.parent)
         graphs.reload(self.parent)
 
     def on_dnd_prepare(self, drag_source, x, y):

--- a/src/main.py
+++ b/src/main.py
@@ -31,7 +31,7 @@ class GraphsApplication(Adw.Application):
         self.author = args[6]
         self.pkgdatadir = args[7]
         self.datadict = {}
-        self.datadict_clipboard = []
+        self.datadict_clipboard = [{}]
         self.clipboard_pos = -1
         self.highlight = None
         font_list = matplotlib.font_manager.findSystemFonts(

--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 """Main application."""
 import logging
-import os
 import sys
 from inspect import getmembers, isfunction
 
@@ -24,19 +23,17 @@ class GraphsApplication(Adw.Application):
         self.appid = args[1]
         super().__init__(application_id=self.appid,
                          flags=Gio.ApplicationFlags.FLAGS_NONE)
-        self.modulepath = os.path.join(
-            os.getenv("XDG_DATA_DIRS").split(":")[0], "graphs", "graphs")
         self.version = args[0]
         self.name = args[2]
         self.copyright = args[3]
         self.website = args[4]
         self.issues = args[5]
         self.author = args[6]
+        self.pkgdatadir = args[7]
         self.datadict = {}
         self.datadict_clipboard = []
         self.clipboard_pos = -1
         self.highlight = None
-        self.item_menu = {}
         font_list = matplotlib.font_manager.findSystemFonts(
             fontpaths=None, fontext="ttf")
         for font in font_list:

--- a/src/main.py
+++ b/src/main.py
@@ -33,6 +33,8 @@ class GraphsApplication(Adw.Application):
         self.issues = args[5]
         self.author = args[6]
         self.datadict = {}
+        self.datadict_clipboard = []
+        self.clipboard_pos = -1
         self.highlight = None
         self.item_menu = {}
         font_list = matplotlib.font_manager.findSystemFonts(

--- a/src/operations.py
+++ b/src/operations.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 import logging
 
-from graphs import calculation, clipboard, graphs, utilities
+from graphs import calculation, clipboard, graphs, ui, utilities
 from graphs.item import Item
 from graphs.misc import InteractionMode
 

--- a/src/operations.py
+++ b/src/operations.py
@@ -241,4 +241,5 @@ def combine(self):
     # Create the item itself
     new_xdata, new_ydata = sort_data(new_xdata, new_ydata)
     graphs.add_item(self, Item(self, new_xdata, new_ydata, "Combined Data"))
-    clipboard.reset(self)
+    clipboard.add(self)
+    ui.reload_item_menu(self)

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -59,6 +59,7 @@ class Preferences():
 @Gtk.Template(resource_path="/se/sjoerd/Graphs/ui/preferences.ui")
 class PreferencesWindow(Adw.PreferencesWindow):
     __gtype_name__ = "PreferencesWindow"
+    clipboard_length = Gtk.Template.Child()
     import_delimiter = Gtk.Template.Child()
     import_separator = Gtk.Template.Child()
     import_column_x = Gtk.Template.Child()
@@ -102,6 +103,7 @@ class PreferencesWindow(Adw.PreferencesWindow):
 
     def load_configuration(self):
         config = self.parent.preferences.config
+        self.clipboard_length.set_value(int(config["clipboard_length"]))
         self.import_delimiter.set_text(config["import_delimiter"])
         utilities.set_chooser(
             self.import_separator, config["import_separator"])
@@ -160,6 +162,7 @@ class PreferencesWindow(Adw.PreferencesWindow):
         config["addequation_x_start"] = self.addequation_x_start.get_text()
         config["addequation_x_stop"] = self.addequation_x_stop.get_text()
         config["addequation_step_size"] = self.addequation_step_size.get_text()
+        config["clipboard_length"] = int(self.clipboard_length.get_value())
         config["export_figure_dpi"] = int(self.export_figure_dpi.get_value())
         config["export_figure_filetype"] = \
             self.export_figure_filetype.get_selected_item().get_string()

--- a/src/ui.py
+++ b/src/ui.py
@@ -33,7 +33,6 @@ def enable_data_dependent_buttons(self, enabled):
 
 
 def reload_item_menu(self):
-    child_counter = 0
     while self.main_window.item_list.get_last_child() is not None:
         self.main_window.item_list.remove(
             self.main_window.item_list.get_last_child())

--- a/src/ui.py
+++ b/src/ui.py
@@ -4,7 +4,7 @@ import os
 from gi.repository import Adw, GLib, Gtk
 
 from graphs import file_io, graphs, utilities
-
+from graphs.item_box import ItemBox
 
 def on_style_change(_shortcut, _theme, _widget, self):
     graphs.reload(self)
@@ -30,6 +30,16 @@ def enable_data_dependent_buttons(self, enabled):
     ]
     for button in dependent_buttons:
         button.set_sensitive(enabled)
+
+
+def reload_item_menu(self):
+    child_counter = 0
+    while self.main_window.item_list.get_last_child() is not None:
+        self.main_window.item_list.remove(
+            self.main_window.item_list.get_last_child())
+
+    for _key, item in self.datadict.items():
+        self.main_window.item_list.append(ItemBox(self, item))
 
 
 def on_confirm_discard_response(_dialog, response, self):


### PR DESCRIPTION
Reworks the clipboard as discussed in issue #201.

Doesn't (yet) set the datadict as it's own class, but that could be a seperate PR if we were to implement this.
Also reworks the item menu as discussed, as that was needed to get the behaviour right.

Actually, this code is simpler than the previous implementation and works quite well. It correctly handles all actions, including deletions and everything. And you can even redo/undo all the way to an empty slate and back.