### PR TITLE
Set active style from style editor

### DIFF
--- a/data/ui/plot_styles.blp
+++ b/data/ui/plot_styles.blp
@@ -83,6 +83,14 @@ template PlotStylesWindow : Adw.Window {
                   dialog: FontDialog {};
                 }
               }
+              Adw.ActionRow set_active_style_row {
+                title: _("Active");
+                subtitle: _("Set this style as the current active style");
+
+                Switch set_active_style {
+                  valign: center;
+                }
+              }
             }
 
             Adw.PreferencesGroup {

--- a/src/misc.py
+++ b/src/misc.py
@@ -39,7 +39,7 @@ class PlotSettings:
         self.top_scale = config["plot_top_scale"]
         self.title = config["plot_title"]
         self.legend = config["plot_legend"]
-        self.use_custom_plot_style = False
+        self.use_custom_plot_style = config["plot_use_custom_style"]
         self.custom_plot_style = config["plot_custom_style"]
 
 

--- a/src/plot_styles.py
+++ b/src/plot_styles.py
@@ -204,7 +204,8 @@ class PlotStylesWindow(Adw.Window):
         self.load_style()
         self.leaflet.navigate(1)
         edit_page = self.leaflet.get_visible_child()
-        self.set_active_style.connect("state-set", self.toggle_style, edit_page)
+        self.set_active_style.connect("state-set", self.toggle_style,
+                                      edit_page)
         self.set_title(style)
 
     def back(self, _):
@@ -227,7 +228,8 @@ class PlotStylesWindow(Adw.Window):
         edit_page = args[-1]
         if self.leaflet.get_visible_child() == edit_page:
             if self.set_active_style.get_active():
-                self.parent.plot_settings.custom_plot_style = self.style["name"]
+                self.parent.plot_settings.custom_plot_style = \
+                    self.style["name"]
             else:
                 system_style = "adwaita"
                 if Adw.StyleManager.get_default().get_dark():

--- a/src/plot_styles.py
+++ b/src/plot_styles.py
@@ -392,8 +392,6 @@ class PlotStylesWindow(Adw.Window):
 
         # other
         style["axes.linewidth"] = self.axis_width.get_value()
-        if self.set_active_style.get_active():
-            self.parent.plot_settings.custom_plot_style = style["name"]
 
         # name & save
         styles_path = os.path.join(utilities.get_config_path(), "styles")

--- a/src/plot_styles.py
+++ b/src/plot_styles.py
@@ -124,6 +124,8 @@ class PlotStylesWindow(Adw.Window):
     minor_tick_width = Gtk.Template.Child()
     major_tick_length = Gtk.Template.Child()
     minor_tick_length = Gtk.Template.Child()
+    set_active_style = Gtk.Template.Child()
+    set_active_style_row = Gtk.Template.Child()
     tick_bottom = Gtk.Template.Child()
     tick_left = Gtk.Template.Child()
     tick_top = Gtk.Template.Child()
@@ -201,6 +203,8 @@ class PlotStylesWindow(Adw.Window):
         self.style["name"] = style
         self.load_style()
         self.leaflet.navigate(1)
+        edit_page = self.leaflet.get_visible_child()
+        self.set_active_style.connect("state-set", self.toggle_style, edit_page)
         self.set_title(style)
 
     def back(self, _):
@@ -219,10 +223,28 @@ class PlotStylesWindow(Adw.Window):
         self.leaflet.navigate(0)
         self.set_title(self.style["name"])
 
+    def toggle_style(self, *args):
+        edit_page = args[-1]
+        if self.leaflet.get_visible_child() == edit_page:
+            if self.set_active_style.get_active():
+                self.parent.plot_settings.custom_plot_style = self.style["name"]
+            else:
+                system_style = "adwaita"
+                if Adw.StyleManager.get_default().get_dark():
+                    system_style += "-dark"
+                self.parent.plot_settings.custom_plot_style = system_style
+            graphs.reload(self.parent)
+
     def load_style(self):
         style = self.style
-
         self.style_name.set_text(style["name"])
+
+        if not self.parent.plot_settings.use_custom_plot_style:
+            self.set_active_style_row.hide()
+        if style["name"] == self.parent.plot_settings.custom_plot_style:
+            self.set_active_style.set_active(True)
+        else:
+            self.set_active_style.set_active(False)
 
         # font
         font_description = self.font_chooser.get_font_desc().from_string(
@@ -368,6 +390,8 @@ class PlotStylesWindow(Adw.Window):
 
         # other
         style["axes.linewidth"] = self.axis_width.get_value()
+        if self.set_active_style.get_active():
+            self.parent.plot_settings.custom_plot_style = style["name"]
 
         # name & save
         styles_path = os.path.join(utilities.get_config_path(), "styles")


### PR DESCRIPTION
Adds a shortcut button that allows to set the style that is being edited as custom style.

I was a bit unsure about the exact behaviour and what would be the most intuitive, but it seemed useful to have a shortcut here to quickly set the style from the editor as well. In the current implementation it hides the button when "System style" is set as default. So only if "Use Custom Style" is enabled, it shows this to allow for quick changing of the plot style.

Pressing the switch sets the style directly to active style. Deselecting it sets  the active style to the system preferred style.

![image](https://user-images.githubusercontent.com/68477016/231698860-ed1fb609-d47c-46bd-b01b-f1f5633aaa43.png)
