### PR TITLE
Set checkmark for active style in style editor

### DIFF
--- a/data/ui/plot_styles.blp
+++ b/data/ui/plot_styles.blp
@@ -84,8 +84,8 @@ template PlotStylesWindow : Adw.Window {
                 }
               }
               Adw.ActionRow set_active_style_row {
-                title: _("Active");
-                subtitle: _("Set this style as the currently active style");
+                title: _("Override system style");
+                subtitle: _("Set this style as the active style instead of the system preferred style");
 
                 Switch set_active_style {
                   valign: center;

--- a/data/ui/plot_styles.blp
+++ b/data/ui/plot_styles.blp
@@ -85,7 +85,7 @@ template PlotStylesWindow : Adw.Window {
               }
               Adw.ActionRow set_active_style_row {
                 title: _("Override system style");
-                subtitle: _("Set this style as the active style instead of the system preferred style");
+                subtitle: _("Set this style as the active style");
 
                 Switch set_active_style {
                   valign: center;

--- a/data/ui/plot_styles.blp
+++ b/data/ui/plot_styles.blp
@@ -83,14 +83,6 @@ template PlotStylesWindow : Adw.Window {
                   dialog: FontDialog {};
                 }
               }
-              Adw.ActionRow set_active_style_row {
-                title: _("Override system style");
-                subtitle: _("Set this style as the active style");
-
-                Switch set_active_style {
-                  valign: center;
-                }
-              }
             }
 
             Adw.PreferencesGroup {

--- a/data/ui/plot_styles.blp
+++ b/data/ui/plot_styles.blp
@@ -85,7 +85,7 @@ template PlotStylesWindow : Adw.Window {
               }
               Adw.ActionRow set_active_style_row {
                 title: _("Active");
-                subtitle: _("Set this style as the current active style");
+                subtitle: _("Set this style as the currently active style");
 
                 Switch set_active_style {
                   valign: center;

--- a/data/ui/style_box.blp
+++ b/data/ui/style_box.blp
@@ -11,8 +11,13 @@ template StyleBox : Box {
   Label label {
     margin-end: 6;
     halign: start;
-    hexpand: true;
   }
+
+  Image check_mark {
+    icon-name: "emblem-ok-symbolic";
+    halign: start;
+    hexpand: true;
+    }
 
   Button copy_button {
     tooltip-text: _("Copy Style");

--- a/src/plot_styles.py
+++ b/src/plot_styles.py
@@ -237,21 +237,17 @@ class PlotStylesWindow(Adw.Window):
         edit_page = args[-1]
         if self.leaflet.get_visible_child() == edit_page:
             if self.set_active_style.get_active():
+                self.parent.plot_settings.use_custom_plot_style = True
                 self.parent.plot_settings.custom_plot_style = \
                     self.style["name"]
             else:
-                system_style = "adwaita"
-                if Adw.StyleManager.get_default().get_dark():
-                    system_style += "-dark"
-                self.parent.plot_settings.custom_plot_style = system_style
+                self.parent.plot_settings.use_custom_plot_style = False
             graphs.reload(self.parent)
 
     def load_style(self):
         style = self.style
         self.style_name.set_text(style["name"])
 
-        if not self.parent.plot_settings.use_custom_plot_style:
-            self.set_active_style_row.hide()
         if style["name"] == self.parent.plot_settings.custom_plot_style:
             self.set_active_style.set_active(True)
         else:

--- a/src/plot_styles.py
+++ b/src/plot_styles.py
@@ -133,8 +133,6 @@ class PlotStylesWindow(Adw.Window):
     minor_tick_width = Gtk.Template.Child()
     major_tick_length = Gtk.Template.Child()
     minor_tick_length = Gtk.Template.Child()
-    set_active_style = Gtk.Template.Child()
-    set_active_style_row = Gtk.Template.Child()
     tick_bottom = Gtk.Template.Child()
     tick_left = Gtk.Template.Child()
     tick_top = Gtk.Template.Child()
@@ -212,9 +210,6 @@ class PlotStylesWindow(Adw.Window):
         self.style["name"] = style
         self.load_style()
         self.leaflet.navigate(1)
-        edit_page = self.leaflet.get_visible_child()
-        self.set_active_style.connect("state-set", self.toggle_style,
-                                      edit_page)
         self.set_title(style)
 
     def back(self, _):
@@ -233,26 +228,10 @@ class PlotStylesWindow(Adw.Window):
         self.leaflet.navigate(0)
         self.set_title(self.style["name"])
 
-    def toggle_style(self, *args):
-        edit_page = args[-1]
-        if self.leaflet.get_visible_child() == edit_page:
-            if self.set_active_style.get_active():
-                self.parent.plot_settings.use_custom_plot_style = True
-                self.parent.plot_settings.custom_plot_style = \
-                    self.style["name"]
-            else:
-                self.parent.plot_settings.use_custom_plot_style = False
-            graphs.reload(self.parent)
 
     def load_style(self):
         style = self.style
         self.style_name.set_text(style["name"])
-
-        if style["name"] == self.parent.plot_settings.custom_plot_style and \
-                self.parent.plot_settings.use_custom_plot_style:
-            self.set_active_style.set_active(True)
-        else:
-            self.set_active_style.set_active(False)
 
         # font
         font_description = self.font_chooser.get_font_desc().from_string(
@@ -447,7 +426,10 @@ class PlotStylesWindow(Adw.Window):
             self.styles_box.remove(self.styles_box.get_row_at_index(0))
         for style in get_user_styles(self.parent).keys():
             box = StyleBox(self, style)
-            if not style == get_current_style(self):
+            current_style = os.path.splitext(
+                Path(get_preferred_style_path(self.parent)).name)[0]
+            print(current_style)
+            if not style == current_style:
                 box.check_mark.hide()
                 box.label.set_hexpand(True)
             self.styles.append(box)

--- a/src/plot_styles.py
+++ b/src/plot_styles.py
@@ -57,17 +57,6 @@ def get_system_preferred_style_path(self):
         shutil.copy(get_system_styles(self)[system_style], stylepath)
     return stylepath
 
-
-def get_current_style(self):
-    if not self.parent.plot_settings.use_custom_plot_style:
-        style = "adwaita"
-        if Adw.StyleManager.get_default().get_dark():
-            style += "-dark"
-    else:
-        style = self.parent.plot_settings.custom_plot_style
-    return style
-
-
 def get_preferred_style_path(self):
     if not self.plot_settings.use_custom_plot_style:
         return get_system_preferred_style_path(self)
@@ -428,7 +417,6 @@ class PlotStylesWindow(Adw.Window):
             box = StyleBox(self, style)
             current_style = os.path.splitext(
                 Path(get_preferred_style_path(self.parent)).name)[0]
-            print(current_style)
             if not style == current_style:
                 box.check_mark.hide()
                 box.label.set_hexpand(True)

--- a/src/plot_styles.py
+++ b/src/plot_styles.py
@@ -248,7 +248,8 @@ class PlotStylesWindow(Adw.Window):
         style = self.style
         self.style_name.set_text(style["name"])
 
-        if style["name"] == self.parent.plot_settings.custom_plot_style:
+        if style["name"] == self.parent.plot_settings.custom_plot_style and \
+            self.parent.plot_settings.use_custom_plot_style:
             self.set_active_style.set_active(True)
         else:
             self.set_active_style.set_active(False)

--- a/src/plot_styles.py
+++ b/src/plot_styles.py
@@ -57,10 +57,18 @@ def get_system_preferred_style_path(self):
         shutil.copy(get_system_styles(self)[system_style], stylepath)
     return stylepath
 
+def get_current_style(self):
+    if not self.parent.plot_settings.use_custom_plot_style:
+        style = "adwaita"
+        if Adw.StyleManager.get_default().get_dark():
+            style += "-dark"
+    else:
+        style = self.parent.plot_settings.custom_plot_style
+    return style
+
 
 def get_preferred_style_path(self):
-    if not self.preferences.config["plot_use_custom_style"] and \
-            not self.plot_settings.use_custom_plot_style:
+    if not self.plot_settings.use_custom_plot_style:
         return get_system_preferred_style_path(self)
     stylename = self.plot_settings.custom_plot_style
     try:
@@ -417,6 +425,9 @@ class PlotStylesWindow(Adw.Window):
             self.styles_box.remove(self.styles_box.get_row_at_index(0))
         for style in get_user_styles(self.parent).keys():
             box = StyleBox(self, style)
+            if not style == get_current_style(self):
+                box.check_mark.hide()
+                box.label.set_hexpand(True)
             self.styles.append(box)
             self.styles_box.append(box)
 
@@ -450,6 +461,7 @@ class PlotStylesWindow(Adw.Window):
 class StyleBox(Gtk.Box):
     __gtype_name__ = "StyleBox"
     label = Gtk.Template.Child()
+    check_mark = Gtk.Template.Child()
     copy_button = Gtk.Template.Child()
     delete_button = Gtk.Template.Child()
     edit_button = Gtk.Template.Child()

--- a/src/plot_styles.py
+++ b/src/plot_styles.py
@@ -57,6 +57,7 @@ def get_system_preferred_style_path(self):
         shutil.copy(get_system_styles(self)[system_style], stylepath)
     return stylepath
 
+
 def get_current_style(self):
     if not self.parent.plot_settings.use_custom_plot_style:
         style = "adwaita"

--- a/src/plot_styles.py
+++ b/src/plot_styles.py
@@ -249,7 +249,7 @@ class PlotStylesWindow(Adw.Window):
         self.style_name.set_text(style["name"])
 
         if style["name"] == self.parent.plot_settings.custom_plot_style and \
-            self.parent.plot_settings.use_custom_plot_style:
+                self.parent.plot_settings.use_custom_plot_style:
             self.set_active_style.set_active(True)
         else:
             self.set_active_style.set_active(False)

--- a/src/plot_styles.py
+++ b/src/plot_styles.py
@@ -57,6 +57,7 @@ def get_system_preferred_style_path(self):
         shutil.copy(get_system_styles(self)[system_style], stylepath)
     return stylepath
 
+
 def get_preferred_style_path(self):
     if not self.plot_settings.use_custom_plot_style:
         return get_system_preferred_style_path(self)
@@ -415,9 +416,7 @@ class PlotStylesWindow(Adw.Window):
             self.styles_box.remove(self.styles_box.get_row_at_index(0))
         for style in get_user_styles(self.parent).keys():
             box = StyleBox(self, style)
-            current_style = os.path.splitext(
-                Path(get_preferred_style_path(self.parent)).name)[0]
-            if not style == current_style:
+            if not style == Path(get_preferred_style_path(self.parent)).stem:
                 box.check_mark.hide()
                 box.label.set_hexpand(True)
             self.styles.append(box)


### PR DESCRIPTION
- Adds a shortcut button that allows to set the style that is being edited as custom style.

I was a bit unsure about the exact behaviour and what would be the most intuitive, but it seemed useful to have a shortcut here to quickly set the style from the editor as well. In the current implementation it hides the button when "System style" is set as default. So only if "Use Custom Style" is enabled, it shows this to allow for quick changing of the plot style. Pressing the switch sets the style directly to active style. Deselecting it sets  the active style to the system preferred style.

 ![image](https://user-images.githubusercontent.com/68477016/231698860-ed1fb609-d47c-46bd-b01b-f1f5633aaa43.png)

- Sets a checkmark for the currently active style in the "Plot Styles" overview, to quickly indicate which style is currently active.

![image](https://user-images.githubusercontent.com/68477016/231712949-0660d0b4-6af7-44d1-84f2-4c088ea8c5e1.png)
