### PR TITLE
Add dedicated "add style" button

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -58,12 +58,11 @@ endif
 
 blueprints = custom_target('blueprints',
   input: files(
-    'ui/add_style.blp',
-    'ui/window.blp',
-    'ui/edit_item.blp',
-    'ui/export_figure.blp',
     'ui/add_data_advanced.blp',
     'ui/add_equation_window.blp',
+    'ui/add_style.blp',
+    'ui/edit_item.blp',
+    'ui/export_figure.blp',
     'ui/help_overlay.blp',
     'ui/item_box.blp',
     'ui/plot_settings.blp',
@@ -72,7 +71,8 @@ blueprints = custom_target('blueprints',
     'ui/rename_window.blp',
     'ui/style_box.blp',
     'ui/style_color_box.blp',
-    'ui/transform_window.blp'
+    'ui/transform_window.blp',
+    'ui/window.blp'
   ),
   output: '.',
   command: [find_program('blueprint-compiler'), 'batch-compile', '@OUTPUT@', '@CURRENT_SOURCE_DIR@', '@INPUT@'],

--- a/data/meson.build
+++ b/data/meson.build
@@ -58,6 +58,7 @@ endif
 
 blueprints = custom_target('blueprints',
   input: files(
+    'ui/add_style.blp',
     'ui/window.blp',
     'ui/edit_item.blp',
     'ui/export_figure.blp',

--- a/data/se.sjoerd.Graphs.gresource.xml
+++ b/data/se.sjoerd.Graphs.gresource.xml
@@ -5,6 +5,7 @@
     <file alias="gtk/help-overlay.ui" preprocess="xml-stripblanks">ui/help_overlay.ui</file>
     <file preprocess="xml-stripblanks">ui/add_data_advanced.ui</file>
     <file preprocess="xml-stripblanks">ui/add_equation_window.ui</file>
+    <file preprocess="xml-stripblanks">ui/add_style.ui</file>
     <file preprocess="xml-stripblanks">ui/edit_item.ui</file>
     <file preprocess="xml-stripblanks">ui/export_figure.ui</file>
     <file preprocess="xml-stripblanks">ui/item_box.ui</file>

--- a/data/ui/add_style.blp
+++ b/data/ui/add_style.blp
@@ -24,6 +24,9 @@ template AddStyleWindow : Adw.Window {
       margin-top: 12;
       margin-bottom: 12;
       Adw.PreferencesGroup {
+      	margin-top: 12;
+	margin-start: 26;
+	margin-end: 26;
         Adw.ComboRow plot_style_templates {
           title: _("Template");
           subtitle: _("The template style used for the new style");
@@ -35,15 +38,12 @@ template AddStyleWindow : Adw.Window {
         }
       Box {
         halign: center;
-        margin-top: 12;
-        margin-bottom: 3;
         orientation: horizontal;
 
         Button confirm_button {
           halign: center;
-          margin-start: 6;
-          margin-top: 12;
-          margin-bottom: 12;
+	  margin-top: 24;
+	  margin-bottom: 12;
           label: _("Add New Style");
           styles ["suggested-action", "pill"]
         }

--- a/data/ui/add_style.blp
+++ b/data/ui/add_style.blp
@@ -39,20 +39,13 @@ template AddStyleWindow : Adw.Window {
         margin-bottom: 3;
         orientation: horizontal;
 
-        Button cancel_button {
-          halign: center;
-          margin-end: 6;
-          margin-top: 12;
-          margin-bottom: 12;
-          label: _("Cancel");
-        }
         Button confirm_button {
           halign: center;
           margin-start: 6;
           margin-top: 12;
           margin-bottom: 12;
-          label: _("Add");
-          styles ["suggested-action"]
+          label: _("Add New Style");
+          styles ["suggested-action", "pill"]
         }
         }
       }

--- a/data/ui/add_style.blp
+++ b/data/ui/add_style.blp
@@ -1,0 +1,61 @@
+using Gtk 4.0;
+using Adw 1;
+
+template AddStyleWindow : Adw.Window {
+  modal: true;
+  default-width: 450;
+  title: _("Add new style");
+
+  ShortcutController {
+    Shortcut {
+      trigger: "Escape";
+      action: "action(window.close)";
+    }
+  }
+
+  Box {
+    orientation: vertical;
+    Adw.HeaderBar {
+      styles ["flat"]
+    }
+    Adw.Clamp {
+      margin-start: 12;
+      margin-end: 12;
+      margin-top: 12;
+      margin-bottom: 12;
+      Adw.PreferencesGroup {
+        Adw.ComboRow plot_style_templates {
+          title: _("Template");
+          subtitle: _("The template style used for the new style");
+          model: StringList {};
+        }
+
+        Adw.EntryRow new_style_name {
+          title: _("New Style Name");
+        }
+      Box {
+        halign: center;
+        margin-top: 12;
+        margin-bottom: 3;
+        orientation: horizontal;
+
+        Button cancel_button {
+          halign: center;
+          margin-end: 6;
+          margin-top: 12;
+          margin-bottom: 12;
+          label: _("Cancel");
+        }
+        Button confirm_button {
+          halign: center;
+          margin-start: 6;
+          margin-top: 12;
+          margin-bottom: 12;
+          label: _("Add");
+          styles ["suggested-action"]
+        }
+        }
+      }
+    }
+  }
+}

--- a/data/ui/plot_styles.blp
+++ b/data/ui/plot_styles.blp
@@ -20,6 +20,10 @@ template PlotStylesWindow : Adw.Window {
     Box {
       orientation: vertical;
       Adw.HeaderBar {
+        Button add_button {
+          icon-name: "list-add-symbolic";
+          tooltip-text: _("Add new data");
+        }
         [end]
         Button reset_button {
           icon-name: "history-undo-symbolic";

--- a/data/ui/plot_styles.blp
+++ b/data/ui/plot_styles.blp
@@ -22,7 +22,7 @@ template PlotStylesWindow : Adw.Window {
       Adw.HeaderBar {
         Button add_button {
           icon-name: "list-add-symbolic";
-          tooltip-text: _("Add new data");
+          tooltip-text: _("Add new style");
         }
         [end]
         Button reset_button {

--- a/data/ui/style_box.blp
+++ b/data/ui/style_box.blp
@@ -19,21 +19,21 @@ template StyleBox : Box {
     hexpand: true;
     }
 
-  Button delete_button {
-    tooltip-text: _("Remove");
-    styles ["flat"]
-    Image {
-      hexpand: false;
-      icon-name: "edit-delete-symbolic";
-    }
-  }
-
   Button edit_button {
     tooltip-text: _("Edit");
     styles ["flat"]
     Image {
       hexpand: false;
       icon-name: "settings-symbolic";
+    }
+  }
+
+  Button delete_button {
+    tooltip-text: _("Remove");
+    styles ["flat"]
+    Image {
+      hexpand: false;
+      icon-name: "edit-delete-symbolic";
     }
   }
 }

--- a/data/ui/style_box.blp
+++ b/data/ui/style_box.blp
@@ -19,16 +19,6 @@ template StyleBox : Box {
     hexpand: true;
     }
 
-  Button copy_button {
-    tooltip-text: _("Copy Style");
-    styles ["flat"]
-    Image {
-      hexpand: false;
-      icon-name: "edit-copy-symbolic";
-      pixel-size: 20;
-    }
-  }
-
   Button delete_button {
     tooltip-text: _("Remove");
     styles ["flat"]

--- a/data/ui/transform_window.blp
+++ b/data/ui/transform_window.blp
@@ -39,6 +39,10 @@ template TransformWindow : Adw.Window {
       margin-top: 12;
       margin-bottom: 12;
       Adw.PreferencesGroup {
+        margin-start: 26;
+        margin-end: 26;
+	margin-top: 12;
+	margin-bottom: 6;
         Adw.EntryRow transform_x_entry {
           title: _("X =");
         }

--- a/src/actions.py
+++ b/src/actions.py
@@ -104,7 +104,7 @@ def export_figure_action(_action, _target, self):
 
 
 def plot_styles_action(_action, _target, self):
-    self.plot_styles_window = PlotStylesWindow(self)
+    PlotStylesWindow(self)
 
 
 def save_project_action(_action, _target, self):

--- a/src/actions.py
+++ b/src/actions.py
@@ -104,7 +104,7 @@ def export_figure_action(_action, _target, self):
 
 
 def plot_styles_action(_action, _target, self):
-    PlotStylesWindow(self)
+    self.plot_styles_window = PlotStylesWindow(self)
 
 
 def save_project_action(_action, _target, self):

--- a/src/plot_styles.py
+++ b/src/plot_styles.py
@@ -524,7 +524,6 @@ class AddStyleWindow(Adw.Window):
         self.new_style_name.set_text(f"{selected_item} (copy)")
 
     def on_confirm(self, _):
-        style = "adwaita"
         style = self.plot_style_templates.get_selected_item().get_string()
         name = self.new_style_name.get_text()
         self.parent.parent.plot_styles_window.copy_style(self, style, name)

--- a/src/plot_styles.py
+++ b/src/plot_styles.py
@@ -529,4 +529,3 @@ class AddStyleWindow(Adw.Window):
         name = self.new_style_name.get_text()
         self.parent.parent.plot_styles_window.copy_style(self, style, name)
         self.close()
-        

--- a/src/plot_styles.py
+++ b/src/plot_styles.py
@@ -495,7 +495,6 @@ class StyleColorBox(Gtk.Box):
 @Gtk.Template(resource_path="/se/sjoerd/Graphs/ui/add_style.ui")
 class AddStyleWindow(Adw.Window):
     __gtype_name__ = "AddStyleWindow"
-    cancel_button = Gtk.Template.Child()
     confirm_button = Gtk.Template.Child()
     new_style_name = Gtk.Template.Child()
     plot_style_templates = Gtk.Template.Child()
@@ -508,15 +507,11 @@ class AddStyleWindow(Adw.Window):
         selected_item = \
             self.plot_style_templates.get_selected_item().get_string()
         self.new_style_name.set_text(f"{selected_item} (copy)")
-        self.cancel_button.connect("clicked", self.on_cancel)
         self.confirm_button.connect("clicked", self.on_confirm)
         self.plot_style_templates.connect("notify::selected",
                                           self.on_template_changed)
         self.set_transient_for(parent.parent.plot_styles_window)
         self.present()
-
-    def on_cancel(self, _):
-        self.close()
 
     def on_template_changed(self, _, __):
         selected_item = \

--- a/src/plot_styles.py
+++ b/src/plot_styles.py
@@ -510,8 +510,8 @@ class AddStyleWindow(Adw.Window):
         self.new_style_name.set_text(f"{selected_item} (copy)")
         self.cancel_button.connect("clicked", self.on_cancel)
         self.confirm_button.connect("clicked", self.on_confirm)
-        self.plot_style_templates.connect("notify::selected", \
-            self.on_template_changed)
+        self.plot_style_templates.connect("notify::selected",
+                                          self.on_template_changed)
         self.set_transient_for(parent.parent.plot_styles_window)
         self.present()
 
@@ -529,3 +529,4 @@ class AddStyleWindow(Adw.Window):
         name = self.new_style_name.get_text()
         self.parent.parent.plot_styles_window.copy_style(self, style, name)
         self.close()
+        

--- a/src/plot_styles.py
+++ b/src/plot_styles.py
@@ -410,8 +410,7 @@ class PlotStylesWindow(Adw.Window):
         self.reload_styles()
 
     def add_data(self, _):
-        win = AddStyleWindow(self)
-        win.present()
+        AddStyleWindow(self)
 
 
     def reset_styles(self, _):
@@ -503,14 +502,14 @@ class AddStyleWindow(Adw.Window):
         super().__init__()
         self.parent = parent
         utilities.populate_chooser(
-            self.plot_style_templates, get_user_styles(parent.parent).keys())
+            self.plot_style_templates, get_user_styles(parent).keys())
         selected_item = \
             self.plot_style_templates.get_selected_item().get_string()
         self.new_style_name.set_text(f"{selected_item} (copy)")
         self.confirm_button.connect("clicked", self.on_confirm)
         self.plot_style_templates.connect("notify::selected",
                                           self.on_template_changed)
-        self.set_transient_for(parent.parent.plot_styles_window)
+        self.set_transient_for(parent)
         self.present()
 
     def on_template_changed(self, _, __):
@@ -521,5 +520,5 @@ class AddStyleWindow(Adw.Window):
     def on_confirm(self, _):
         style = self.plot_style_templates.get_selected_item().get_string()
         name = self.new_style_name.get_text()
-        self.parent.parent.plot_styles_window.copy_style(self, style, name)
+        self.parent.copy_style(self, style, name)
         self.close()

--- a/src/plot_styles.py
+++ b/src/plot_styles.py
@@ -103,6 +103,7 @@ def get_style(self, stylename):
 @Gtk.Template(resource_path="/se/sjoerd/Graphs/ui/plot_styles.ui")
 class PlotStylesWindow(Adw.Window):
     __gtype_name__ = "PlotStylesWindow"
+    add_button = Gtk.Template.Child()
     leaflet = Gtk.Template.Child()
     styles_box = Gtk.Template.Child()
     reset_button = Gtk.Template.Child()
@@ -148,6 +149,7 @@ class PlotStylesWindow(Adw.Window):
         self.styles = []
         self.style = None
         self.reload_styles()
+        self.add_button.connect("clicked", self.add_data)
         self.reset_button.connect("clicked", self.reset_styles)
         self.back_button.connect("clicked", self.back)
         self.connect("close-request", self.on_close)
@@ -389,21 +391,28 @@ class PlotStylesWindow(Adw.Window):
         os.remove(get_user_styles(self.parent)[style])
         self.reload_styles()
 
-    def copy_style(self, _, style):
+    def copy_style(self, _, style, new_style):
         loop = True
         i = 0
         while loop:
-            i += 1
-            new_style = f"{style} ({i})"
-            loop = False
             for style_1 in get_user_styles(self.parent).keys():
+                i += 1
                 if new_style == style_1:
                     loop = True
+                    new_style = f"{new_style} ({i})"
+                    continue
+                else:
+                    loop = False
         user_path = os.path.join(utilities.get_config_path(), "styles")
         shutil.copy(
             os.path.join(user_path, f"{style}.mplstyle"),
             os.path.join(user_path, f"{new_style}.mplstyle"))
         self.reload_styles()
+
+    def add_data(self, _):
+        win = AddStyleWindow(self)
+        win.present()
+
 
     def reset_styles(self, _):
         reset_user_styles(self.parent)
@@ -452,14 +461,12 @@ class StyleBox(Gtk.Box):
     __gtype_name__ = "StyleBox"
     label = Gtk.Template.Child()
     check_mark = Gtk.Template.Child()
-    copy_button = Gtk.Template.Child()
     delete_button = Gtk.Template.Child()
     edit_button = Gtk.Template.Child()
 
     def __init__(self, parent, style):
         super().__init__()
         self.label.set_label(utilities.shorten_label(style, 50))
-        self.copy_button.connect("clicked", parent.copy_style, style)
         self.delete_button.connect("clicked", parent.delete_style, style)
         self.edit_button.connect("clicked", parent.edit_style, style)
 
@@ -483,3 +490,42 @@ class StyleColorBox(Gtk.Box):
             f"button {{ color: #{color}; }}", -1)
         self.color_button.connect("clicked", parent.on_color_change)
         self.delete_button.connect("clicked", parent.delete_color, self)
+
+
+@Gtk.Template(resource_path="/se/sjoerd/Graphs/ui/add_style.ui")
+class AddStyleWindow(Adw.Window):
+    __gtype_name__ = "AddStyleWindow"
+    cancel_button = Gtk.Template.Child()
+    confirm_button = Gtk.Template.Child()
+    new_style_name = Gtk.Template.Child()
+    plot_style_templates = Gtk.Template.Child()
+
+    def __init__(self, parent):
+        super().__init__()
+        self.parent = parent
+        utilities.populate_chooser(
+            self.plot_style_templates, get_user_styles(parent.parent).keys())
+        selected_item = \
+            self.plot_style_templates.get_selected_item().get_string()
+        self.new_style_name.set_text(f"{selected_item} (copy)")
+        self.cancel_button.connect("clicked", self.on_cancel)
+        self.confirm_button.connect("clicked", self.on_confirm)
+        self.plot_style_templates.connect("notify::selected", \
+            self.on_template_changed)
+        self.set_transient_for(parent.parent.plot_styles_window)
+        self.present()
+
+    def on_cancel(self, _):
+        self.close()
+
+    def on_template_changed(self, _, __):
+        selected_item = \
+            self.plot_style_templates.get_selected_item().get_string()
+        self.new_style_name.set_text(f"{selected_item} (copy)")
+
+    def on_confirm(self, _):
+        style = "adwaita"
+        style = self.plot_style_templates.get_selected_item().get_string()
+        name = self.new_style_name.get_text()
+        self.parent.parent.plot_styles_window.copy_style(self, style, name)
+        self.close()


### PR DESCRIPTION
Instead of having a copy button on each style row, this adds one single "add style" button that pops up a dialog. It then gives a dropdown with a choice which style to base the new one on, and a field for the name of the new style. The name is automatically filled in based on the template the user chooses, but can be changed manually of course .

Other than this, there's not really something I really want in the upcoming release. Except for a warning dialog when deleting styles ("This will delete {style name}, are you sure") and for resetting the styles to the default settings, as those actions are destructive. See PR #229. 

![image](https://user-images.githubusercontent.com/68477016/232209183-672d1e01-abb9-4971-98cc-0099bd9ec107.png)
