### PR TITLE
Add style change to clipboard

### DIFF
--- a/src/operations.py
+++ b/src/operations.py
@@ -1,8 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 import logging
 
-from graphs import (calculation, clipboard, graphs, ui,
-    utilities)
+from graphs import calculation, clipboard, graphs, ui, utilities
 from graphs.item import Item
 from graphs.misc import InteractionMode
 

--- a/src/operations.py
+++ b/src/operations.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 import logging
 
-from graphs import calculation, clipboard, graphs, ui, utilities
+from graphs import (calculation, clipboard, graphs, ui,
+    utilities)
 from graphs.item import Item
 from graphs.misc import InteractionMode
 

--- a/src/plot_settings.py
+++ b/src/plot_settings.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 from gi.repository import Adw, Gtk
 
-from graphs import clipboard, graphs, plot_styles, plotting_tools, ui, utilities
+from graphs import (clipboard, graphs, plot_styles, plotting_tools, ui,
+                    utilities)
 from graphs.canvas import Canvas
 
 from matplotlib import pyplot

--- a/src/plot_settings.py
+++ b/src/plot_settings.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 from gi.repository import Adw, Gtk
 
-from graphs import graphs, plot_styles, plotting_tools, ui, utilities
+from graphs import clipboard, graphs, plot_styles, plotting_tools, ui, utilities
 from graphs.canvas import Canvas
 
 from matplotlib import pyplot
@@ -151,6 +151,7 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
                 item.markerstyle = pyplot.rcParams["lines.marker"]
                 item.markersize = \
                     float(pyplot.rcParams["lines.markersize"])
+            clipboard.add(parent)
 
         # Reload UI
         ui.reload_item_menu(parent)


### PR DESCRIPTION
In the current release version, if line settings (colors, thickness etc) are changed upon a style change, this event is not added to the clipboard. If the user then undoes directly after changing the style, all lines are reset to the old color cycle and the information about the new color cycle is "lost", which is annoying. 

This PR fixes this by adding the style change to the clipboard, this way the new color cycle (and also line thickness etc..) is not lost upon an undo action immediately after a style change, see second video.

Before:
[Screencast from 2023-04-17 13-43-39.webm](https://user-images.githubusercontent.com/68477016/232475423-4812ab58-c8fb-4864-b9be-aab71cb8ac5a.webm)

After this PR:
[Screencast from 2023-04-17 13-49-32.webm](https://user-images.githubusercontent.com/68477016/232475870-43405383-da40-46b7-8997-39ec09ae60ad.webm)

