### PR TITLE
Hotfix update

### DIFF
--- a/data/se.sjoerd.Graphs.appdata.xml.in.in
+++ b/data/se.sjoerd.Graphs.appdata.xml.in.in
@@ -47,6 +47,16 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="1.5.1" date="2023-04-17">
+      <description>
+        <p>Hotfix update.</p>
+        <p>Bug fixes</p>
+          <li>Fixes a bug that prevents "Add Equation" from generating new data</li>
+          <li>Fixes a bug where a change of item properties was not included in the clipboard when loading a new style</li>
+          <li>Fixes a bug where the "Restore View" did not properly find the correct limits in specific situations</li>
+        </ul>
+      </description>
+    </release>
     <release version="1.5.0" date="2023-04-16">
       <description>
         <p>Major Highlights</p>

--- a/data/se.sjoerd.Graphs.appdata.xml.in.in
+++ b/data/se.sjoerd.Graphs.appdata.xml.in.in
@@ -51,6 +51,7 @@
       <description>
         <p>Hotfix update.</p>
         <p>Bug fixes</p>
+        <ul>
           <li>Fixes a bug that prevents "Add Equation" from generating new data</li>
           <li>Fixes a bug where a change of item properties was not included in the clipboard when loading a new style</li>
           <li>Fixes a bug where the "Restore View" did not properly find the correct limits in specific situations</li>

--- a/data/ui/window.blp
+++ b/data/ui/window.blp
@@ -310,7 +310,7 @@ template GraphsWindow : Adw.ApplicationWindow {
                 title: _("Translate and Multiply");
                 Adw.EntryRow translate_x_entry {
                   max-width-chars: 6;
-                  title: _("Translate x-Axis");
+                  title: _("Translate X-Axis");
                   Button translate_x_button {
                     valign: center;
                     action-name: "app.translate_x";
@@ -323,7 +323,7 @@ template GraphsWindow : Adw.ApplicationWindow {
 
                 Adw.EntryRow translate_y_entry {
                   max-width-chars: 6;
-                  title: _("Translate y-Axis");
+                  title: _("Translate Y-Axis");
                   Button translate_y_button {
                     valign: center;
                     action-name: "app.translate_y";
@@ -336,7 +336,7 @@ template GraphsWindow : Adw.ApplicationWindow {
 
                 Adw.EntryRow multiply_x_entry {
                   max-width-chars: 6;
-                  title: _("Multiply x-Axis");
+                  title: _("Multiply X-Axis");
                   Button multiply_x_button {
                     valign: center;
                     action-name: "app.multiply_x";
@@ -349,7 +349,7 @@ template GraphsWindow : Adw.ApplicationWindow {
 
                 Adw.EntryRow multiply_y_entry {
                   max-width-chars: 6;
-                  title: _("Multiply y-Axis");
+                  title: _("Multiply Y-Axis");
                   Button multiply_y_button {
                     valign: center;
                     action-name: "app.multiply_y";

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 project('graphs',
-          version: '1.5.0',
+          version: '1.5.1',
     meson_version: '>= 0.59.0',
   default_options: [ 'warning_level=2', 'werror=false', ],
 )

--- a/src/actions.py
+++ b/src/actions.py
@@ -74,7 +74,7 @@ def redo_action(_action, _target, self):
 
 
 def restore_view_action(_action, _target, self):
-    self.canvas.dummy_toolbar.home()
+    graphs.reload(self)
 
 
 def view_back_action(_action, _target, self):

--- a/src/add_equation.py
+++ b/src/add_equation.py
@@ -42,8 +42,8 @@ class AddEquationWindow(Adw.Window):
             if name == "":
                 name = f"Y = {equation}"
             graphs.add_item(parent, Item(parent, xdata, ydata, name))
-            graphs.reload(self)
-            ui.reload_item_menu(self)
+            graphs.reload(parent)
+            ui.reload_item_menu(parent)
             self.destroy()
         except (NameError, SyntaxError) as exception:
             exception_type = exception.__class__.__name__


### PR DESCRIPTION
Some bug fixes, one of them being major:

- The add equation window was broken, not sure when this happened but this fixes this!
- The canvas zoom was indeed broken on extremely specific scenarios that I still cannot trace down to specific scenarios. But it has something to do with the old state not being properly stored when doing a bunch of transformations. See attached screencast. This PR binds the "Restore View" button directly to the own graphs.reload() function. I haven't been able to replicate this bugged behaviour in this new PR.

@cmkohnen Given the broken "add equation" functionality being quite severe of an issue, I am planning to push this as an "unscheduled" hotfix update as soon this is merged.  If you've got any specific bug fixes or such we can include that but I am planning to update the Flathub release today.

[Screencast from 2023-04-17 16-44-25.webm](https://user-images.githubusercontent.com/68477016/232523400-53ce60e8-d30a-4e18-94e0-5fbe4e0b1baf.webm)
