### PR TITLE
Reset axes limit less agressively

### DIFF
--- a/data/se.sjoerd.Graphs.appdata.xml.in.in
+++ b/data/se.sjoerd.Graphs.appdata.xml.in.in
@@ -55,6 +55,10 @@
           <li>Started initial work on localization support</li>
           <li>Refactors under-the-hood</li>
         </ul>
+        <p>Bug fixes:</p>
+        <ul>
+          <li>Fixed a bug where data was not saved when multiple files were exported simultaniously</li>
+        </ul>
       </description>
     </release>
     <release version="1.5.1" date="2023-04-17">

--- a/data/se.sjoerd.Graphs.appdata.xml.in.in
+++ b/data/se.sjoerd.Graphs.appdata.xml.in.in
@@ -47,6 +47,16 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="1.5.2" date="2023-04-19">
+      <description>
+        <p>Changes:</p>
+        <ul>
+          <li>Changed the behaviour of the canvas so that the limits are not reset unnecessarily</li>
+          <li>Started initial work on localization support</li>
+          <li>Refactors under-the-hood</li>
+        </ul>
+      </description>
+    </release>
     <release version="1.5.1" date="2023-04-17">
       <description>
         <p>Hotfix update with bug fixes:</p>

--- a/data/se.sjoerd.Graphs.appdata.xml.in.in
+++ b/data/se.sjoerd.Graphs.appdata.xml.in.in
@@ -57,7 +57,7 @@
         </ul>
         <p>Bug fixes:</p>
         <ul>
-          <li>Fixed a bug where data was not saved when multiple files were exported simultaniously</li>
+          <li>Fixed a bug where data was not saved when multiple files were exported simultaneously</li>
         </ul>
       </description>
     </release>

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -64,6 +64,28 @@ class Canvas(FigureCanvas):
             linewidth=linewidth, markersize=markersize)
         self.set_legend()
 
+    def set_manual_limits(self, limits):
+        self.axis.set_xlim(float(limits["min_bottom"]),
+                           float(limits["max_bottom"]))
+        self.axis.set_ylim(float(limits["min_left"]),
+                           float(limits["max_left"]))
+        self.right_axis.set_ylim(float(limits["min_right"]),
+                                 float(limits["max_right"]))
+        self.top_left_axis.set_xlim(float(limits["min_top"]),
+                                    float(limits["max_top"]))
+
+    def get_limits(self):
+        limits = {}
+        limits["min_left"] = min(self.axis.get_ylim())
+        limits["max_left"] = max(self.axis.get_ylim())
+        limits["min_bottom"] = min(self.axis.get_xlim())
+        limits["max_bottom"] = max(self.axis.get_xlim())
+        limits["min_right"] = min(self.right_axis.get_ylim())
+        limits["max_right"] = max(self.right_axis.get_ylim())
+        limits["min_top"] = min(self.top_left_axis.get_ylim())
+        limits["max_top"] = max(self.top_left_axis.get_ylim())
+        return limits
+
     def set_axis_properties(self):
         """Set the properties that are related to the axes."""
         plot_settings = self.parent.plot_settings

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -206,7 +206,7 @@ class Canvas(FigureCanvas):
             "left": self.axis,
             "right": self.right_axis,
             "top": self.top_left_axis,
-            "bottom": self.axis
+            "bottom": self.axis,
         }
 
         # Find the limits from data

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -64,15 +64,24 @@ class Canvas(FigureCanvas):
             linewidth=linewidth, markersize=markersize)
         self.set_legend()
 
-    def set_manual_limits(self, limits):
-        self.axis.set_xlim(float(limits["min_bottom"]),
-                           float(limits["max_bottom"]))
-        self.axis.set_ylim(float(limits["min_left"]),
-                           float(limits["max_left"]))
-        self.right_axis.set_ylim(float(limits["min_right"]),
-                                 float(limits["max_right"]))
-        self.top_left_axis.set_xlim(float(limits["min_top"]),
-                                    float(limits["max_top"]))
+    def set_limits(self, limits):
+        used_axes, _items = utilities.get_used_axes(self.parent)
+        if used_axes["bottom"]:
+            for axis in [self.axis, self.right_axis]:
+                axis.set_xlim(float(limits["min_bottom"]),
+                              float(limits["max_bottom"]))
+        if used_axes["left"]:
+            for axis in [self.axis, self.top_left_axis]:
+                axis.set_ylim(float(limits["min_left"]),
+                              float(limits["max_left"]))
+        if used_axes["right"]:
+            for axis in [self.right_axis, self.top_right_axis]:
+                axis.set_ylim(float(limits["min_right"]),
+                              float(limits["max_right"]))
+        if used_axes["top"]:
+            for axis in [self.top_left_axis, self.top_right_axis]:
+                axis.set_xlim(float(limits["min_top"]),
+                              float(limits["max_top"]))
 
     def get_limits(self):
         limits = {}
@@ -95,11 +104,15 @@ class Canvas(FigureCanvas):
             plot_settings.right_label)
         self.top_label = self.top_left_axis.set_xlabel(plot_settings.top_label)
         self.left_label = self.axis.set_ylabel(plot_settings.ylabel)
+        self.axis.set_xscale(plot_settings.xscale)
         self.axis.set_yscale(plot_settings.yscale)
+        self.right_axis.set_xscale(plot_settings.xscale)
         self.right_axis.set_yscale(plot_settings.right_scale)
         self.top_left_axis.set_xscale(plot_settings.top_scale)
+        self.top_left_axis.set_yscale(plot_settings.yscale)
         self.top_right_axis.set_xscale(plot_settings.top_scale)
-        self.axis.set_xscale(plot_settings.xscale)
+        self.top_right_axis.set_yscale(plot_settings.right_scale)
+
 
     def set_ticks(self):
         bottom = pyplot.rcParams["xtick.bottom"]
@@ -186,39 +199,34 @@ class Canvas(FigureCanvas):
                     loc=self.parent.plot_settings.legend_position,
                     frameon=True, reverse=True)
 
-    def set_limits(self):
-        """Set the canvas limits for each axis that is present"""
+    def restore_view(self):
+        """Set the canvas limits for each axis to the initial view"""
         used_axes, items = utilities.get_used_axes(self.parent)
-        axes = {
-            "left": self.axis.get_yscale(),
-            "right": self.right_axis.get_yscale(),
-            "top": self.top_left_axis.get_xscale(),
-            "bottom": self.axis.get_xscale(),
+        axis_map = {
+            "left": self.axis,
+            "right": self.right_axis,
+            "top": self.top_left_axis,
+            "bottom": self.axis
         }
-        limits = {position: plotting_tools.find_limits(
-            scale, items[position]) for position, scale in axes.items()}
-        if used_axes["left"]:
-            if used_axes["bottom"]:
-                plotting_tools.set_axis_limits(
-                    limits["left"], self.axis, axis_type="Y")
-                plotting_tools.set_axis_limits(
-                    limits["bottom"], self.axis, axis_type="X")
-            if used_axes["top"]:
-                plotting_tools.set_axis_limits(
-                    limits["left"], self.top_left_axis, axis_type="Y")
-                plotting_tools.set_axis_limits(
-                    limits["top"], self.top_left_axis, axis_type="X")
-        if used_axes["right"]:
-            if used_axes["bottom"]:
-                plotting_tools.set_axis_limits(
-                    limits["right"], self.right_axis, axis_type="Y")
-                plotting_tools.set_axis_limits(
-                    limits["bottom"], self.right_axis, axis_type="X")
-            if used_axes["top"]:
-                plotting_tools.set_axis_limits(
-                    limits["right"], self.top_right_axis, axis_type="Y")
-                plotting_tools.set_axis_limits(
-                    limits["top"], self.top_right_axis, axis_type="X")
+
+        # Find the limits from data
+        limits = {}
+        for direction, used in used_axes.items():
+            if used:
+                if direction in ["top", "bottom"]:
+                    limits[f"min_{direction}"], limits[f"max_{direction}"] = \
+                        plotting_tools.find_min_max(
+                        axis_map[direction], items[direction], "X")
+                if direction in ["left", "right"]:
+                    limits[f"min_{direction}"], limits[f"max_{direction}"] = \
+                        plotting_tools.find_min_max(
+                        axis_map[direction], items[direction], "Y")
+
+        # Add padding to the limits
+        self.set_limits(limits)
+        for position, axis in used_axes.items():
+            if axis:
+                plotting_tools.set_limit_padding(position, axis_map[position])
 
 
 class DummyToolbar(NavigationToolbar2):

--- a/src/edit_item.py
+++ b/src/edit_item.py
@@ -72,10 +72,10 @@ class EditItemWindow(Adw.PreferencesWindow):
 
         # Only change limits when axes change, otherwise this is not needed
         set_limits = (
-            self.item.plot_x_position !=
-            self.plot_x_position.get_selected_item().get_string()
-            or self.item.plot_y_position !=
-            self.plot_y_position.get_selected_item().get_string()
+            self.item.plot_x_position
+            != self.plot_x_position.get_selected_item().get_string()
+            or self.item.plot_y_position
+            != self.plot_y_position.get_selected_item().get_string()
         )
 
         self.item.plot_x_position = \

--- a/src/edit_item.py
+++ b/src/edit_item.py
@@ -72,10 +72,10 @@ class EditItemWindow(Adw.PreferencesWindow):
 
         # Only change limits when axes change, otherwise this is not needed
         set_limits = \
-           self.item.plot_x_position \
-           != self.plot_x_position.get_selected_item().get_string() \
-           or self.item.plot_y_position \
-           != self.plot_y_position.get_selected_item().get_string()
+            self.item.plot_x_position \
+            != self.plot_x_position.get_selected_item().get_string() \
+            or self.item.plot_y_position \
+            != self.plot_y_position.get_selected_item().get_string()
 
         self.item.plot_x_position = \
             self.plot_x_position.get_selected_item().get_string()

--- a/src/edit_item.py
+++ b/src/edit_item.py
@@ -71,12 +71,11 @@ class EditItemWindow(Adw.PreferencesWindow):
         self.item.name = self.name_entry.get_text()
 
         # Only change limits when axes change, otherwise this is not needed
-        set_limits = (
-            self.item.plot_x_position
-            != self.plot_x_position.get_selected_item().get_string()
-            or self.item.plot_y_position
-            != self.plot_y_position.get_selected_item().get_string()
-        )
+        set_limits = \
+           self.item.plot_x_position \
+           != self.plot_x_position.get_selected_item().get_string() \
+           or self.item.plot_y_position \
+           != self.plot_y_position.get_selected_item().get_string()
 
         self.item.plot_x_position = \
             self.plot_x_position.get_selected_item().get_string()

--- a/src/edit_item.py
+++ b/src/edit_item.py
@@ -71,11 +71,12 @@ class EditItemWindow(Adw.PreferencesWindow):
         self.item.name = self.name_entry.get_text()
 
         # Only change limits when axes change, otherwise this is not needed
-        set_limits = \
-           self.item.plot_x_position != \
-           self.plot_x_position.get_selected_item().get_string() \
-           or self.item.plot_y_position != \
-           self.plot_y_position.get_selected_item().get_string()
+        set_limits = (
+            self.item.plot_x_position !=
+            self.plot_x_position.get_selected_item().get_string()
+            or self.item.plot_y_position !=
+            self.plot_y_position.get_selected_item().get_string()
+        )
 
         self.item.plot_x_position = \
             self.plot_x_position.get_selected_item().get_string()

--- a/src/edit_item.py
+++ b/src/edit_item.py
@@ -67,7 +67,18 @@ class EditItemWindow(Adw.PreferencesWindow):
         self.markersize.set_value(self.item.markersize)
 
     def apply(self, _):
+
         self.item.name = self.name_entry.get_text()
+
+        # Only change limits when axes change, otherwise this is not needed
+        if self.item.plot_x_position != \
+                self.plot_x_position.get_selected_item().get_string() \
+                or self.item.plot_y_position != \
+                self.plot_y_position.get_selected_item().get_string():
+            set_limits = True
+        else:
+            set_limits = False
+
         self.item.plot_x_position = \
             self.plot_x_position.get_selected_item().get_string()
         self.item.plot_y_position = \
@@ -79,4 +90,4 @@ class EditItemWindow(Adw.PreferencesWindow):
         self.item.markersize = self.markersize.get_value()
         ui.reload_item_menu(self.parent)
         clipboard.add(self.parent)
-        graphs.refresh(self.parent, set_limits=True)
+        graphs.refresh(self.parent, set_limits)

--- a/src/edit_item.py
+++ b/src/edit_item.py
@@ -71,13 +71,11 @@ class EditItemWindow(Adw.PreferencesWindow):
         self.item.name = self.name_entry.get_text()
 
         # Only change limits when axes change, otherwise this is not needed
-        if self.item.plot_x_position != \
-                self.plot_x_position.get_selected_item().get_string() \
-                or self.item.plot_y_position != \
-                self.plot_y_position.get_selected_item().get_string():
-            set_limits = True
-        else:
-            set_limits = False
+        set_limits = \
+           self.item.plot_x_position != \
+           self.plot_x_position.get_selected_item().get_string() \
+           or self.item.plot_y_position != \
+           self.plot_y_position.get_selected_item().get_string()
 
         self.item.plot_x_position = \
             self.plot_x_position.get_selected_item().get_string()

--- a/src/file_io.py
+++ b/src/file_io.py
@@ -46,7 +46,7 @@ def save_file(self, path):
             file_path = f"{path}/{filename}.txt"
             if os.path.exists(file_path):
                 file_path = f"{path}/{filename} (copy).txt"
-            numpy.savetxt(str(file_path, array, delimiter="\t"))
+            numpy.savetxt(str(file_path, array), delimiter="\t")
 
 
 def get_xrdml(self, import_settings):

--- a/src/graphs.py
+++ b/src/graphs.py
@@ -126,7 +126,7 @@ def check_open_data(self):
         ui.enable_data_dependent_buttons(self, False)
 
 
-def reload(self):
+def reload(self, canvas_limits = None):
     """Completely reload the plot of the graph"""
     self.canvas = Canvas(parent=self)
     self.main_window.toast_overlay.set_child(self.canvas)

--- a/src/graphs.py
+++ b/src/graphs.py
@@ -42,7 +42,6 @@ def open_files(self, files, import_settings):
                 continue
     ui.reload_item_menu(self)
     reload(self)
-    self.canvas.set_limits()
 
 
 def open_project(self, path):
@@ -67,7 +66,6 @@ def open_project(self, path):
         ui.enable_data_dependent_buttons(
             self, utilities.get_selected_keys(self))
         reload(self)
-        self.canvas.set_limits()
     except (EOFError, UnpicklingError):
         message = "Could not open project"
         self.main_window.add_toast(message)
@@ -133,7 +131,7 @@ def reload(self, reset_limits=True):
     self.main_window.toast_overlay.set_child(self.canvas)
     refresh(self, set_limits=True)
     if not reset_limits:
-        self.canvas.set_manual_limits(limits)
+        self.canvas.set_limits(limits)
     self.set_mode(None, None, self.interaction_mode)
     self.canvas.grab_focus()
 
@@ -151,5 +149,5 @@ def refresh(self, set_limits=False):
                  item.selected):
             self.canvas.plot(item)
     if set_limits and len(self.datadict) > 0:
-        self.canvas.set_limits()
+        self.canvas.restore_view()
     self.canvas.draw()

--- a/src/graphs.py
+++ b/src/graphs.py
@@ -126,11 +126,14 @@ def check_open_data(self):
         ui.enable_data_dependent_buttons(self, False)
 
 
-def reload(self, canvas_limits = None):
+def reload(self, reset_limits = True):
     """Completely reload the plot of the graph"""
+    limits = self.canvas.get_limits()
     self.canvas = Canvas(parent=self)
     self.main_window.toast_overlay.set_child(self.canvas)
     refresh(self, set_limits=True)
+    if not reset_limits:
+        self.canvas.set_manual_limits(limits)
     self.set_mode(None, None, self.interaction_mode)
     self.canvas.grab_focus()
 

--- a/src/graphs.py
+++ b/src/graphs.py
@@ -126,7 +126,7 @@ def check_open_data(self):
         ui.enable_data_dependent_buttons(self, False)
 
 
-def reload(self, reset_limits = True):
+def reload(self, reset_limits=True):
     """Completely reload the plot of the graph"""
     limits = self.canvas.get_limits()
     self.canvas = Canvas(parent=self)

--- a/src/graphs.py
+++ b/src/graphs.py
@@ -129,7 +129,7 @@ def reload(self, reset_limits=True):
     limits = self.canvas.get_limits()
     self.canvas = Canvas(parent=self)
     self.main_window.toast_overlay.set_child(self.canvas)
-    refresh(self, set_limits=True)
+    refresh(self, set_limits=reset_limits)
     if not reset_limits:
         self.canvas.set_limits(limits)
     self.set_mode(None, None, self.interaction_mode)

--- a/src/item_box.py
+++ b/src/item_box.py
@@ -49,7 +49,7 @@ class ItemBox(Gtk.Box):
             self.parent.datadict, drop_target.key, value)
         ui.reload_item_menu(self.parent)
         clipboard.add(self.parent)
-        graphs.reload(self.parent, reset_limits = False)
+        graphs.reload(self.parent, reset_limits=False)
 
     def on_dnd_prepare(self, drag_source, x, y):
         snapshot = Gtk.Snapshot.new()

--- a/src/item_box.py
+++ b/src/item_box.py
@@ -44,12 +44,14 @@ class ItemBox(Gtk.Box):
 
     def on_dnd_drop(self, drop_target, value, _x, _y):
         # Handle the dropped data here
+        limits = self.parent.canvas.get_limits()
         self.parent.datadict
         self.parent.datadict = utilities.change_key_position(
             self.parent.datadict, drop_target.key, value)
         ui.reload_item_menu(self.parent)
         clipboard.add(self.parent)
         graphs.reload(self.parent)
+        self.parent.canvas.set_manual_limits(limits)
 
     def on_dnd_prepare(self, drag_source, x, y):
         snapshot = Gtk.Snapshot.new()

--- a/src/item_box.py
+++ b/src/item_box.py
@@ -44,14 +44,12 @@ class ItemBox(Gtk.Box):
 
     def on_dnd_drop(self, drop_target, value, _x, _y):
         # Handle the dropped data here
-        limits = self.parent.canvas.get_limits()
         self.parent.datadict
         self.parent.datadict = utilities.change_key_position(
             self.parent.datadict, drop_target.key, value)
         ui.reload_item_menu(self.parent)
         clipboard.add(self.parent)
-        graphs.reload(self.parent)
-        self.parent.canvas.set_manual_limits(limits)
+        graphs.reload(self.parent, reset_limits = False)
 
     def on_dnd_prepare(self, drag_source, x, y):
         snapshot = Gtk.Snapshot.new()

--- a/src/plot_settings.py
+++ b/src/plot_settings.py
@@ -91,20 +91,17 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
             self.min_bottom.set_visible(False)
             self.max_bottom.set_visible(False)
 
-    def set_limits(self, parent):
-        min_left = float(self.min_left.get_text())
-        max_left = float(self.max_left.get_text())
-        min_bottom = float(self.min_bottom.get_text())
-        max_bottom = float(self.max_bottom.get_text())
-        min_right = float(self.min_right.get_text())
-        max_right = float(self.max_right.get_text())
-        min_top = float(self.min_top.get_text())
-        max_top = float(self.max_top.get_text())
-
-        parent.canvas.axis.set_xlim(min_bottom, max_bottom)
-        parent.canvas.axis.set_ylim(min_left, max_left)
-        parent.canvas.right_axis.set_ylim(min_right, max_right)
-        parent.canvas.top_left_axis.set_xlim(min_top, max_top)
+    def get_limits(self):
+        limits = {}
+        limits["min_left"] = float(self.min_left.get_text())
+        limits["max_left"] = float(self.max_left.get_text())
+        limits["min_bottom"] = float(self.min_bottom.get_text())
+        limits["max_bottom"] = float(self.max_bottom.get_text())
+        limits["min_right"] = float(self.min_right.get_text())
+        limits["max_right"] = float(self.max_right.get_text())
+        limits["min_top"] = float(self.min_top.get_text())
+        limits["max_top"] = float(self.max_top.get_text())
+        return limits
 
     def on_close(self, _, parent):
         plot_settings = parent.plot_settings
@@ -157,4 +154,4 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
         # Reload UI
         ui.reload_item_menu(parent)
         graphs.reload(parent)
-        self.set_limits(parent)
+        parent.canvas.set_limits(self.get_limits())

--- a/src/plot_styles.py
+++ b/src/plot_styles.py
@@ -229,7 +229,7 @@ class PlotStylesWindow(Adw.Window):
         self.style = None
         self.leaflet.navigate(0)
         self.set_title("Plot Styles")
-        graphs.reload(self.parent)
+        graphs.reload(self.parent, reset_limits = False)
 
     def edit_line_colors(self, _):
         self.leaflet.navigate(1)
@@ -466,7 +466,7 @@ class PlotStylesWindow(Adw.Window):
     def on_close(self, _):
         if self.style is not None:
             self.save_style()
-        graphs.reload(self.parent)
+        graphs.reload(self.parent, reset_limits = False)
         self.destroy()
 
     def on_color_change(self, button):

--- a/src/plot_styles.py
+++ b/src/plot_styles.py
@@ -229,7 +229,7 @@ class PlotStylesWindow(Adw.Window):
         self.style = None
         self.leaflet.navigate(0)
         self.set_title("Plot Styles")
-        graphs.reload(self.parent, reset_limits = False)
+        graphs.reload(self.parent, reset_limits=False)
 
     def edit_line_colors(self, _):
         self.leaflet.navigate(1)
@@ -466,7 +466,7 @@ class PlotStylesWindow(Adw.Window):
     def on_close(self, _):
         if self.style is not None:
             self.save_style()
-        graphs.reload(self.parent, reset_limits = False)
+        graphs.reload(self.parent, reset_limits=False)
         self.destroy()
 
     def on_color_change(self, button):

--- a/src/plotting_tools.py
+++ b/src/plotting_tools.py
@@ -32,14 +32,14 @@ def set_limit_padding(axis_direction, axis):
         ymin *= 0.5
         ymax *= 2
     try:
-            xmin = utilities.sig_fig_round(xmin, 3)
-            xmax = utilities.sig_fig_round(xmax, 3)
-            ymin = utilities.sig_fig_round(ymin, 3)
-            ymax = utilities.sig_fig_round(ymax, 3)
-            if axis_direction in ["left", "right"]:
-                axis.set_ylim(ymin, ymax)
-            if axis_direction in ["top", "bottom"]:
-                axis.set_xlim(xmin, xmax)
+        xmin = utilities.sig_fig_round(xmin, 3)
+        xmax = utilities.sig_fig_round(xmax, 3)
+        ymin = utilities.sig_fig_round(ymin, 3)
+        ymax = utilities.sig_fig_round(ymax, 3)
+        if axis_direction in ["left", "right"]:
+            axis.set_ylim(ymin, ymax)
+        if axis_direction in ["top", "bottom"]:
+            axis.set_xlim(xmin, xmax)
     except ValueError:
         logging.error(
             "Could not set limits, one of the values was probably infinite")
@@ -51,10 +51,10 @@ def find_min_max(axis, items, axis_type):
     max_all = None
 
     for item in items:
-        if axis_type == 'X':
+        if axis_type == "X":
             data = item.xdata
             scale = axis.get_xscale()
-        elif axis_type == 'Y':
+        elif axis_type == "Y":
             data = item.ydata
             scale = axis.get_yscale()
 
@@ -103,29 +103,6 @@ def hide_unused_axes(self, canvas):
     canvas.right_axis.get_xaxis().set_visible(False)
     canvas.top_right_axis.get_yaxis().set_visible(False)
     canvas.top_left_axis.get_yaxis().set_visible(False)
-
-def change_scale(action, target, self, scale_type, axis_type):
-    scale = target.get_string()
-    if scale_type == 'X':
-        if axis_type == 'top':
-            self.canvas.top_left_axis.set_xscale(scale)
-            self.canvas.top_right_axis.set_xscale(scale)
-            self.plot_settings.top_scale = scale
-        elif axis_type == 'bottom':
-            self.canvas.axis.set_xscale(scale)
-            self.canvas.right_axis.set_xscale(scale)
-            self.plot_settings.xscale = scale
-    elif scale_type == 'Y':
-        if axis_type == 'left':
-            self.canvas.axis.set_yscale(scale)
-            self.canvas.top_left_axis.set_yscale(scale)
-            self.plot_settings.yscale = scale
-        elif axis_type == 'right':
-            self.canvas.top_right_axis.set_yscale(scale)
-            self.canvas.right_axis.set_yscale(scale)
-            self.plot_settings.right_scale = scale
-    action.change_state(target)
-    graphs.refresh(self, set_limits=True)
 
 
 def change_left_yscale(action, target, self):

--- a/src/plotting_tools.py
+++ b/src/plotting_tools.py
@@ -6,89 +6,74 @@ from graphs import graphs, utilities
 from matplotlib import pyplot
 
 
-def set_axis_limits(graph_limits, axis, axis_type, limits=None):
-    """Set an calculate the canvas limits for a given axis."""
-    if not limits:
-        limits = {"xmin": None, "xmax": None, "ymin": None, "ymax": None}
+def set_limit_padding(axis_direction, axis):
+    """Apply some padding to the limits on the axes."""
     # Update graph limits with limits that were given as argument
-    for key, item in limits.items():
-        if item is not None:
-            graph_limits[key] = item
-    x_span = (graph_limits["xmax"] - graph_limits["xmin"])
-    y_span = (graph_limits["ymax"] - graph_limits["ymin"])
+    xmin = min(axis.get_xlim())
+    xmax = max(axis.get_xlim())
+    ymin = min(axis.get_ylim())
+    ymax = max(axis.get_ylim())
+    x_span = xmax - xmin
+    y_span = ymax - ymin
     if axis.get_xscale() == "linear":
-        graph_limits["xmin"] -= 0.015 * x_span
-        graph_limits["xmax"] += 0.015 * x_span
+        xmin -= 0.015 * x_span
+        xmax += 0.015 * x_span
     if axis.get_yscale() == "linear":
         if y_span != 0:
-            if graph_limits["ymin"] > 0:
-                graph_limits["ymin"] *= 0.95
+            if ymin > 0:
+                ymin *= 0.95
             else:
-                graph_limits["ymin"] *= 1.05
-            graph_limits["ymax"] *= 1.05
+                ymin *= 1.05
+            ymax *= 1.05
         else:
-            graph_limits["ymax"] += abs(graph_limits["ymax"] * 0.05)
-            graph_limits["ymin"] -= abs(graph_limits["ymin"] * 0.05)
+            ymax += abs(ymax * 0.05)
+            ymin -= abs(ymin * 0.05)
     else:
-        graph_limits["ymin"] *= 0.5
-        graph_limits["ymax"] *= 2
+        ymin *= 0.5
+        ymax *= 2
     try:
-        if axis_type == "X":
-            xmin = utilities.sig_fig_round(graph_limits["xmin"], 3)
-            xmax = utilities.sig_fig_round(graph_limits["xmax"], 3)
-            axis.set_xlim(xmin, xmax)
-        if axis_type == "Y":
-            ymin = utilities.sig_fig_round(graph_limits["ymin"], 3)
-            ymax = utilities.sig_fig_round(graph_limits["ymax"], 3)
-            axis.set_ylim(ymin, ymax)
+            xmin = utilities.sig_fig_round(xmin, 3)
+            xmax = utilities.sig_fig_round(xmax, 3)
+            ymin = utilities.sig_fig_round(ymin, 3)
+            ymax = utilities.sig_fig_round(ymax, 3)
+            if axis_direction in ["left", "right"]:
+                axis.set_ylim(ymin, ymax)
+            if axis_direction in ["top", "bottom"]:
+                axis.set_xlim(xmin, xmax)
     except ValueError:
         logging.error(
             "Could not set limits, one of the values was probably infinite")
 
 
-def find_limits(scale, items):
-    """Find the limits that are to be used for the axes."""
-    xmin_all = None
-    xmax_all = None
-    ymin_all = None
-    ymax_all = None
+def find_min_max(axis, items, axis_type):
+    """Find min and max value on a given axis, skip zeroes for log scale."""
+    min_all = None
+    max_all = None
 
     for item in items:
-        # Check the limits of each item, as long as it exists and it has the
-        # same axes as the one we"re adjusting right now
-        if item is not None and len(item.xdata) > 0:
-            # Nonzero ydata is needed for logs
-            nonzero_ydata = list(filter(lambda x: (x != 0), item.ydata))
-            xmin_item = min(item.xdata)
-            xmax_item = max(item.xdata)
+        if axis_type == 'X':
+            data = item.xdata
+            scale = axis.get_xscale()
+        elif axis_type == 'Y':
+            data = item.ydata
+            scale = axis.get_yscale()
 
-            if scale == "log" and len(nonzero_ydata) > 0:
-                ymin_item = min(nonzero_ydata)
-            else:
-                ymin_item = min(item.ydata)
-            ymax_item = max(item.ydata)
+        nonzero_data = list(filter(lambda x: (x != 0), data))
+        if scale == "log" and len(nonzero_data) > 0:
+            min_item = min(nonzero_data)
+        else:
+            min_item = min(data)
+        max_item = max(data)
+        if min_all is None:
+            min_all = min_item
+        if max_all is None:
+            max_all = max_item
+        if min_item < min_all:
+            min_all = min_item
+        if max_item > max_all:
+            max_all = max_item
 
-            if xmin_all is None:
-                xmin_all = xmin_item
-            if xmax_all is None:
-                xmax_all = xmax_item
-            if ymin_all is None:
-                ymin_all = ymin_item
-            if ymax_all is None:
-                ymax_all = ymax_item
-            if xmin_item < xmin_all:
-                xmin_all = xmin_item
-            if xmax_item > xmax_all:
-                xmax_all = xmax_item
-            if (ymin_item < ymin_all):
-                ymin_all = ymin_item
-            if ymax_item > ymax_all:
-                ymax_all = ymax_item
-    return {
-        "xmin": xmin_all,
-        "xmax": xmax_all,
-        "ymin": ymin_all,
-        "ymax": ymax_all}
+    return min_all, max_all
 
 
 def hide_unused_axes(self, canvas):
@@ -118,6 +103,29 @@ def hide_unused_axes(self, canvas):
     canvas.right_axis.get_xaxis().set_visible(False)
     canvas.top_right_axis.get_yaxis().set_visible(False)
     canvas.top_left_axis.get_yaxis().set_visible(False)
+
+def change_scale(action, target, self, scale_type, axis_type):
+    scale = target.get_string()
+    if scale_type == 'X':
+        if axis_type == 'top':
+            self.canvas.top_left_axis.set_xscale(scale)
+            self.canvas.top_right_axis.set_xscale(scale)
+            self.plot_settings.top_scale = scale
+        elif axis_type == 'bottom':
+            self.canvas.axis.set_xscale(scale)
+            self.canvas.right_axis.set_xscale(scale)
+            self.plot_settings.xscale = scale
+    elif scale_type == 'Y':
+        if axis_type == 'left':
+            self.canvas.axis.set_yscale(scale)
+            self.canvas.top_left_axis.set_yscale(scale)
+            self.plot_settings.yscale = scale
+        elif axis_type == 'right':
+            self.canvas.top_right_axis.set_yscale(scale)
+            self.canvas.right_axis.set_yscale(scale)
+            self.plot_settings.right_scale = scale
+    action.change_state(target)
+    graphs.refresh(self, set_limits=True)
 
 
 def change_left_yscale(action, target, self):

--- a/src/rename.py
+++ b/src/rename.py
@@ -44,5 +44,5 @@ class RenameWindow(Adw.Window):
             parent.plot_settings.right_label = text
         if item == parent.canvas.title:
             parent.plot_settings.title = text
-        graphs.reload(parent, reset_limits = False)
+        graphs.reload(parent, reset_limits=False)
         self.destroy()

--- a/src/rename.py
+++ b/src/rename.py
@@ -44,5 +44,5 @@ class RenameWindow(Adw.Window):
             parent.plot_settings.right_label = text
         if item == parent.canvas.title:
             parent.plot_settings.title = text
-        graphs.reload(parent)
+        graphs.reload(parent, reset_limits = False)
         self.destroy()

--- a/src/ui.py
+++ b/src/ui.py
@@ -8,7 +8,7 @@ from graphs.item_box import ItemBox
 
 
 def on_style_change(_shortcut, _theme, _widget, self):
-    graphs.reload(self, reset_limits = False)
+    graphs.reload(self, reset_limits=False)
 
 
 def enable_data_dependent_buttons(self, enabled):

--- a/src/ui.py
+++ b/src/ui.py
@@ -8,7 +8,7 @@ from graphs.item_box import ItemBox
 
 
 def on_style_change(_shortcut, _theme, _widget, self):
-    graphs.reload(self)
+    graphs.reload(self, reset_limits = False)
 
 
 def enable_data_dependent_buttons(self, enabled):


### PR DESCRIPTION
This adds the ability to keep the old limits after reloading a graph. In the current main branch, when switching to dark mode for instance, the limits are reset. The same is true when reordering lines to put one in front. This has annoyed me at some occasions.
This adds the optional argument reset_limits to the graphs.reload function (true by default). If this is set to false, the old limits are applied again after reloading.

In this PR, this new function is used to make the canvas resets way less aggressive. This way the old limits are kept when changing styles, line properties, plot settings etc..