### PR TITLE
Add new "thesis" style

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -132,6 +132,7 @@ styles = files(
   'styles/seaborn-whitegrid.mplstyle',
   'styles/solarized-light.mplstyle',
   'styles/tableau-colorblind10.mplstyle',
+  'styles/thesis.mplstyle',
 )
 styles_dir = join_paths(pkgdatadir, 'styles')
 install_data(styles, install_dir: styles_dir, install_mode: 'rwxrwxrwx')

--- a/data/styles/seaborn-ticks.mplstyle
+++ b/data/styles/seaborn-ticks.mplstyle
@@ -57,8 +57,8 @@ ytick.alignment: center
 
 xtick.bottom: True
 ytick.left: True
-xtick.top: True
-ytick.right: True
+xtick.top: False
+ytick.right: False
 
 xtick.bottom: True
 ytick.left: True

--- a/data/styles/seaborn-ticks.mplstyle
+++ b/data/styles/seaborn-ticks.mplstyle
@@ -60,11 +60,6 @@ ytick.left: True
 xtick.top: False
 ytick.right: False
 
-xtick.bottom: True
-ytick.left: True
-xtick.top: True
-ytick.right: True
-
 # grid
 axes.grid: False
 axes.grid.which: major

--- a/data/styles/thesis.mplstyle
+++ b/data/styles/thesis.mplstyle
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# adwaita
+
+# font
+font.family: sans-serif
+font.sans-serif: Cantarell
+font.style: normal
+font.weight: normal
+axes.titleweight: normal
+axes.labelweight: normal
+figure.titleweight: normal
+figure.labelweight: normal
+font.size: 12
+axes.labelsize: 12
+xtick.labelsize: 12
+ytick.labelsize: 12
+axes.titlesize: 12
+legend.fontsize: 12
+figure.titlesize: 12
+figure.labelsize: 12
+
+# lines
+lines.linewidth: 3
+lines.linestyle: solid
+lines.marker: none
+lines.markersize: 7
+lines.markerfacecolor: auto
+lines.markeredgecolor: auto
+lines.markeredgewidth: 0
+lines.dash_joinstyle: round
+lines.dash_capstyle: butt
+lines.solid_joinstyle: round
+lines.solid_capstyle: round
+lines.antialiased: True
+lines.dashed_pattern: 6, 6
+lines.dashdot_pattern: 3, 5, 1, 5
+lines.dotted_pattern: 1, 3
+lines.scale_dashes: False
+markers.fillstyle: full
+
+
+# ticks
+xtick.direction: in
+xtick.minor.visible: True
+xtick.major.width: 1
+xtick.minor.width: 0.5
+xtick.major.size: 8
+xtick.minor.size: 4
+xtick.alignment: center
+
+ytick.direction: in
+ytick.minor.visible: True
+ytick.major.width: 1
+ytick.minor.width: 0.5
+ytick.major.size: 8
+ytick.minor.size: 4
+ytick.alignment: center
+
+xtick.bottom: True
+ytick.left: True
+xtick.top: True
+ytick.right: True
+
+
+# grid
+axes.grid: False
+axes.grid.which: major
+axes.grid.axis: both
+grid.linewidth: 0.6
+grid.alpha: 1.0
+grid.linestyle: -
+
+# padding
+xtick.major.pad: 7
+xtick.minor.pad: 7
+ytick.major.pad: 7
+ytick.minor.pad: 7
+axes.labelpad: 5
+axes.titlepad: 15
+
+# colors
+text.color: 000000
+axes.labelcolor: 000000
+xtick.labelcolor: 000000
+ytick.labelcolor: 000000
+xtick.color: 000000
+ytick.color: 000000
+axes.edgecolor: 000000
+grid.color: 646464
+axes.facecolor: FFFFFF
+figure.facecolor: FFFFFF
+figure.edgecolor: FFFFFF
+
+
+axes.prop_cycle: cycler('color', ['BF1926', '1970D7', '33A02C', 'FF7F00', 'A6CEE3', 'B2DF8A', 'FB9A99', 'FDBF6F', 'CAB2D6'])
+patch.facecolor: E24A33
+
+# other
+axes.linewidth: 1
+
+mathtext.default: regular
+axes.axisbelow: True
+legend.fancybox: True
+legend.frameon: True
+
+# custom
+patch.linewidth: 0.5
+patch.edgecolor: EEEEEE
+patch.antialiased: True

--- a/data/styles/thesis.mplstyle
+++ b/data/styles/thesis.mplstyle
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
-# adwaita
+# thesis
 
 # font
 font.family: sans-serif


### PR DESCRIPTION
Add the style that I use for my own thesis. Basically it's without grids,  slightly longer ticks on the inside on all borders and a more "standard" like color cycle. I also use the same style as the basis for academic articles.

Felt to me that a style like this was missing somewhat, and for me personally it's convenient to ship these as well.

![image](https://user-images.githubusercontent.com/68477016/232012141-497d863e-1dcf-47c2-8c4c-5eb79ada0d89.png)
