### PR TITLE
Respect style's line settings when applying custom style

### DIFF
--- a/data/config.json
+++ b/data/config.json
@@ -16,6 +16,7 @@
 "import_delimiter": "\\s+",
 "import_separator": ".",
 "import_skip_rows": 0,
+"override_style_change": true,
 "plot_custom_style": "adwaita",
 "plot_legend": true,
 "plot_legend_position": "best",

--- a/data/ui/preferences.blp
+++ b/data/ui/preferences.blp
@@ -314,6 +314,14 @@ template PreferencesWindow : Adw.PreferencesWindow {
           model: StringList {};
         }
       }
+      Adw.ActionRow {
+        title: _("Override Line Styling on Style Change");
+        subtitle: _("Override the active line styling when switching plot style");
+
+        Switch override_style_change {
+          valign: center;
+        }
+      }
     }
   }
 }

--- a/src/plot_settings.py
+++ b/src/plot_settings.py
@@ -109,11 +109,11 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
 
         # Check if style change when override is enabled
         self.style_changed = \
-            parent.preferences.config["override_style_change"] \
-            and (plot_settings.use_custom_plot_style != \
-                 self.use_custom_plot_style.get_enable_expansion()
-                 or plot_settings.custom_plot_style != \
-                 self.custom_plot_style.get_selected_item().get_string())
+            plot_settings.use_custom_plot_style \
+            != self.use_custom_plot_style.get_enable_expansion() \
+            or plot_settings.custom_plot_style \
+            != self.custom_plot_style.get_selected_item().get_string() \
+            and parent.preferences.config["override_style_change"]
 
         # Set new plot settings
         plot_settings.title = self.plot_title.get_text()

--- a/src/plot_settings.py
+++ b/src/plot_settings.py
@@ -111,6 +111,7 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
         self.style_changed = \
             plot_settings.use_custom_plot_style \
             != self.use_custom_plot_style.get_enable_expansion() \
+            and parent.preferences.config["override_style_change"] \
             or plot_settings.custom_plot_style \
             != self.custom_plot_style.get_selected_item().get_string() \
             and parent.preferences.config["override_style_change"]

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -75,6 +75,7 @@ class PreferencesWindow(Adw.PreferencesWindow):
     action_center_data = Gtk.Template.Child()
     other_handle_duplicates = Gtk.Template.Child()
     other_hide_unselected = Gtk.Template.Child()
+    override_style_change = Gtk.Template.Child()
     plot_title = Gtk.Template.Child()
     plot_x_label = Gtk.Template.Child()
     plot_y_label = Gtk.Template.Child()
@@ -126,7 +127,7 @@ class PreferencesWindow(Adw.PreferencesWindow):
         utilities.set_chooser(
             self.other_handle_duplicates, config["handle_duplicates"])
         self.other_hide_unselected.set_active(config["hide_unselected"])
-
+        self.override_style_change.set_active(config["override_style_change"])
         self.plot_title.set_text(config["plot_title"])
         self.plot_x_label.set_text(config["plot_x_label"])
         self.plot_y_label.set_text(config["plot_y_label"])
@@ -177,7 +178,8 @@ class PreferencesWindow(Adw.PreferencesWindow):
         config["handle_duplicates"] = \
             self.other_handle_duplicates.get_selected_item().get_string()
         config["hide_unselected"] = self.other_hide_unselected.get_active()
-
+        config["override_style_change"] = \
+            self.override_style_change.get_active()
         config["plot_title"] = self.plot_title.get_text()
         config["plot_x_label"] = self.plot_x_label.get_text()
         config["plot_y_label"] = self.plot_y_label.get_text()


### PR DESCRIPTION
Respects the set color cycle when changing plot styles in plot_settings, I think that can have a pretty useful usecase. Especially if you have prepared a specific color cycle for specific purposes and want to change everything. 

It doesn't override the set colors if the plot style is not changed, only when the plot style is changed. Either to a different custom plot style, or when changing back to the system style.

[Screencast from 2023-04-14 11-12-43.webm](https://user-images.githubusercontent.com/68477016/232009052-0d0db8db-8d06-4804-af39-81960a9e100f.webm)
