### PR TITLE
make choosers translatable

### DIFF
--- a/data/ui/add_data_advanced.blp
+++ b/data/ui/add_data_advanced.blp
@@ -39,9 +39,6 @@ template AddAdvancedWindow : Adw.Window {
         Adw.ComboRow separator {
           title: _("Decimal Separator");
           subtitle: _("The character that is used as decimal separator");
-          model: StringList {
-            strings [".", ","]
-          };
         }
 
         Adw.ActionRow {

--- a/data/ui/add_style.blp
+++ b/data/ui/add_style.blp
@@ -25,12 +25,11 @@ template AddStyleWindow : Adw.Window {
       margin-bottom: 12;
       Adw.PreferencesGroup {
       	margin-top: 12;
-	margin-start: 26;
-	margin-end: 26;
+	      margin-start: 26;
+	      margin-end: 26;
         Adw.ComboRow plot_style_templates {
           title: _("Template");
           subtitle: _("The template style used for the new style");
-          model: StringList {};
         }
 
         Adw.EntryRow new_style_name {
@@ -42,8 +41,8 @@ template AddStyleWindow : Adw.Window {
 
         Button confirm_button {
           halign: center;
-	  margin-top: 24;
-	  margin-bottom: 12;
+	        margin-top: 24;
+	        margin-bottom: 12;
           label: _("Add New Style");
           styles ["suggested-action", "pill"]
         }

--- a/data/ui/edit_item.blp
+++ b/data/ui/edit_item.blp
@@ -15,7 +15,6 @@ template EditItemWindow : Adw.PreferencesWindow {
       Adw.ComboRow item_selector {
         title: _("Selected Item");
         subtitle: _("Choose which item to edit");
-        model: StringList {};
       }
     }
 
@@ -31,17 +30,11 @@ template EditItemWindow : Adw.PreferencesWindow {
       Adw.ComboRow plot_x_position {
         title: _("X-Axis Position");
         subtitle: _("The position of the X-axis");
-        model: StringList {
-          strings ["top", "bottom"]
-        };
       }
 
       Adw.ComboRow plot_y_position {
         title: _("Y-Axis Position");
         subtitle: _("The position of the Y-axis");
-        model: StringList {
-          strings ["left", "right"]
-        };
       }
     }
 
@@ -52,9 +45,6 @@ template EditItemWindow : Adw.PreferencesWindow {
       Adw.ComboRow linestyle {
         title: _("Linestyle");
         subtitle: _("The linestyle");
-        model: StringList {
-          strings ["none", "solid", "dotted", "dashed", "dashdot"]
-        };
       }
 
       Adw.ActionRow {
@@ -70,9 +60,6 @@ template EditItemWindow : Adw.PreferencesWindow {
       Adw.ComboRow markers {
         title: _("Markers");
         subtitle: _("The markers that are used");
-        model: StringList {
-          strings ["none"]
-        };
       }
 
       Adw.ActionRow {

--- a/data/ui/export_figure.blp
+++ b/data/ui/export_figure.blp
@@ -29,7 +29,6 @@ template ExportFigureWindow : Adw.Window {
         Adw.ComboRow file_format {
           title: _("File Format");
           subtitle: _("In which file format should the graph be exported?");
-          model: StringList {};
         }
 
       Adw.ActionRow {

--- a/data/ui/plot_settings.blp
+++ b/data/ui/plot_settings.blp
@@ -118,33 +118,21 @@ template PlotSettingsWindow : Adw.PreferencesWindow {
       Adw.ComboRow plot_x_scale {
         title: _("Bottom Axis Scale");
         subtitle: _("Scaling on the bottom axis");
-        model: StringList {
-          strings ["log", "linear"]
-        };
       }
 
       Adw.ComboRow plot_y_scale {
         title: _("Left Axis Scale");
         subtitle: _("Scaling used for the left-hand axis");
-        model: StringList {
-          strings ["log", "linear"]
-        };
       }
 
       Adw.ComboRow plot_top_scale {
         title: _("Top Axis Scale");
         subtitle: _("Scaling used for the top axis");
-        model: StringList {
-          strings ["log", "linear"]
-        };
       }
 
       Adw.ComboRow plot_right_scale {
         title: _("Right Axis Scale");
         subtitle: _("Scaling used for the right-hand axis");
-        model: StringList {
-          strings ["log", "linear"]
-        };
       }
     }
 
@@ -158,11 +146,8 @@ template PlotSettingsWindow : Adw.PreferencesWindow {
         Adw.ComboRow plot_legend_position {
           title: _("Legend position");
           subtitle: _("The position of the legend");
-          model: StringList {
-          strings ["Best", "Upper right", "Upper left", "Lower left", "Lower right", "Center left", "Center right", "Lower center", "Upper center", "Center"]
-        };
+        }
       }
-    }
 
       Adw.ExpanderRow use_custom_plot_style {
         title: _("Custom Plot Style");
@@ -171,7 +156,6 @@ template PlotSettingsWindow : Adw.PreferencesWindow {
         Adw.ComboRow custom_plot_style {
           title: _("Graph Style");
           subtitle: _("The style sheet used for the graph");
-          model: StringList {};
         }
       }
     }

--- a/data/ui/plot_styles.blp
+++ b/data/ui/plot_styles.blp
@@ -96,9 +96,6 @@ template PlotStylesWindow : Adw.Window {
               Adw.ComboRow linestyle {
                 title: _("Linestyle");
                 subtitle: _("The linestyle used");
-                model: StringList {
-                  strings ["solid", "dotted", "dashed", "dashdot"]
-                };
               }
 
               Adw.ActionRow {
@@ -114,9 +111,6 @@ template PlotStylesWindow : Adw.Window {
               Adw.ComboRow markers {
                 title: _("Markers");
                 subtitle: _("The markers that are used");
-                model: StringList {
-                  strings ["none"]
-                };
               }
 
               Adw.ActionRow {
@@ -137,9 +131,6 @@ template PlotStylesWindow : Adw.Window {
               Adw.ComboRow tick_direction {
                 title: _("Tick Directions");
                 subtitle: _("Choose to have the ticks in the plot either in or out");
-                model: StringList {
-                  strings ["in", "out"]
-                };
               }
 
               Adw.ActionRow {

--- a/data/ui/preferences.blp
+++ b/data/ui/preferences.blp
@@ -21,9 +21,6 @@ template PreferencesWindow : Adw.PreferencesWindow {
       Adw.ComboRow import_separator {
         title: _("Decimal Separator");
         subtitle: _("The character that is used as decimal separator");
-        model: StringList {
-          strings [".", ","]
-        };
       }
 
       Adw.ActionRow {
@@ -109,9 +106,6 @@ template PreferencesWindow : Adw.PreferencesWindow {
       Adw.ComboRow export_figure_filetype {
         title: _("Default Filetype");
         subtitle: _("The default filetype of saved graphs");
-        model: StringList {
-          strings ["png", "ps", "pdf", "svg", "jpeg", "webp", "eps", "tiff"]
-        };
       }
 
       Adw.ActionRow {
@@ -148,9 +142,6 @@ template PreferencesWindow : Adw.PreferencesWindow {
       Adw.ComboRow action_center_data {
         title: _("Center Data");
         subtitle: _("The behaviour of the center data button");
-        model: StringList {
-          strings ["Center at maximum Y value", "Center at middle coordinate"]
-        };
       }
     }
 
@@ -177,9 +168,6 @@ template PreferencesWindow : Adw.PreferencesWindow {
       Adw.ComboRow other_handle_duplicates {
         title: _("Handle duplicate entries");
         subtitle: _("Choose how to handle duplicate entries to be loaded");
-        model: StringList {
-          strings ["Auto-rename duplicates", "Ignore duplicates", "Add duplicates", "Override existing items"]
-        };
       }
 
       Adw.ActionRow {
@@ -240,49 +228,31 @@ template PreferencesWindow : Adw.PreferencesWindow {
       Adw.ComboRow plot_x_scale {
         title: _("Default Bottom Axis Scale");
         subtitle: _("The scaling on the bottom axis");
-        model: StringList {
-          strings ["log", "linear"]
-        };
       }
 
       Adw.ComboRow plot_y_scale {
         title: _("Default Left Axis Scale");
         subtitle: _("The scaling on the left-hand axis");
-        model: StringList {
-          strings ["log", "linear"]
-        };
       }
 
       Adw.ComboRow plot_top_scale {
         title: _("Default Top Axis Scale");
         subtitle: _("The scaling on the top axis");
-        model: StringList {
-          strings ["log", "linear"]
-        };
       }
 
       Adw.ComboRow plot_right_scale {
         title: _("Default Right Axis Scale");
         subtitle: _("The scaling on the right-hand axis");
-        model: StringList {
-          strings ["log", "linear"]
-        };
       }
 
       Adw.ComboRow plot_x_position {
         title: _("Default X-Axis Position");
         subtitle: _("The position of the X-axis");
-        model: StringList {
-          strings ["top", "bottom"]
-        };
       }
 
       Adw.ComboRow plot_y_position {
         title: _("Default Y-Axis Position");
         subtitle: _("The default position of the Y-axis");
-        model: StringList {
-          strings ["left", "right"]
-        };
       }
     }
 
@@ -297,9 +267,6 @@ template PreferencesWindow : Adw.PreferencesWindow {
         Adw.ComboRow plot_legend_position {
           title: _("Legend position");
           subtitle: _("The default position of the legend");
-          model: StringList {
-          strings ["Best", "Upper right", "Upper left", "Lower left", "Lower right", "Center left", "Center right", "Lower center", "Upper center", "Center"]
-        };
       }
     }
 
@@ -311,7 +278,6 @@ template PreferencesWindow : Adw.PreferencesWindow {
         Adw.ComboRow plot_custom_style {
           title: _("Custom Style");
           subtitle: _("The custom style sheet used by default");
-          model: StringList {};
         }
       }
       Adw.ActionRow {

--- a/data/ui/transform_window.blp
+++ b/data/ui/transform_window.blp
@@ -41,8 +41,8 @@ template TransformWindow : Adw.Window {
       Adw.PreferencesGroup {
         margin-start: 26;
         margin-end: 26;
-	margin-top: 12;
-	margin-bottom: 6;
+	      margin-top: 12;
+	      margin-bottom: 6;
         Adw.EntryRow transform_x_entry {
           title: _("X =");
         }

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: graphs\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-25 21:15+0200\n"
+"POT-Creation-Date: 2023-04-29 20:52+0200\n"
 "PO-Revision-Date: 2023-04-17 17:45+0200\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -37,44 +37,44 @@ msgstr ""
 msgid "The character that is used as decimal separator"
 msgstr ""
 
-#: data/ui/add_data_advanced.blp:48 data/ui/preferences.blp:30
+#: data/ui/add_data_advanced.blp:45 data/ui/preferences.blp:27
 msgid "Column X"
 msgstr ""
 
-#: data/ui/add_data_advanced.blp:49
+#: data/ui/add_data_advanced.blp:46
 msgid "Choose which column to load for the X-data"
 msgstr ""
 
-#: data/ui/add_data_advanced.blp:63 data/ui/preferences.blp:47
+#: data/ui/add_data_advanced.blp:60 data/ui/preferences.blp:44
 msgid "Column Y"
 msgstr ""
 
-#: data/ui/add_data_advanced.blp:64
+#: data/ui/add_data_advanced.blp:61
 msgid "Choose which column to load for the Y-data"
 msgstr ""
 
-#: data/ui/add_data_advanced.blp:78 data/ui/preferences.blp:64
+#: data/ui/add_data_advanced.blp:75 data/ui/preferences.blp:61
 msgid "Skip Rows"
 msgstr ""
 
-#: data/ui/add_data_advanced.blp:79
+#: data/ui/add_data_advanced.blp:76
 msgid "Choose how many rows to skip while loading data"
 msgstr ""
 
-#: data/ui/add_data_advanced.blp:93
+#: data/ui/add_data_advanced.blp:90
 msgid "Retrieve Label"
 msgstr ""
 
-#: data/ui/add_data_advanced.blp:94 data/ui/preferences.blp:227
+#: data/ui/add_data_advanced.blp:91 data/ui/preferences.blp:215
 msgid "Try and retrieve label from the header in the dataset"
 msgstr ""
 
-#: data/ui/add_data_advanced.blp:105
+#: data/ui/add_data_advanced.blp:102
 msgid "Open Files"
 msgstr ""
 
 #: data/ui/add_equation_window.blp:7 data/ui/add_equation_window.blp:84
-#: data/ui/preferences.blp:81
+#: data/ui/preferences.blp:78
 msgid "Add Equation"
 msgstr ""
 
@@ -114,11 +114,11 @@ msgstr ""
 msgid "The template style used for the new style"
 msgstr ""
 
-#: data/ui/add_style.blp:37
+#: data/ui/add_style.blp:36
 msgid "New Style Name"
 msgstr ""
 
-#: data/ui/add_style.blp:47
+#: data/ui/add_style.blp:46
 msgid "Add New Style"
 msgstr ""
 
@@ -130,71 +130,71 @@ msgstr ""
 msgid "Choose which item to edit"
 msgstr ""
 
-#: data/ui/edit_item.blp:23
+#: data/ui/edit_item.blp:22
 msgid "Data"
 msgstr ""
 
-#: data/ui/edit_item.blp:24
+#: data/ui/edit_item.blp:23
 msgid "Change the name of the data set and the axis positions"
 msgstr ""
 
-#: data/ui/edit_item.blp:27
+#: data/ui/edit_item.blp:26
 msgid "Change Name"
 msgstr ""
 
-#: data/ui/edit_item.blp:32
+#: data/ui/edit_item.blp:31
 msgid "X-Axis Position"
 msgstr ""
 
-#: data/ui/edit_item.blp:33 data/ui/preferences.blp:274
+#: data/ui/edit_item.blp:32 data/ui/preferences.blp:250
 msgid "The position of the X-axis"
 msgstr ""
 
-#: data/ui/edit_item.blp:40
+#: data/ui/edit_item.blp:36
 msgid "Y-Axis Position"
 msgstr ""
 
-#: data/ui/edit_item.blp:41
+#: data/ui/edit_item.blp:37
 msgid "The position of the Y-axis"
 msgstr ""
 
-#: data/ui/edit_item.blp:49
+#: data/ui/edit_item.blp:42
 msgid "Line Style"
 msgstr ""
 
-#: data/ui/edit_item.blp:50
+#: data/ui/edit_item.blp:43
 msgid "Change properties of the lines"
 msgstr ""
 
-#: data/ui/edit_item.blp:53
+#: data/ui/edit_item.blp:46
 msgid "Linestyle"
 msgstr ""
 
-#: data/ui/edit_item.blp:54
+#: data/ui/edit_item.blp:47
 msgid "The linestyle"
 msgstr ""
 
-#: data/ui/edit_item.blp:61
+#: data/ui/edit_item.blp:51
 msgid "Linewidth"
 msgstr ""
 
-#: data/ui/edit_item.blp:62
+#: data/ui/edit_item.blp:52
 msgid "The width of lines"
 msgstr ""
 
-#: data/ui/edit_item.blp:71
+#: data/ui/edit_item.blp:61
 msgid "Markers"
 msgstr ""
 
-#: data/ui/edit_item.blp:72
+#: data/ui/edit_item.blp:62
 msgid "The markers that are used"
 msgstr ""
 
-#: data/ui/edit_item.blp:79
+#: data/ui/edit_item.blp:66
 msgid "Marker Size"
 msgstr ""
 
-#: data/ui/edit_item.blp:80
+#: data/ui/edit_item.blp:67
 msgid "The size of the markers"
 msgstr ""
 
@@ -210,23 +210,23 @@ msgstr ""
 msgid "In which file format should the graph be exported?"
 msgstr ""
 
-#: data/ui/export_figure.blp:36
+#: data/ui/export_figure.blp:35
 msgid "Graph dpi"
 msgstr ""
 
-#: data/ui/export_figure.blp:37
+#: data/ui/export_figure.blp:36
 msgid "Set the resolution of the graph in dots per inch "
 msgstr ""
 
-#: data/ui/export_figure.blp:52 data/ui/preferences.blp:134
+#: data/ui/export_figure.blp:51 data/ui/preferences.blp:128
 msgid "Transparent Background"
 msgstr ""
 
-#: data/ui/export_figure.blp:53
+#: data/ui/export_figure.blp:52
 msgid "Export using a transparent background."
 msgstr ""
 
-#: data/ui/export_figure.blp:64 src/export_figure.py:52
+#: data/ui/export_figure.blp:63 src/export_figure.py:52
 msgid "Export"
 msgstr ""
 
@@ -393,7 +393,7 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: data/ui/plot_settings.blp:18 data/ui/preferences.blp:202
+#: data/ui/plot_settings.blp:18 data/ui/preferences.blp:190
 msgid "Plot Labels"
 msgstr ""
 
@@ -485,67 +485,67 @@ msgstr ""
 msgid "Scaling on the bottom axis"
 msgstr ""
 
-#: data/ui/plot_settings.blp:127
+#: data/ui/plot_settings.blp:124
 msgid "Left Axis Scale"
 msgstr ""
 
-#: data/ui/plot_settings.blp:128
+#: data/ui/plot_settings.blp:125
 msgid "Scaling used for the left-hand axis"
 msgstr ""
 
-#: data/ui/plot_settings.blp:135
+#: data/ui/plot_settings.blp:129
 msgid "Top Axis Scale"
 msgstr ""
 
-#: data/ui/plot_settings.blp:136
+#: data/ui/plot_settings.blp:130
 msgid "Scaling used for the top axis"
 msgstr ""
 
-#: data/ui/plot_settings.blp:143
+#: data/ui/plot_settings.blp:134
 msgid "Right Axis Scale"
 msgstr ""
 
-#: data/ui/plot_settings.blp:144
+#: data/ui/plot_settings.blp:135
 msgid "Scaling used for the right-hand axis"
 msgstr ""
 
-#: data/ui/plot_settings.blp:152
+#: data/ui/plot_settings.blp:140
 msgid "Style"
 msgstr ""
 
-#: data/ui/plot_settings.blp:153
+#: data/ui/plot_settings.blp:141
 msgid "Settings for the graph style"
 msgstr ""
 
-#: data/ui/plot_settings.blp:155 data/ui/preferences.blp:294
+#: data/ui/plot_settings.blp:143 data/ui/preferences.blp:264
 msgid "Legend"
 msgstr ""
 
-#: data/ui/plot_settings.blp:156
+#: data/ui/plot_settings.blp:144
 msgid "Use a legend for the lines"
 msgstr ""
 
-#: data/ui/plot_settings.blp:159 data/ui/preferences.blp:298
+#: data/ui/plot_settings.blp:147 data/ui/preferences.blp:268
 msgid "Legend position"
 msgstr ""
 
-#: data/ui/plot_settings.blp:160
+#: data/ui/plot_settings.blp:148
 msgid "The position of the legend"
 msgstr ""
 
-#: data/ui/plot_settings.blp:168 data/ui/preferences.blp:307
+#: data/ui/plot_settings.blp:153 data/ui/preferences.blp:274
 msgid "Custom Plot Style"
 msgstr ""
 
-#: data/ui/plot_settings.blp:169
+#: data/ui/plot_settings.blp:154
 msgid "Use a custom plot style instead of following the system style"
 msgstr ""
 
-#: data/ui/plot_settings.blp:172
+#: data/ui/plot_settings.blp:157
 msgid "Graph Style"
 msgstr ""
 
-#: data/ui/plot_settings.blp:173
+#: data/ui/plot_settings.blp:158
 msgid "The style sheet used for the graph"
 msgstr ""
 
@@ -561,228 +561,228 @@ msgstr ""
 msgid "Delimiter"
 msgstr ""
 
-#: data/ui/preferences.blp:31
+#: data/ui/preferences.blp:28
 msgid "Which column to load for the X-data"
 msgstr ""
 
-#: data/ui/preferences.blp:48
+#: data/ui/preferences.blp:45
 msgid "Which column to load for the Y-data"
 msgstr ""
 
-#: data/ui/preferences.blp:65
+#: data/ui/preferences.blp:62
 msgid "How many rows to skip while loading data"
 msgstr ""
 
-#: data/ui/preferences.blp:82
+#: data/ui/preferences.blp:79
 msgid "Settings for the \"Add Equation\" option"
 msgstr ""
 
-#: data/ui/preferences.blp:85
+#: data/ui/preferences.blp:82
 msgid "Default Equation: Y ="
 msgstr ""
 
-#: data/ui/preferences.blp:90
+#: data/ui/preferences.blp:87
 msgid "Default X start"
 msgstr ""
 
-#: data/ui/preferences.blp:95
+#: data/ui/preferences.blp:92
 msgid "Default X stop"
 msgstr ""
 
-#: data/ui/preferences.blp:100
+#: data/ui/preferences.blp:97
 msgid "Default Step Size"
 msgstr ""
 
-#: data/ui/preferences.blp:106
+#: data/ui/preferences.blp:103
 msgid "Export Options"
 msgstr ""
 
-#: data/ui/preferences.blp:107
+#: data/ui/preferences.blp:104
 msgid "Options for exporting the graph"
 msgstr ""
 
-#: data/ui/preferences.blp:110
+#: data/ui/preferences.blp:107
 msgid "Default Filetype"
 msgstr ""
 
-#: data/ui/preferences.blp:111
+#: data/ui/preferences.blp:108
 msgid "The default filetype of saved graphs"
 msgstr ""
 
-#: data/ui/preferences.blp:118
+#: data/ui/preferences.blp:112
 msgid "Default dpi"
 msgstr ""
 
-#: data/ui/preferences.blp:119
+#: data/ui/preferences.blp:113
 msgid "The default resolution of saved graphs in dots per inch"
 msgstr ""
 
-#: data/ui/preferences.blp:135
+#: data/ui/preferences.blp:129
 msgid "Use a transparent background for the saved plots by default"
 msgstr ""
 
-#: data/ui/preferences.blp:145
+#: data/ui/preferences.blp:139
 msgid "Action Behaviour"
 msgstr ""
 
-#: data/ui/preferences.blp:146
+#: data/ui/preferences.blp:140
 msgid "Behaviour of specific actions"
 msgstr ""
 
-#: data/ui/preferences.blp:149
+#: data/ui/preferences.blp:143
 msgid "Center Data"
 msgstr ""
 
-#: data/ui/preferences.blp:150
+#: data/ui/preferences.blp:144
 msgid "The behaviour of the center data button"
 msgstr ""
 
-#: data/ui/preferences.blp:158
+#: data/ui/preferences.blp:149
 msgid "Other"
 msgstr ""
 
-#: data/ui/preferences.blp:159
+#: data/ui/preferences.blp:150
 msgid "Other general settings"
 msgstr ""
 
-#: data/ui/preferences.blp:162
+#: data/ui/preferences.blp:153
 msgid "Clipboard length"
 msgstr ""
 
-#: data/ui/preferences.blp:163
+#: data/ui/preferences.blp:154
 msgid "Choose how many states are stored in the clipboard"
 msgstr ""
 
-#: data/ui/preferences.blp:178
+#: data/ui/preferences.blp:169
 msgid "Handle duplicate entries"
 msgstr ""
 
-#: data/ui/preferences.blp:179
+#: data/ui/preferences.blp:170
 msgid "Choose how to handle duplicate entries to be loaded"
 msgstr ""
 
-#: data/ui/preferences.blp:186
+#: data/ui/preferences.blp:174
 msgid "Hide Unselected"
 msgstr ""
 
-#: data/ui/preferences.blp:187
+#: data/ui/preferences.blp:175
 msgid "Whether to hide items, that aren't selected"
 msgstr ""
 
-#: data/ui/preferences.blp:203
+#: data/ui/preferences.blp:191
 msgid "Set the labels and title that are used by default"
 msgstr ""
 
-#: data/ui/preferences.blp:206
+#: data/ui/preferences.blp:194
 msgid "Default Title"
 msgstr ""
 
-#: data/ui/preferences.blp:210
+#: data/ui/preferences.blp:198
 msgid "Default Bottom Axis label"
 msgstr ""
 
-#: data/ui/preferences.blp:214
+#: data/ui/preferences.blp:202
 msgid "Default Left Axis Label"
 msgstr ""
 
-#: data/ui/preferences.blp:218
+#: data/ui/preferences.blp:206
 msgid "Default Top Axis label"
 msgstr ""
 
-#: data/ui/preferences.blp:222
+#: data/ui/preferences.blp:210
 msgid "Default Right Axis Label"
 msgstr ""
 
-#: data/ui/preferences.blp:226
+#: data/ui/preferences.blp:214
 msgid "Retrieve label"
 msgstr ""
 
-#: data/ui/preferences.blp:237
+#: data/ui/preferences.blp:225
 msgid "Axes settings"
 msgstr ""
 
-#: data/ui/preferences.blp:238
+#: data/ui/preferences.blp:226
 msgid "Set the default axes scale and position used upon launch"
 msgstr ""
 
-#: data/ui/preferences.blp:241
+#: data/ui/preferences.blp:229
 msgid "Default Bottom Axis Scale"
 msgstr ""
 
-#: data/ui/preferences.blp:242
+#: data/ui/preferences.blp:230
 msgid "The scaling on the bottom axis"
 msgstr ""
 
-#: data/ui/preferences.blp:249
+#: data/ui/preferences.blp:234
 msgid "Default Left Axis Scale"
 msgstr ""
 
-#: data/ui/preferences.blp:250
+#: data/ui/preferences.blp:235
 msgid "The scaling on the left-hand axis"
 msgstr ""
 
-#: data/ui/preferences.blp:257
+#: data/ui/preferences.blp:239
 msgid "Default Top Axis Scale"
 msgstr ""
 
-#: data/ui/preferences.blp:258
+#: data/ui/preferences.blp:240
 msgid "The scaling on the top axis"
 msgstr ""
 
-#: data/ui/preferences.blp:265
+#: data/ui/preferences.blp:244
 msgid "Default Right Axis Scale"
 msgstr ""
 
-#: data/ui/preferences.blp:266
+#: data/ui/preferences.blp:245
 msgid "The scaling on the right-hand axis"
 msgstr ""
 
-#: data/ui/preferences.blp:273
+#: data/ui/preferences.blp:249
 msgid "Default X-Axis Position"
 msgstr ""
 
-#: data/ui/preferences.blp:281
+#: data/ui/preferences.blp:254
 msgid "Default Y-Axis Position"
 msgstr ""
 
-#: data/ui/preferences.blp:282
+#: data/ui/preferences.blp:255
 msgid "The default position of the Y-axis"
 msgstr ""
 
-#: data/ui/preferences.blp:290
+#: data/ui/preferences.blp:260
 msgid "Styling"
 msgstr ""
 
-#: data/ui/preferences.blp:291
+#: data/ui/preferences.blp:261
 msgid "Change default plot style and other visual changes"
 msgstr ""
 
-#: data/ui/preferences.blp:295
+#: data/ui/preferences.blp:265
 msgid "Use a legend by default"
 msgstr ""
 
-#: data/ui/preferences.blp:299
+#: data/ui/preferences.blp:269
 msgid "The default position of the legend"
 msgstr ""
 
-#: data/ui/preferences.blp:308
+#: data/ui/preferences.blp:275
 msgid ""
 "Use a custom plot style instead of following the system style by default"
 msgstr ""
 
-#: data/ui/preferences.blp:312
+#: data/ui/preferences.blp:279
 msgid "Custom Style"
 msgstr ""
 
-#: data/ui/preferences.blp:313
+#: data/ui/preferences.blp:280
 msgid "The custom style sheet used by default"
 msgstr ""
 
-#: data/ui/preferences.blp:318
+#: data/ui/preferences.blp:284
 msgid "Override Line Styling on Style Change"
 msgstr ""
 
-#: data/ui/preferences.blp:319
+#: data/ui/preferences.blp:285
 msgid "Override the active line styling when switching plot style"
 msgstr ""
 
@@ -901,7 +901,7 @@ msgstr ""
 msgid "Smoothen the Data"
 msgstr ""
 
-#: data/ui/window.blp:263
+#: data/ui/window.blp:263 src/misc.py:67
 msgid "Center"
 msgstr ""
 
@@ -1001,7 +1001,7 @@ msgstr ""
 msgid "Export Data"
 msgstr ""
 
-#: data/ui/window.blp:497 src/plot_styles.py:232
+#: data/ui/window.blp:497 src/plot_styles.py:229
 msgid "Plot Styles"
 msgstr ""
 
@@ -1888,7 +1888,7 @@ msgstr ""
 msgid "Graphs Project File"
 msgstr ""
 
-#: src/actions.py:126 src/plot_styles.py:207 src/plot_styles.py:421
+#: src/actions.py:126 src/plot_styles.py:204 src/plot_styles.py:420
 msgid "Cancel"
 msgstr ""
 
@@ -1952,24 +1952,224 @@ msgstr ""
 msgid "Could not load %s"
 msgstr ""
 
+#: src/misc.py:63
+msgid "linear"
+msgstr ""
+
+#: src/misc.py:63
+msgid "log"
+msgstr ""
+
+#: src/misc.py:65
+msgid "Best"
+msgstr ""
+
+#: src/misc.py:65
+msgid "Upper right"
+msgstr ""
+
+#: src/misc.py:65
+msgid "Upper left"
+msgstr ""
+
+#: src/misc.py:65
+msgid "Lower left"
+msgstr ""
+
+#: src/misc.py:66
+msgid "Lower right"
+msgstr ""
+
+#: src/misc.py:66
+msgid "Center left"
+msgstr ""
+
+#: src/misc.py:66
+msgid "Center right"
+msgstr ""
+
+#: src/misc.py:66
+msgid "Lower center"
+msgstr ""
+
+#: src/misc.py:67
+msgid "Upper center"
+msgstr ""
+
+#: src/misc.py:69
+msgid "top"
+msgstr ""
+
+#: src/misc.py:69
+msgid "bottom"
+msgstr ""
+
+#: src/misc.py:70
+msgid "left"
+msgstr ""
+
+#: src/misc.py:70
+msgid "right"
+msgstr ""
+
+#: src/misc.py:73
+msgid "Center at maximum Y value"
+msgstr ""
+
+#: src/misc.py:73
+msgid "Center at middle coordinate"
+msgstr ""
+
+#: src/misc.py:76
+msgid "Auto-rename duplicates"
+msgstr ""
+
+#: src/misc.py:76
+msgid "Ignore duplicates"
+msgstr ""
+
+#: src/misc.py:76
+msgid "Add duplicates"
+msgstr ""
+
+#: src/misc.py:77
+msgid "Override existing items"
+msgstr ""
+
+#: src/misc.py:79
+msgid "none"
+msgstr ""
+
+#: src/misc.py:79
+msgid "solid"
+msgstr ""
+
+#: src/misc.py:79
+msgid "dotted"
+msgstr ""
+
+#: src/misc.py:79
+msgid "dashed"
+msgstr ""
+
+#: src/misc.py:79
+msgid "dashdot"
+msgstr ""
+
+#: src/misc.py:81
+msgid "Point"
+msgstr ""
+
+#: src/misc.py:81
+msgid "Pixel"
+msgstr ""
+
+#: src/misc.py:81
+msgid "Circle"
+msgstr ""
+
+#: src/misc.py:82
+msgid "Triangle down"
+msgstr ""
+
+#: src/misc.py:82
+msgid "Triangle up"
+msgstr ""
+
+#: src/misc.py:82
+msgid "Triangle left"
+msgstr ""
+
+#: src/misc.py:83
+msgid "Triangle right"
+msgstr ""
+
+#: src/misc.py:83
+msgid "Octagon"
+msgstr ""
+
+#: src/misc.py:83
+msgid "Square"
+msgstr ""
+
+#: src/misc.py:84
+msgid "Pentagon"
+msgstr ""
+
+#: src/misc.py:84
+msgid "Star"
+msgstr ""
+
+#: src/misc.py:84
+msgid "Hexagon 1"
+msgstr ""
+
+#: src/misc.py:85
+msgid "Hexagon 2"
+msgstr ""
+
+#: src/misc.py:85
+msgid "Plus"
+msgstr ""
+
+#: src/misc.py:85
+msgid "x"
+msgstr ""
+
+#: src/misc.py:85
+msgid "Diamond"
+msgstr ""
+
+#: src/misc.py:86
+msgid "Thin diamond"
+msgstr ""
+
+#: src/misc.py:86
+msgid "Vertical line"
+msgstr ""
+
+#: src/misc.py:86
+msgid "Horizontal line"
+msgstr ""
+
+#: src/misc.py:87
+msgid "Filled plus"
+msgstr ""
+
+#: src/misc.py:87
+msgid "Filled x"
+msgstr ""
+
+#: src/misc.py:87
+msgid "Nothing"
+msgstr ""
+
+#: src/misc.py:89
+msgid "in"
+msgstr ""
+
+#: src/misc.py:89
+msgid "out"
+msgstr ""
+
 #: src/operations.py:85
 msgid "No data found within the highlighted area"
 msgstr ""
 
-#: src/plot_styles.py:208
+#: src/plot_styles.py:205
 msgid "Reset"
 msgstr ""
 
-#: src/plot_styles.py:238
+#: src/plot_styles.py:235
 #, python-brace-format
 msgid "{name} - line colors"
 msgstr ""
 
-#: src/plot_styles.py:422
+#: src/plot_styles.py:421
 msgid "Delete"
 msgstr ""
 
-#: src/plot_styles.py:544 src/plot_styles.py:555
+#: src/plot_styles.py:543 src/plot_styles.py:554
 #, python-brace-format
 msgid "{name} (copy)"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: graphs\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-25 21:15+0200\n"
+"POT-Creation-Date: 2023-04-29 20:52+0200\n"
 "PO-Revision-Date: 2023-04-17 18:28+0200\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -37,44 +37,44 @@ msgstr ""
 msgid "The character that is used as decimal separator"
 msgstr ""
 
-#: data/ui/add_data_advanced.blp:48 data/ui/preferences.blp:30
+#: data/ui/add_data_advanced.blp:45 data/ui/preferences.blp:27
 msgid "Column X"
 msgstr ""
 
-#: data/ui/add_data_advanced.blp:49
+#: data/ui/add_data_advanced.blp:46
 msgid "Choose which column to load for the X-data"
 msgstr ""
 
-#: data/ui/add_data_advanced.blp:63 data/ui/preferences.blp:47
+#: data/ui/add_data_advanced.blp:60 data/ui/preferences.blp:44
 msgid "Column Y"
 msgstr ""
 
-#: data/ui/add_data_advanced.blp:64
+#: data/ui/add_data_advanced.blp:61
 msgid "Choose which column to load for the Y-data"
 msgstr ""
 
-#: data/ui/add_data_advanced.blp:78 data/ui/preferences.blp:64
+#: data/ui/add_data_advanced.blp:75 data/ui/preferences.blp:61
 msgid "Skip Rows"
 msgstr ""
 
-#: data/ui/add_data_advanced.blp:79
+#: data/ui/add_data_advanced.blp:76
 msgid "Choose how many rows to skip while loading data"
 msgstr ""
 
-#: data/ui/add_data_advanced.blp:93
+#: data/ui/add_data_advanced.blp:90
 msgid "Retrieve Label"
 msgstr ""
 
-#: data/ui/add_data_advanced.blp:94 data/ui/preferences.blp:227
+#: data/ui/add_data_advanced.blp:91 data/ui/preferences.blp:215
 msgid "Try and retrieve label from the header in the dataset"
 msgstr ""
 
-#: data/ui/add_data_advanced.blp:105
+#: data/ui/add_data_advanced.blp:102
 msgid "Open Files"
 msgstr ""
 
 #: data/ui/add_equation_window.blp:7 data/ui/add_equation_window.blp:84
-#: data/ui/preferences.blp:81
+#: data/ui/preferences.blp:78
 msgid "Add Equation"
 msgstr ""
 
@@ -114,11 +114,11 @@ msgstr ""
 msgid "The template style used for the new style"
 msgstr ""
 
-#: data/ui/add_style.blp:37
+#: data/ui/add_style.blp:36
 msgid "New Style Name"
 msgstr ""
 
-#: data/ui/add_style.blp:47
+#: data/ui/add_style.blp:46
 msgid "Add New Style"
 msgstr ""
 
@@ -130,71 +130,71 @@ msgstr ""
 msgid "Choose which item to edit"
 msgstr ""
 
-#: data/ui/edit_item.blp:23
+#: data/ui/edit_item.blp:22
 msgid "Data"
 msgstr ""
 
-#: data/ui/edit_item.blp:24
+#: data/ui/edit_item.blp:23
 msgid "Change the name of the data set and the axis positions"
 msgstr ""
 
-#: data/ui/edit_item.blp:27
+#: data/ui/edit_item.blp:26
 msgid "Change Name"
 msgstr ""
 
-#: data/ui/edit_item.blp:32
+#: data/ui/edit_item.blp:31
 msgid "X-Axis Position"
 msgstr ""
 
-#: data/ui/edit_item.blp:33 data/ui/preferences.blp:274
+#: data/ui/edit_item.blp:32 data/ui/preferences.blp:250
 msgid "The position of the X-axis"
 msgstr ""
 
-#: data/ui/edit_item.blp:40
+#: data/ui/edit_item.blp:36
 msgid "Y-Axis Position"
 msgstr ""
 
-#: data/ui/edit_item.blp:41
+#: data/ui/edit_item.blp:37
 msgid "The position of the Y-axis"
 msgstr ""
 
-#: data/ui/edit_item.blp:49
+#: data/ui/edit_item.blp:42
 msgid "Line Style"
 msgstr ""
 
-#: data/ui/edit_item.blp:50
+#: data/ui/edit_item.blp:43
 msgid "Change properties of the lines"
 msgstr ""
 
-#: data/ui/edit_item.blp:53
+#: data/ui/edit_item.blp:46
 msgid "Linestyle"
 msgstr ""
 
-#: data/ui/edit_item.blp:54
+#: data/ui/edit_item.blp:47
 msgid "The linestyle"
 msgstr ""
 
-#: data/ui/edit_item.blp:61
+#: data/ui/edit_item.blp:51
 msgid "Linewidth"
 msgstr ""
 
-#: data/ui/edit_item.blp:62
+#: data/ui/edit_item.blp:52
 msgid "The width of lines"
 msgstr ""
 
-#: data/ui/edit_item.blp:71
+#: data/ui/edit_item.blp:61
 msgid "Markers"
 msgstr ""
 
-#: data/ui/edit_item.blp:72
+#: data/ui/edit_item.blp:62
 msgid "The markers that are used"
 msgstr ""
 
-#: data/ui/edit_item.blp:79
+#: data/ui/edit_item.blp:66
 msgid "Marker Size"
 msgstr ""
 
-#: data/ui/edit_item.blp:80
+#: data/ui/edit_item.blp:67
 msgid "The size of the markers"
 msgstr ""
 
@@ -210,23 +210,23 @@ msgstr ""
 msgid "In which file format should the graph be exported?"
 msgstr ""
 
-#: data/ui/export_figure.blp:36
+#: data/ui/export_figure.blp:35
 msgid "Graph dpi"
 msgstr ""
 
-#: data/ui/export_figure.blp:37
+#: data/ui/export_figure.blp:36
 msgid "Set the resolution of the graph in dots per inch "
 msgstr ""
 
-#: data/ui/export_figure.blp:52 data/ui/preferences.blp:134
+#: data/ui/export_figure.blp:51 data/ui/preferences.blp:128
 msgid "Transparent Background"
 msgstr ""
 
-#: data/ui/export_figure.blp:53
+#: data/ui/export_figure.blp:52
 msgid "Export using a transparent background."
 msgstr ""
 
-#: data/ui/export_figure.blp:64 src/export_figure.py:52
+#: data/ui/export_figure.blp:63 src/export_figure.py:52
 msgid "Export"
 msgstr ""
 
@@ -393,7 +393,7 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: data/ui/plot_settings.blp:18 data/ui/preferences.blp:202
+#: data/ui/plot_settings.blp:18 data/ui/preferences.blp:190
 msgid "Plot Labels"
 msgstr ""
 
@@ -485,67 +485,67 @@ msgstr ""
 msgid "Scaling on the bottom axis"
 msgstr ""
 
-#: data/ui/plot_settings.blp:127
+#: data/ui/plot_settings.blp:124
 msgid "Left Axis Scale"
 msgstr ""
 
-#: data/ui/plot_settings.blp:128
+#: data/ui/plot_settings.blp:125
 msgid "Scaling used for the left-hand axis"
 msgstr ""
 
-#: data/ui/plot_settings.blp:135
+#: data/ui/plot_settings.blp:129
 msgid "Top Axis Scale"
 msgstr ""
 
-#: data/ui/plot_settings.blp:136
+#: data/ui/plot_settings.blp:130
 msgid "Scaling used for the top axis"
 msgstr ""
 
-#: data/ui/plot_settings.blp:143
+#: data/ui/plot_settings.blp:134
 msgid "Right Axis Scale"
 msgstr ""
 
-#: data/ui/plot_settings.blp:144
+#: data/ui/plot_settings.blp:135
 msgid "Scaling used for the right-hand axis"
 msgstr ""
 
-#: data/ui/plot_settings.blp:152
+#: data/ui/plot_settings.blp:140
 msgid "Style"
 msgstr ""
 
-#: data/ui/plot_settings.blp:153
+#: data/ui/plot_settings.blp:141
 msgid "Settings for the graph style"
 msgstr ""
 
-#: data/ui/plot_settings.blp:155 data/ui/preferences.blp:294
+#: data/ui/plot_settings.blp:143 data/ui/preferences.blp:264
 msgid "Legend"
 msgstr ""
 
-#: data/ui/plot_settings.blp:156
+#: data/ui/plot_settings.blp:144
 msgid "Use a legend for the lines"
 msgstr ""
 
-#: data/ui/plot_settings.blp:159 data/ui/preferences.blp:298
+#: data/ui/plot_settings.blp:147 data/ui/preferences.blp:268
 msgid "Legend position"
 msgstr ""
 
-#: data/ui/plot_settings.blp:160
+#: data/ui/plot_settings.blp:148
 msgid "The position of the legend"
 msgstr ""
 
-#: data/ui/plot_settings.blp:168 data/ui/preferences.blp:307
+#: data/ui/plot_settings.blp:153 data/ui/preferences.blp:274
 msgid "Custom Plot Style"
 msgstr ""
 
-#: data/ui/plot_settings.blp:169
+#: data/ui/plot_settings.blp:154
 msgid "Use a custom plot style instead of following the system style"
 msgstr ""
 
-#: data/ui/plot_settings.blp:172
+#: data/ui/plot_settings.blp:157
 msgid "Graph Style"
 msgstr ""
 
-#: data/ui/plot_settings.blp:173
+#: data/ui/plot_settings.blp:158
 msgid "The style sheet used for the graph"
 msgstr ""
 
@@ -561,228 +561,228 @@ msgstr ""
 msgid "Delimiter"
 msgstr ""
 
-#: data/ui/preferences.blp:31
+#: data/ui/preferences.blp:28
 msgid "Which column to load for the X-data"
 msgstr ""
 
-#: data/ui/preferences.blp:48
+#: data/ui/preferences.blp:45
 msgid "Which column to load for the Y-data"
 msgstr ""
 
-#: data/ui/preferences.blp:65
+#: data/ui/preferences.blp:62
 msgid "How many rows to skip while loading data"
 msgstr ""
 
-#: data/ui/preferences.blp:82
+#: data/ui/preferences.blp:79
 msgid "Settings for the \"Add Equation\" option"
 msgstr ""
 
-#: data/ui/preferences.blp:85
+#: data/ui/preferences.blp:82
 msgid "Default Equation: Y ="
 msgstr ""
 
-#: data/ui/preferences.blp:90
+#: data/ui/preferences.blp:87
 msgid "Default X start"
 msgstr ""
 
-#: data/ui/preferences.blp:95
+#: data/ui/preferences.blp:92
 msgid "Default X stop"
 msgstr ""
 
-#: data/ui/preferences.blp:100
+#: data/ui/preferences.blp:97
 msgid "Default Step Size"
 msgstr ""
 
-#: data/ui/preferences.blp:106
+#: data/ui/preferences.blp:103
 msgid "Export Options"
 msgstr ""
 
-#: data/ui/preferences.blp:107
+#: data/ui/preferences.blp:104
 msgid "Options for exporting the graph"
 msgstr ""
 
-#: data/ui/preferences.blp:110
+#: data/ui/preferences.blp:107
 msgid "Default Filetype"
 msgstr ""
 
-#: data/ui/preferences.blp:111
+#: data/ui/preferences.blp:108
 msgid "The default filetype of saved graphs"
 msgstr ""
 
-#: data/ui/preferences.blp:118
+#: data/ui/preferences.blp:112
 msgid "Default dpi"
 msgstr ""
 
-#: data/ui/preferences.blp:119
+#: data/ui/preferences.blp:113
 msgid "The default resolution of saved graphs in dots per inch"
 msgstr ""
 
-#: data/ui/preferences.blp:135
+#: data/ui/preferences.blp:129
 msgid "Use a transparent background for the saved plots by default"
 msgstr ""
 
-#: data/ui/preferences.blp:145
+#: data/ui/preferences.blp:139
 msgid "Action Behaviour"
 msgstr ""
 
-#: data/ui/preferences.blp:146
+#: data/ui/preferences.blp:140
 msgid "Behaviour of specific actions"
 msgstr ""
 
-#: data/ui/preferences.blp:149
+#: data/ui/preferences.blp:143
 msgid "Center Data"
 msgstr ""
 
-#: data/ui/preferences.blp:150
+#: data/ui/preferences.blp:144
 msgid "The behaviour of the center data button"
 msgstr ""
 
-#: data/ui/preferences.blp:158
+#: data/ui/preferences.blp:149
 msgid "Other"
 msgstr ""
 
-#: data/ui/preferences.blp:159
+#: data/ui/preferences.blp:150
 msgid "Other general settings"
 msgstr ""
 
-#: data/ui/preferences.blp:162
+#: data/ui/preferences.blp:153
 msgid "Clipboard length"
 msgstr ""
 
-#: data/ui/preferences.blp:163
+#: data/ui/preferences.blp:154
 msgid "Choose how many states are stored in the clipboard"
 msgstr ""
 
-#: data/ui/preferences.blp:178
+#: data/ui/preferences.blp:169
 msgid "Handle duplicate entries"
 msgstr ""
 
-#: data/ui/preferences.blp:179
+#: data/ui/preferences.blp:170
 msgid "Choose how to handle duplicate entries to be loaded"
 msgstr ""
 
-#: data/ui/preferences.blp:186
+#: data/ui/preferences.blp:174
 msgid "Hide Unselected"
 msgstr ""
 
-#: data/ui/preferences.blp:187
+#: data/ui/preferences.blp:175
 msgid "Whether to hide items, that aren't selected"
 msgstr ""
 
-#: data/ui/preferences.blp:203
+#: data/ui/preferences.blp:191
 msgid "Set the labels and title that are used by default"
 msgstr ""
 
-#: data/ui/preferences.blp:206
+#: data/ui/preferences.blp:194
 msgid "Default Title"
 msgstr ""
 
-#: data/ui/preferences.blp:210
+#: data/ui/preferences.blp:198
 msgid "Default Bottom Axis label"
 msgstr ""
 
-#: data/ui/preferences.blp:214
+#: data/ui/preferences.blp:202
 msgid "Default Left Axis Label"
 msgstr ""
 
-#: data/ui/preferences.blp:218
+#: data/ui/preferences.blp:206
 msgid "Default Top Axis label"
 msgstr ""
 
-#: data/ui/preferences.blp:222
+#: data/ui/preferences.blp:210
 msgid "Default Right Axis Label"
 msgstr ""
 
-#: data/ui/preferences.blp:226
+#: data/ui/preferences.blp:214
 msgid "Retrieve label"
 msgstr ""
 
-#: data/ui/preferences.blp:237
+#: data/ui/preferences.blp:225
 msgid "Axes settings"
 msgstr ""
 
-#: data/ui/preferences.blp:238
+#: data/ui/preferences.blp:226
 msgid "Set the default axes scale and position used upon launch"
 msgstr ""
 
-#: data/ui/preferences.blp:241
+#: data/ui/preferences.blp:229
 msgid "Default Bottom Axis Scale"
 msgstr ""
 
-#: data/ui/preferences.blp:242
+#: data/ui/preferences.blp:230
 msgid "The scaling on the bottom axis"
 msgstr ""
 
-#: data/ui/preferences.blp:249
+#: data/ui/preferences.blp:234
 msgid "Default Left Axis Scale"
 msgstr ""
 
-#: data/ui/preferences.blp:250
+#: data/ui/preferences.blp:235
 msgid "The scaling on the left-hand axis"
 msgstr ""
 
-#: data/ui/preferences.blp:257
+#: data/ui/preferences.blp:239
 msgid "Default Top Axis Scale"
 msgstr ""
 
-#: data/ui/preferences.blp:258
+#: data/ui/preferences.blp:240
 msgid "The scaling on the top axis"
 msgstr ""
 
-#: data/ui/preferences.blp:265
+#: data/ui/preferences.blp:244
 msgid "Default Right Axis Scale"
 msgstr ""
 
-#: data/ui/preferences.blp:266
+#: data/ui/preferences.blp:245
 msgid "The scaling on the right-hand axis"
 msgstr ""
 
-#: data/ui/preferences.blp:273
+#: data/ui/preferences.blp:249
 msgid "Default X-Axis Position"
 msgstr ""
 
-#: data/ui/preferences.blp:281
+#: data/ui/preferences.blp:254
 msgid "Default Y-Axis Position"
 msgstr ""
 
-#: data/ui/preferences.blp:282
+#: data/ui/preferences.blp:255
 msgid "The default position of the Y-axis"
 msgstr ""
 
-#: data/ui/preferences.blp:290
+#: data/ui/preferences.blp:260
 msgid "Styling"
 msgstr ""
 
-#: data/ui/preferences.blp:291
+#: data/ui/preferences.blp:261
 msgid "Change default plot style and other visual changes"
 msgstr ""
 
-#: data/ui/preferences.blp:295
+#: data/ui/preferences.blp:265
 msgid "Use a legend by default"
 msgstr ""
 
-#: data/ui/preferences.blp:299
+#: data/ui/preferences.blp:269
 msgid "The default position of the legend"
 msgstr ""
 
-#: data/ui/preferences.blp:308
+#: data/ui/preferences.blp:275
 msgid ""
 "Use a custom plot style instead of following the system style by default"
 msgstr ""
 
-#: data/ui/preferences.blp:312
+#: data/ui/preferences.blp:279
 msgid "Custom Style"
 msgstr ""
 
-#: data/ui/preferences.blp:313
+#: data/ui/preferences.blp:280
 msgid "The custom style sheet used by default"
 msgstr ""
 
-#: data/ui/preferences.blp:318
+#: data/ui/preferences.blp:284
 msgid "Override Line Styling on Style Change"
 msgstr ""
 
-#: data/ui/preferences.blp:319
+#: data/ui/preferences.blp:285
 msgid "Override the active line styling when switching plot style"
 msgstr ""
 
@@ -901,7 +901,7 @@ msgstr ""
 msgid "Smoothen the Data"
 msgstr ""
 
-#: data/ui/window.blp:263
+#: data/ui/window.blp:263 src/misc.py:67
 msgid "Center"
 msgstr ""
 
@@ -1001,7 +1001,7 @@ msgstr ""
 msgid "Export Data"
 msgstr ""
 
-#: data/ui/window.blp:497 src/plot_styles.py:232
+#: data/ui/window.blp:497 src/plot_styles.py:229
 msgid "Plot Styles"
 msgstr ""
 
@@ -1888,7 +1888,7 @@ msgstr ""
 msgid "Graphs Project File"
 msgstr ""
 
-#: src/actions.py:126 src/plot_styles.py:207 src/plot_styles.py:421
+#: src/actions.py:126 src/plot_styles.py:204 src/plot_styles.py:420
 msgid "Cancel"
 msgstr ""
 
@@ -1952,24 +1952,224 @@ msgstr ""
 msgid "Could not load %s"
 msgstr ""
 
+#: src/misc.py:63
+msgid "linear"
+msgstr ""
+
+#: src/misc.py:63
+msgid "log"
+msgstr ""
+
+#: src/misc.py:65
+msgid "Best"
+msgstr ""
+
+#: src/misc.py:65
+msgid "Upper right"
+msgstr ""
+
+#: src/misc.py:65
+msgid "Upper left"
+msgstr ""
+
+#: src/misc.py:65
+msgid "Lower left"
+msgstr ""
+
+#: src/misc.py:66
+msgid "Lower right"
+msgstr ""
+
+#: src/misc.py:66
+msgid "Center left"
+msgstr ""
+
+#: src/misc.py:66
+msgid "Center right"
+msgstr ""
+
+#: src/misc.py:66
+msgid "Lower center"
+msgstr ""
+
+#: src/misc.py:67
+msgid "Upper center"
+msgstr ""
+
+#: src/misc.py:69
+msgid "top"
+msgstr ""
+
+#: src/misc.py:69
+msgid "bottom"
+msgstr ""
+
+#: src/misc.py:70
+msgid "left"
+msgstr ""
+
+#: src/misc.py:70
+msgid "right"
+msgstr ""
+
+#: src/misc.py:73
+msgid "Center at maximum Y value"
+msgstr ""
+
+#: src/misc.py:73
+msgid "Center at middle coordinate"
+msgstr ""
+
+#: src/misc.py:76
+msgid "Auto-rename duplicates"
+msgstr ""
+
+#: src/misc.py:76
+msgid "Ignore duplicates"
+msgstr ""
+
+#: src/misc.py:76
+msgid "Add duplicates"
+msgstr ""
+
+#: src/misc.py:77
+msgid "Override existing items"
+msgstr ""
+
+#: src/misc.py:79
+msgid "none"
+msgstr ""
+
+#: src/misc.py:79
+msgid "solid"
+msgstr ""
+
+#: src/misc.py:79
+msgid "dotted"
+msgstr ""
+
+#: src/misc.py:79
+msgid "dashed"
+msgstr ""
+
+#: src/misc.py:79
+msgid "dashdot"
+msgstr ""
+
+#: src/misc.py:81
+msgid "Point"
+msgstr ""
+
+#: src/misc.py:81
+msgid "Pixel"
+msgstr ""
+
+#: src/misc.py:81
+msgid "Circle"
+msgstr ""
+
+#: src/misc.py:82
+msgid "Triangle down"
+msgstr ""
+
+#: src/misc.py:82
+msgid "Triangle up"
+msgstr ""
+
+#: src/misc.py:82
+msgid "Triangle left"
+msgstr ""
+
+#: src/misc.py:83
+msgid "Triangle right"
+msgstr ""
+
+#: src/misc.py:83
+msgid "Octagon"
+msgstr ""
+
+#: src/misc.py:83
+msgid "Square"
+msgstr ""
+
+#: src/misc.py:84
+msgid "Pentagon"
+msgstr ""
+
+#: src/misc.py:84
+msgid "Star"
+msgstr ""
+
+#: src/misc.py:84
+msgid "Hexagon 1"
+msgstr ""
+
+#: src/misc.py:85
+msgid "Hexagon 2"
+msgstr ""
+
+#: src/misc.py:85
+msgid "Plus"
+msgstr ""
+
+#: src/misc.py:85
+msgid "x"
+msgstr ""
+
+#: src/misc.py:85
+msgid "Diamond"
+msgstr ""
+
+#: src/misc.py:86
+msgid "Thin diamond"
+msgstr ""
+
+#: src/misc.py:86
+msgid "Vertical line"
+msgstr ""
+
+#: src/misc.py:86
+msgid "Horizontal line"
+msgstr ""
+
+#: src/misc.py:87
+msgid "Filled plus"
+msgstr ""
+
+#: src/misc.py:87
+msgid "Filled x"
+msgstr ""
+
+#: src/misc.py:87
+msgid "Nothing"
+msgstr ""
+
+#: src/misc.py:89
+msgid "in"
+msgstr ""
+
+#: src/misc.py:89
+msgid "out"
+msgstr ""
+
 #: src/operations.py:85
 msgid "No data found within the highlighted area"
 msgstr ""
 
-#: src/plot_styles.py:208
+#: src/plot_styles.py:205
 msgid "Reset"
 msgstr ""
 
-#: src/plot_styles.py:238
+#: src/plot_styles.py:235
 #, python-brace-format
 msgid "{name} - line colors"
 msgstr ""
 
-#: src/plot_styles.py:422
+#: src/plot_styles.py:421
 msgid "Delete"
 msgstr ""
 
-#: src/plot_styles.py:544 src/plot_styles.py:555
+#: src/plot_styles.py:543 src/plot_styles.py:554
 #, python-brace-format
 msgid "{name} (copy)"
 msgstr ""

--- a/po/graphs.pot
+++ b/po/graphs.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: graphs\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-25 21:15+0200\n"
+"POT-Creation-Date: 2023-04-29 20:52+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -37,44 +37,44 @@ msgstr ""
 msgid "The character that is used as decimal separator"
 msgstr ""
 
-#: data/ui/add_data_advanced.blp:48 data/ui/preferences.blp:30
+#: data/ui/add_data_advanced.blp:45 data/ui/preferences.blp:27
 msgid "Column X"
 msgstr ""
 
-#: data/ui/add_data_advanced.blp:49
+#: data/ui/add_data_advanced.blp:46
 msgid "Choose which column to load for the X-data"
 msgstr ""
 
-#: data/ui/add_data_advanced.blp:63 data/ui/preferences.blp:47
+#: data/ui/add_data_advanced.blp:60 data/ui/preferences.blp:44
 msgid "Column Y"
 msgstr ""
 
-#: data/ui/add_data_advanced.blp:64
+#: data/ui/add_data_advanced.blp:61
 msgid "Choose which column to load for the Y-data"
 msgstr ""
 
-#: data/ui/add_data_advanced.blp:78 data/ui/preferences.blp:64
+#: data/ui/add_data_advanced.blp:75 data/ui/preferences.blp:61
 msgid "Skip Rows"
 msgstr ""
 
-#: data/ui/add_data_advanced.blp:79
+#: data/ui/add_data_advanced.blp:76
 msgid "Choose how many rows to skip while loading data"
 msgstr ""
 
-#: data/ui/add_data_advanced.blp:93
+#: data/ui/add_data_advanced.blp:90
 msgid "Retrieve Label"
 msgstr ""
 
-#: data/ui/add_data_advanced.blp:94 data/ui/preferences.blp:227
+#: data/ui/add_data_advanced.blp:91 data/ui/preferences.blp:215
 msgid "Try and retrieve label from the header in the dataset"
 msgstr ""
 
-#: data/ui/add_data_advanced.blp:105
+#: data/ui/add_data_advanced.blp:102
 msgid "Open Files"
 msgstr ""
 
 #: data/ui/add_equation_window.blp:7 data/ui/add_equation_window.blp:84
-#: data/ui/preferences.blp:81
+#: data/ui/preferences.blp:78
 msgid "Add Equation"
 msgstr ""
 
@@ -114,11 +114,11 @@ msgstr ""
 msgid "The template style used for the new style"
 msgstr ""
 
-#: data/ui/add_style.blp:37
+#: data/ui/add_style.blp:36
 msgid "New Style Name"
 msgstr ""
 
-#: data/ui/add_style.blp:47
+#: data/ui/add_style.blp:46
 msgid "Add New Style"
 msgstr ""
 
@@ -130,71 +130,71 @@ msgstr ""
 msgid "Choose which item to edit"
 msgstr ""
 
-#: data/ui/edit_item.blp:23
+#: data/ui/edit_item.blp:22
 msgid "Data"
 msgstr ""
 
-#: data/ui/edit_item.blp:24
+#: data/ui/edit_item.blp:23
 msgid "Change the name of the data set and the axis positions"
 msgstr ""
 
-#: data/ui/edit_item.blp:27
+#: data/ui/edit_item.blp:26
 msgid "Change Name"
 msgstr ""
 
-#: data/ui/edit_item.blp:32
+#: data/ui/edit_item.blp:31
 msgid "X-Axis Position"
 msgstr ""
 
-#: data/ui/edit_item.blp:33 data/ui/preferences.blp:274
+#: data/ui/edit_item.blp:32 data/ui/preferences.blp:250
 msgid "The position of the X-axis"
 msgstr ""
 
-#: data/ui/edit_item.blp:40
+#: data/ui/edit_item.blp:36
 msgid "Y-Axis Position"
 msgstr ""
 
-#: data/ui/edit_item.blp:41
+#: data/ui/edit_item.blp:37
 msgid "The position of the Y-axis"
 msgstr ""
 
-#: data/ui/edit_item.blp:49
+#: data/ui/edit_item.blp:42
 msgid "Line Style"
 msgstr ""
 
-#: data/ui/edit_item.blp:50
+#: data/ui/edit_item.blp:43
 msgid "Change properties of the lines"
 msgstr ""
 
-#: data/ui/edit_item.blp:53
+#: data/ui/edit_item.blp:46
 msgid "Linestyle"
 msgstr ""
 
-#: data/ui/edit_item.blp:54
+#: data/ui/edit_item.blp:47
 msgid "The linestyle"
 msgstr ""
 
-#: data/ui/edit_item.blp:61
+#: data/ui/edit_item.blp:51
 msgid "Linewidth"
 msgstr ""
 
-#: data/ui/edit_item.blp:62
+#: data/ui/edit_item.blp:52
 msgid "The width of lines"
 msgstr ""
 
-#: data/ui/edit_item.blp:71
+#: data/ui/edit_item.blp:61
 msgid "Markers"
 msgstr ""
 
-#: data/ui/edit_item.blp:72
+#: data/ui/edit_item.blp:62
 msgid "The markers that are used"
 msgstr ""
 
-#: data/ui/edit_item.blp:79
+#: data/ui/edit_item.blp:66
 msgid "Marker Size"
 msgstr ""
 
-#: data/ui/edit_item.blp:80
+#: data/ui/edit_item.blp:67
 msgid "The size of the markers"
 msgstr ""
 
@@ -210,23 +210,23 @@ msgstr ""
 msgid "In which file format should the graph be exported?"
 msgstr ""
 
-#: data/ui/export_figure.blp:36
+#: data/ui/export_figure.blp:35
 msgid "Graph dpi"
 msgstr ""
 
-#: data/ui/export_figure.blp:37
+#: data/ui/export_figure.blp:36
 msgid "Set the resolution of the graph in dots per inch "
 msgstr ""
 
-#: data/ui/export_figure.blp:52 data/ui/preferences.blp:134
+#: data/ui/export_figure.blp:51 data/ui/preferences.blp:128
 msgid "Transparent Background"
 msgstr ""
 
-#: data/ui/export_figure.blp:53
+#: data/ui/export_figure.blp:52
 msgid "Export using a transparent background."
 msgstr ""
 
-#: data/ui/export_figure.blp:64 src/export_figure.py:52
+#: data/ui/export_figure.blp:63 src/export_figure.py:52
 msgid "Export"
 msgstr ""
 
@@ -393,7 +393,7 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: data/ui/plot_settings.blp:18 data/ui/preferences.blp:202
+#: data/ui/plot_settings.blp:18 data/ui/preferences.blp:190
 msgid "Plot Labels"
 msgstr ""
 
@@ -485,67 +485,67 @@ msgstr ""
 msgid "Scaling on the bottom axis"
 msgstr ""
 
-#: data/ui/plot_settings.blp:127
+#: data/ui/plot_settings.blp:124
 msgid "Left Axis Scale"
 msgstr ""
 
-#: data/ui/plot_settings.blp:128
+#: data/ui/plot_settings.blp:125
 msgid "Scaling used for the left-hand axis"
 msgstr ""
 
-#: data/ui/plot_settings.blp:135
+#: data/ui/plot_settings.blp:129
 msgid "Top Axis Scale"
 msgstr ""
 
-#: data/ui/plot_settings.blp:136
+#: data/ui/plot_settings.blp:130
 msgid "Scaling used for the top axis"
 msgstr ""
 
-#: data/ui/plot_settings.blp:143
+#: data/ui/plot_settings.blp:134
 msgid "Right Axis Scale"
 msgstr ""
 
-#: data/ui/plot_settings.blp:144
+#: data/ui/plot_settings.blp:135
 msgid "Scaling used for the right-hand axis"
 msgstr ""
 
-#: data/ui/plot_settings.blp:152
+#: data/ui/plot_settings.blp:140
 msgid "Style"
 msgstr ""
 
-#: data/ui/plot_settings.blp:153
+#: data/ui/plot_settings.blp:141
 msgid "Settings for the graph style"
 msgstr ""
 
-#: data/ui/plot_settings.blp:155 data/ui/preferences.blp:294
+#: data/ui/plot_settings.blp:143 data/ui/preferences.blp:264
 msgid "Legend"
 msgstr ""
 
-#: data/ui/plot_settings.blp:156
+#: data/ui/plot_settings.blp:144
 msgid "Use a legend for the lines"
 msgstr ""
 
-#: data/ui/plot_settings.blp:159 data/ui/preferences.blp:298
+#: data/ui/plot_settings.blp:147 data/ui/preferences.blp:268
 msgid "Legend position"
 msgstr ""
 
-#: data/ui/plot_settings.blp:160
+#: data/ui/plot_settings.blp:148
 msgid "The position of the legend"
 msgstr ""
 
-#: data/ui/plot_settings.blp:168 data/ui/preferences.blp:307
+#: data/ui/plot_settings.blp:153 data/ui/preferences.blp:274
 msgid "Custom Plot Style"
 msgstr ""
 
-#: data/ui/plot_settings.blp:169
+#: data/ui/plot_settings.blp:154
 msgid "Use a custom plot style instead of following the system style"
 msgstr ""
 
-#: data/ui/plot_settings.blp:172
+#: data/ui/plot_settings.blp:157
 msgid "Graph Style"
 msgstr ""
 
-#: data/ui/plot_settings.blp:173
+#: data/ui/plot_settings.blp:158
 msgid "The style sheet used for the graph"
 msgstr ""
 
@@ -561,228 +561,228 @@ msgstr ""
 msgid "Delimiter"
 msgstr ""
 
-#: data/ui/preferences.blp:31
+#: data/ui/preferences.blp:28
 msgid "Which column to load for the X-data"
 msgstr ""
 
-#: data/ui/preferences.blp:48
+#: data/ui/preferences.blp:45
 msgid "Which column to load for the Y-data"
 msgstr ""
 
-#: data/ui/preferences.blp:65
+#: data/ui/preferences.blp:62
 msgid "How many rows to skip while loading data"
 msgstr ""
 
-#: data/ui/preferences.blp:82
+#: data/ui/preferences.blp:79
 msgid "Settings for the \"Add Equation\" option"
 msgstr ""
 
-#: data/ui/preferences.blp:85
+#: data/ui/preferences.blp:82
 msgid "Default Equation: Y ="
 msgstr ""
 
-#: data/ui/preferences.blp:90
+#: data/ui/preferences.blp:87
 msgid "Default X start"
 msgstr ""
 
-#: data/ui/preferences.blp:95
+#: data/ui/preferences.blp:92
 msgid "Default X stop"
 msgstr ""
 
-#: data/ui/preferences.blp:100
+#: data/ui/preferences.blp:97
 msgid "Default Step Size"
 msgstr ""
 
-#: data/ui/preferences.blp:106
+#: data/ui/preferences.blp:103
 msgid "Export Options"
 msgstr ""
 
-#: data/ui/preferences.blp:107
+#: data/ui/preferences.blp:104
 msgid "Options for exporting the graph"
 msgstr ""
 
-#: data/ui/preferences.blp:110
+#: data/ui/preferences.blp:107
 msgid "Default Filetype"
 msgstr ""
 
-#: data/ui/preferences.blp:111
+#: data/ui/preferences.blp:108
 msgid "The default filetype of saved graphs"
 msgstr ""
 
-#: data/ui/preferences.blp:118
+#: data/ui/preferences.blp:112
 msgid "Default dpi"
 msgstr ""
 
-#: data/ui/preferences.blp:119
+#: data/ui/preferences.blp:113
 msgid "The default resolution of saved graphs in dots per inch"
 msgstr ""
 
-#: data/ui/preferences.blp:135
+#: data/ui/preferences.blp:129
 msgid "Use a transparent background for the saved plots by default"
 msgstr ""
 
-#: data/ui/preferences.blp:145
+#: data/ui/preferences.blp:139
 msgid "Action Behaviour"
 msgstr ""
 
-#: data/ui/preferences.blp:146
+#: data/ui/preferences.blp:140
 msgid "Behaviour of specific actions"
 msgstr ""
 
-#: data/ui/preferences.blp:149
+#: data/ui/preferences.blp:143
 msgid "Center Data"
 msgstr ""
 
-#: data/ui/preferences.blp:150
+#: data/ui/preferences.blp:144
 msgid "The behaviour of the center data button"
 msgstr ""
 
-#: data/ui/preferences.blp:158
+#: data/ui/preferences.blp:149
 msgid "Other"
 msgstr ""
 
-#: data/ui/preferences.blp:159
+#: data/ui/preferences.blp:150
 msgid "Other general settings"
 msgstr ""
 
-#: data/ui/preferences.blp:162
+#: data/ui/preferences.blp:153
 msgid "Clipboard length"
 msgstr ""
 
-#: data/ui/preferences.blp:163
+#: data/ui/preferences.blp:154
 msgid "Choose how many states are stored in the clipboard"
 msgstr ""
 
-#: data/ui/preferences.blp:178
+#: data/ui/preferences.blp:169
 msgid "Handle duplicate entries"
 msgstr ""
 
-#: data/ui/preferences.blp:179
+#: data/ui/preferences.blp:170
 msgid "Choose how to handle duplicate entries to be loaded"
 msgstr ""
 
-#: data/ui/preferences.blp:186
+#: data/ui/preferences.blp:174
 msgid "Hide Unselected"
 msgstr ""
 
-#: data/ui/preferences.blp:187
+#: data/ui/preferences.blp:175
 msgid "Whether to hide items, that aren't selected"
 msgstr ""
 
-#: data/ui/preferences.blp:203
+#: data/ui/preferences.blp:191
 msgid "Set the labels and title that are used by default"
 msgstr ""
 
-#: data/ui/preferences.blp:206
+#: data/ui/preferences.blp:194
 msgid "Default Title"
 msgstr ""
 
-#: data/ui/preferences.blp:210
+#: data/ui/preferences.blp:198
 msgid "Default Bottom Axis label"
 msgstr ""
 
-#: data/ui/preferences.blp:214
+#: data/ui/preferences.blp:202
 msgid "Default Left Axis Label"
 msgstr ""
 
-#: data/ui/preferences.blp:218
+#: data/ui/preferences.blp:206
 msgid "Default Top Axis label"
 msgstr ""
 
-#: data/ui/preferences.blp:222
+#: data/ui/preferences.blp:210
 msgid "Default Right Axis Label"
 msgstr ""
 
-#: data/ui/preferences.blp:226
+#: data/ui/preferences.blp:214
 msgid "Retrieve label"
 msgstr ""
 
-#: data/ui/preferences.blp:237
+#: data/ui/preferences.blp:225
 msgid "Axes settings"
 msgstr ""
 
-#: data/ui/preferences.blp:238
+#: data/ui/preferences.blp:226
 msgid "Set the default axes scale and position used upon launch"
 msgstr ""
 
-#: data/ui/preferences.blp:241
+#: data/ui/preferences.blp:229
 msgid "Default Bottom Axis Scale"
 msgstr ""
 
-#: data/ui/preferences.blp:242
+#: data/ui/preferences.blp:230
 msgid "The scaling on the bottom axis"
 msgstr ""
 
-#: data/ui/preferences.blp:249
+#: data/ui/preferences.blp:234
 msgid "Default Left Axis Scale"
 msgstr ""
 
-#: data/ui/preferences.blp:250
+#: data/ui/preferences.blp:235
 msgid "The scaling on the left-hand axis"
 msgstr ""
 
-#: data/ui/preferences.blp:257
+#: data/ui/preferences.blp:239
 msgid "Default Top Axis Scale"
 msgstr ""
 
-#: data/ui/preferences.blp:258
+#: data/ui/preferences.blp:240
 msgid "The scaling on the top axis"
 msgstr ""
 
-#: data/ui/preferences.blp:265
+#: data/ui/preferences.blp:244
 msgid "Default Right Axis Scale"
 msgstr ""
 
-#: data/ui/preferences.blp:266
+#: data/ui/preferences.blp:245
 msgid "The scaling on the right-hand axis"
 msgstr ""
 
-#: data/ui/preferences.blp:273
+#: data/ui/preferences.blp:249
 msgid "Default X-Axis Position"
 msgstr ""
 
-#: data/ui/preferences.blp:281
+#: data/ui/preferences.blp:254
 msgid "Default Y-Axis Position"
 msgstr ""
 
-#: data/ui/preferences.blp:282
+#: data/ui/preferences.blp:255
 msgid "The default position of the Y-axis"
 msgstr ""
 
-#: data/ui/preferences.blp:290
+#: data/ui/preferences.blp:260
 msgid "Styling"
 msgstr ""
 
-#: data/ui/preferences.blp:291
+#: data/ui/preferences.blp:261
 msgid "Change default plot style and other visual changes"
 msgstr ""
 
-#: data/ui/preferences.blp:295
+#: data/ui/preferences.blp:265
 msgid "Use a legend by default"
 msgstr ""
 
-#: data/ui/preferences.blp:299
+#: data/ui/preferences.blp:269
 msgid "The default position of the legend"
 msgstr ""
 
-#: data/ui/preferences.blp:308
+#: data/ui/preferences.blp:275
 msgid ""
 "Use a custom plot style instead of following the system style by default"
 msgstr ""
 
-#: data/ui/preferences.blp:312
+#: data/ui/preferences.blp:279
 msgid "Custom Style"
 msgstr ""
 
-#: data/ui/preferences.blp:313
+#: data/ui/preferences.blp:280
 msgid "The custom style sheet used by default"
 msgstr ""
 
-#: data/ui/preferences.blp:318
+#: data/ui/preferences.blp:284
 msgid "Override Line Styling on Style Change"
 msgstr ""
 
-#: data/ui/preferences.blp:319
+#: data/ui/preferences.blp:285
 msgid "Override the active line styling when switching plot style"
 msgstr ""
 
@@ -901,7 +901,7 @@ msgstr ""
 msgid "Smoothen the Data"
 msgstr ""
 
-#: data/ui/window.blp:263
+#: data/ui/window.blp:263 src/misc.py:67
 msgid "Center"
 msgstr ""
 
@@ -1001,7 +1001,7 @@ msgstr ""
 msgid "Export Data"
 msgstr ""
 
-#: data/ui/window.blp:497 src/plot_styles.py:232
+#: data/ui/window.blp:497 src/plot_styles.py:229
 msgid "Plot Styles"
 msgstr ""
 
@@ -1888,7 +1888,7 @@ msgstr ""
 msgid "Graphs Project File"
 msgstr ""
 
-#: src/actions.py:126 src/plot_styles.py:207 src/plot_styles.py:421
+#: src/actions.py:126 src/plot_styles.py:204 src/plot_styles.py:420
 msgid "Cancel"
 msgstr ""
 
@@ -1952,24 +1952,224 @@ msgstr ""
 msgid "Could not load %s"
 msgstr ""
 
+#: src/misc.py:63
+msgid "linear"
+msgstr ""
+
+#: src/misc.py:63
+msgid "log"
+msgstr ""
+
+#: src/misc.py:65
+msgid "Best"
+msgstr ""
+
+#: src/misc.py:65
+msgid "Upper right"
+msgstr ""
+
+#: src/misc.py:65
+msgid "Upper left"
+msgstr ""
+
+#: src/misc.py:65
+msgid "Lower left"
+msgstr ""
+
+#: src/misc.py:66
+msgid "Lower right"
+msgstr ""
+
+#: src/misc.py:66
+msgid "Center left"
+msgstr ""
+
+#: src/misc.py:66
+msgid "Center right"
+msgstr ""
+
+#: src/misc.py:66
+msgid "Lower center"
+msgstr ""
+
+#: src/misc.py:67
+msgid "Upper center"
+msgstr ""
+
+#: src/misc.py:69
+msgid "top"
+msgstr ""
+
+#: src/misc.py:69
+msgid "bottom"
+msgstr ""
+
+#: src/misc.py:70
+msgid "left"
+msgstr ""
+
+#: src/misc.py:70
+msgid "right"
+msgstr ""
+
+#: src/misc.py:73
+msgid "Center at maximum Y value"
+msgstr ""
+
+#: src/misc.py:73
+msgid "Center at middle coordinate"
+msgstr ""
+
+#: src/misc.py:76
+msgid "Auto-rename duplicates"
+msgstr ""
+
+#: src/misc.py:76
+msgid "Ignore duplicates"
+msgstr ""
+
+#: src/misc.py:76
+msgid "Add duplicates"
+msgstr ""
+
+#: src/misc.py:77
+msgid "Override existing items"
+msgstr ""
+
+#: src/misc.py:79
+msgid "none"
+msgstr ""
+
+#: src/misc.py:79
+msgid "solid"
+msgstr ""
+
+#: src/misc.py:79
+msgid "dotted"
+msgstr ""
+
+#: src/misc.py:79
+msgid "dashed"
+msgstr ""
+
+#: src/misc.py:79
+msgid "dashdot"
+msgstr ""
+
+#: src/misc.py:81
+msgid "Point"
+msgstr ""
+
+#: src/misc.py:81
+msgid "Pixel"
+msgstr ""
+
+#: src/misc.py:81
+msgid "Circle"
+msgstr ""
+
+#: src/misc.py:82
+msgid "Triangle down"
+msgstr ""
+
+#: src/misc.py:82
+msgid "Triangle up"
+msgstr ""
+
+#: src/misc.py:82
+msgid "Triangle left"
+msgstr ""
+
+#: src/misc.py:83
+msgid "Triangle right"
+msgstr ""
+
+#: src/misc.py:83
+msgid "Octagon"
+msgstr ""
+
+#: src/misc.py:83
+msgid "Square"
+msgstr ""
+
+#: src/misc.py:84
+msgid "Pentagon"
+msgstr ""
+
+#: src/misc.py:84
+msgid "Star"
+msgstr ""
+
+#: src/misc.py:84
+msgid "Hexagon 1"
+msgstr ""
+
+#: src/misc.py:85
+msgid "Hexagon 2"
+msgstr ""
+
+#: src/misc.py:85
+msgid "Plus"
+msgstr ""
+
+#: src/misc.py:85
+msgid "x"
+msgstr ""
+
+#: src/misc.py:85
+msgid "Diamond"
+msgstr ""
+
+#: src/misc.py:86
+msgid "Thin diamond"
+msgstr ""
+
+#: src/misc.py:86
+msgid "Vertical line"
+msgstr ""
+
+#: src/misc.py:86
+msgid "Horizontal line"
+msgstr ""
+
+#: src/misc.py:87
+msgid "Filled plus"
+msgstr ""
+
+#: src/misc.py:87
+msgid "Filled x"
+msgstr ""
+
+#: src/misc.py:87
+msgid "Nothing"
+msgstr ""
+
+#: src/misc.py:89
+msgid "in"
+msgstr ""
+
+#: src/misc.py:89
+msgid "out"
+msgstr ""
+
 #: src/operations.py:85
 msgid "No data found within the highlighted area"
 msgstr ""
 
-#: src/plot_styles.py:208
+#: src/plot_styles.py:205
 msgid "Reset"
 msgstr ""
 
-#: src/plot_styles.py:238
+#: src/plot_styles.py:235
 #, python-brace-format
 msgid "{name} - line colors"
 msgstr ""
 
-#: src/plot_styles.py:422
+#: src/plot_styles.py:421
 msgid "Delete"
 msgstr ""
 
-#: src/plot_styles.py:544 src/plot_styles.py:555
+#: src/plot_styles.py:543 src/plot_styles.py:554
 #, python-brace-format
 msgid "{name} (copy)"
 msgstr ""

--- a/src/add_data_advanced.py
+++ b/src/add_data_advanced.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 from gi.repository import Adw, Gtk
 
-from graphs import ui, utilities
+from graphs import misc, ui, utilities
 from graphs.misc import ImportSettings
 
 
@@ -22,6 +22,7 @@ class AddAdvancedWindow(Adw.Window):
         self.parent = parent
         config = parent.preferences.config
         self.delimiter.set_text(config["import_delimiter"])
+        utilities.populate_chooser(self.separator, misc.SEPARATORS, False)
         utilities.set_chooser(self.separator, config["import_separator"])
         self.column_x.set_value(int(config["import_column_x"]))
         self.column_y.set_value(int(config["import_column_y"]))
@@ -40,7 +41,7 @@ class AddAdvancedWindow(Adw.Window):
             "column_x": int(self.column_x.get_value()),
             "column_y": int(self.column_y.get_value()),
             "skip_rows": int(self.skip_rows.get_value()),
-            "separator": self.separator.get_selected_item().get_string(),
+            "separator": utilities.get_selected_chooser_item(self.separator),
             "delimiter": self.delimiter.get_text(),
             "guess_headers": self.guess_headers.get_active(),
         }

--- a/src/export_figure.py
+++ b/src/export_figure.py
@@ -22,27 +22,27 @@ class ExportFigureWindow(Adw.Window):
         self.confirm_button.connect("clicked", self.on_accept)
         self.transparent.set_active(
             self.parent.preferences.config["export_figure_transparent"])
-        items = self.parent.canvas.get_supported_filetypes_grouped().items()
+        self.items = \
+            self.parent.canvas.get_supported_filetypes_grouped().items()
         self.dpi.set_value(
             int(self.parent.preferences.config["export_figure_dpi"]))
         file_formats = []
         default_format = None
-        for name, formats in items:
+        for name, formats in self.items:
             file_formats.append(name)
             if self.parent.preferences.config["export_figure_filetype"] in \
                     formats:
                 default_format = name
-        utilities.populate_chooser(self.file_format, file_formats)
+        utilities.populate_chooser(self.file_format, file_formats, False)
         if default_format is not None:
             utilities.set_chooser(self.file_format, default_format)
         self.present()
 
-    def on_accept(self, _):
+    def on_accept(self, _button):
         dpi = int(self.dpi.get_value())
-        fmt = self.file_format.get_selected_item().get_string()
+        fmt = utilities.get_selected_chooser_item(self.file_format)
         file_suffix = None
-        items = self.parent.canvas.get_supported_filetypes_grouped().items()
-        for name, formats in items:
+        for name, formats in self.items:
             if name == fmt:
                 file_suffix = formats[0]
         filename = Path(self.parent.canvas.get_default_filename()).stem

--- a/src/misc.py
+++ b/src/misc.py
@@ -53,3 +53,39 @@ class InteractionMode(Enum):
     PAN = 1
     ZOOM = 2
     SELECT = 3
+
+
+# Translatable lists
+def _(message):
+    return message
+
+
+SCALES = [_("linear"), _("log")]
+LEGEND_POSITIONS = [
+    _("Best"), _("Upper right"), _("Upper left"), _("Lower left"),
+    _("Lower right"), _("Center left"), _("Center right"), _("Lower center"),
+    _("Upper center"), _("Center"),
+]
+X_POSITIONS = [_("top"), _("bottom")]
+Y_POSITIONS = [_("left"), _("right")]
+SEPARATORS = [",", "."]
+ACTION_CENTER_DATA = [
+    _("Center at maximum Y value"), _("Center at middle coordinate"),
+]
+HANDLE_DUPLICATES = [
+    _("Auto-rename duplicates"), _("Ignore duplicates"), _("Add duplicates"),
+    _("Override existing items"),
+]
+LINESTYLES = [_("none"), _("solid"), _("dotted"), _("dashed"), _("dashdot")]
+MARKERS = {
+    _("Point"): ".", _("Pixel"): ",", _("Circle"): "o",
+    _("Triangle down"): "v", _("Triangle up"): "^", _("Triangle left"): "<",
+    _("Triangle right"): ">", _("Octagon"): "8", _("Square"): "s",
+    _("Pentagon"): "p", _("Star"): "*", _("Hexagon 1"): "h",
+    _("Hexagon 2"): "H", _("Plus"): "+", _("x"): "x", _("Diamond"): "D",
+    _("Thin diamond"): "d", _("Vertical line"): "|", _("Horizontal line"): "_",
+    _("Filled plus"): "P", _("Filled x"): "X", _("Nothing"): "none",
+}
+TICK_DIRECTIONS = [_("in"), _("out")]
+
+del _

--- a/src/plot_settings.py
+++ b/src/plot_settings.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 from gi.repository import Adw, Gtk
 
-from graphs import (clipboard, graphs, plot_styles, plotting_tools, ui,
+from graphs import (clipboard, graphs, misc, plot_styles, plotting_tools, ui,
                     utilities)
 from graphs.canvas import Canvas
 
@@ -50,22 +50,29 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
         self.plot_y_label.set_text(parent.plot_settings.ylabel)
         self.plot_top_label.set_text(parent.plot_settings.top_label)
         self.plot_right_label.set_text(parent.plot_settings.right_label)
+        utilities.populate_chooser(self.plot_x_scale, misc.SCALES)
         utilities.set_chooser(
             self.plot_x_scale, parent.plot_settings.xscale)
+        utilities.populate_chooser(self.plot_y_scale, misc.SCALES)
         utilities.set_chooser(
             self.plot_y_scale, parent.plot_settings.yscale)
+        utilities.populate_chooser(self.plot_top_scale, misc.SCALES)
         utilities.set_chooser(
             self.plot_top_scale, parent.plot_settings.top_scale)
+        utilities.populate_chooser(self.plot_right_scale, misc.SCALES)
         utilities.set_chooser(
             self.plot_right_scale, parent.plot_settings.right_scale)
         self.use_custom_plot_style.set_enable_expansion(
             parent.plot_settings.use_custom_plot_style)
         utilities.populate_chooser(
-            self.custom_plot_style, plot_styles.get_user_styles(parent).keys())
+            self.custom_plot_style, plot_styles.get_user_styles(parent).keys(),
+            translate=False)
         utilities.set_chooser(
             self.custom_plot_style, parent.plot_settings.custom_plot_style)
         self.plot_legend.set_enable_expansion(
             parent.plot_settings.legend)
+        utilities.populate_chooser(
+            self.plot_legend_position, misc.LEGEND_POSITIONS)
         utilities.set_chooser(
             self.plot_legend_position,
             parent.plot_settings.legend_position.capitalize())
@@ -112,7 +119,7 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
             != self.use_custom_plot_style.get_enable_expansion() \
             and parent.preferences.config["override_style_change"] \
             or plot_settings.custom_plot_style \
-            != self.custom_plot_style.get_selected_item().get_string() \
+            != utilities.get_selected_chooser_item(self.custom_plot_style) \
             and parent.preferences.config["override_style_change"]
 
         # Set new plot settings
@@ -122,20 +129,20 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
         plot_settings.top_label = self.plot_top_label.get_text()
         plot_settings.right_label = self.plot_right_label.get_text()
         plot_settings.xscale = \
-            self.plot_x_scale.get_selected_item().get_string()
+            utilities.get_selected_chooser_item(self.plot_x_scale)
         plot_settings.yscale = \
-            self.plot_y_scale.get_selected_item().get_string()
+            utilities.get_selected_chooser_item(self.plot_y_scale)
         plot_settings.top_scale = \
-            self.plot_top_scale.get_selected_item().get_string()
+            utilities.get_selected_chooser_item(self.plot_top_scale)
         plot_settings.right_scale = \
-            self.plot_right_scale.get_selected_item().get_string()
+            utilities.get_selected_chooser_item(self.plot_right_scale)
         plot_settings.legend = self.plot_legend.get_enable_expansion()
         plot_settings.legend_position = \
-            self.plot_legend_position.get_selected_item().get_string().lower()
+            utilities.get_selected_chooser_item(self.plot_x_scale).lower()
         plot_settings.use_custom_plot_style = \
             self.use_custom_plot_style.get_enable_expansion()
         plot_settings.custom_plot_style = \
-            self.custom_plot_style.get_selected_item().get_string()
+            utilities.get_selected_chooser_item(self.custom_plot_style)
 
         # Set new item properties
         if self.style_changed:

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -7,7 +7,7 @@ from gettext import gettext as _
 
 from gi.repository import Adw, Gtk
 
-from graphs import graphs, plot_styles, utilities
+from graphs import graphs, misc, plot_styles, utilities
 
 
 class Preferences():
@@ -97,8 +97,30 @@ class PreferencesWindow(Adw.PreferencesWindow):
     def __init__(self, parent):
         super().__init__()
         self.parent = parent
+        self.supported_filetypes = \
+            self.parent.canvas.get_supported_filetypes_grouped()
+
         utilities.populate_chooser(
-            self.plot_custom_style, plot_styles.get_user_styles(parent).keys())
+            self.import_separator, misc.SEPARATORS, translate=False)
+        utilities.populate_chooser(
+            self.export_figure_filetype, self.supported_filetypes.keys(),
+            translate=False)
+        utilities.populate_chooser(
+            self.action_center_data, misc.ACTION_CENTER_DATA)
+        utilities.populate_chooser(
+            self.other_handle_duplicates, misc.HANDLE_DUPLICATES)
+        utilities.populate_chooser(self.plot_x_scale, misc.SCALES)
+        utilities.populate_chooser(self.plot_y_scale, misc.SCALES)
+        utilities.populate_chooser(self.plot_top_scale, misc.SCALES)
+        utilities.populate_chooser(self.plot_right_scale, misc.SCALES)
+        utilities.populate_chooser(self.plot_x_position, misc.X_POSITIONS)
+        utilities.populate_chooser(self.plot_y_position, misc.Y_POSITIONS)
+        utilities.populate_chooser(
+            self.plot_legend_position, misc.LEGEND_POSITIONS)
+
+        utilities.populate_chooser(
+            self.plot_custom_style, plot_styles.get_user_styles(parent).keys(),
+            translate=False)
         self.load_configuration()
         self.connect("close-request", self.on_close, self.parent)
         self.set_transient_for(self.parent.main_window)
@@ -119,8 +141,10 @@ class PreferencesWindow(Adw.PreferencesWindow):
         self.addequation_step_size.set_text(
             str(config["addequation_step_size"]))
         self.export_figure_dpi.set_value(int(config["export_figure_dpi"]))
-        utilities.set_chooser(
-            self.export_figure_filetype, config["export_figure_filetype"])
+        for name, formats in self.supported_filetypes.items():
+            if config["export_figure_filetype"] in formats:
+                filetype = name
+        utilities.set_chooser(self.export_figure_filetype, filetype)
         self.export_figure_transparent.set_active(
             config["export_figure_transparent"])
         utilities.set_chooser(
@@ -160,7 +184,7 @@ class PreferencesWindow(Adw.PreferencesWindow):
         config = self.parent.preferences.config
         config["import_delimiter"] = self.import_delimiter.get_text()
         config["import_separator"] = \
-            self.import_separator.get_selected_item().get_string()
+            utilities.get_selected_chooser_item(self.import_separator)
         config["import_column_x"] = int(self.import_column_x.get_value())
         config["import_column_y"] = int(self.import_column_y.get_value())
         config["import_skip_rows"] = int(self.import_skip_rows.get_value())
@@ -170,14 +194,19 @@ class PreferencesWindow(Adw.PreferencesWindow):
         config["addequation_step_size"] = self.addequation_step_size.get_text()
         config["clipboard_length"] = int(self.clipboard_length.get_value())
         config["export_figure_dpi"] = int(self.export_figure_dpi.get_value())
-        config["export_figure_filetype"] = \
-            self.export_figure_filetype.get_selected_item().get_string()
+        filetype_name = \
+            utilities.get_selected_chooser_item(self.export_figure_filetype)
+        for name, formats in \
+                self.parent.canvas.get_supported_filetypes_grouped().items():
+            if name == filetype_name:
+                export_figure_filetyope = formats[0]
+        config["export_figure_filetype"] = export_figure_filetyope
         config["export_figure_transparent"] = \
             self.export_figure_transparent.get_active()
         config["action_center_data"] = \
-            self.action_center_data.get_selected_item().get_string()
+            utilities.get_selected_chooser_item(self.action_center_data)
         config["handle_duplicates"] = \
-            self.other_handle_duplicates.get_selected_item().get_string()
+            utilities.get_selected_chooser_item(self.other_handle_duplicates)
         config["hide_unselected"] = self.other_hide_unselected.get_active()
         config["override_style_change"] = \
             self.override_style_change.get_active()
@@ -188,24 +217,25 @@ class PreferencesWindow(Adw.PreferencesWindow):
         config["plot_right_label"] = self.plot_right_label.get_text()
         config["guess_headers"] = self.plot_guess_headers.get_active()
         config["plot_x_scale"] = \
-            self.plot_x_scale.get_selected_item().get_string()
+            utilities.get_selected_chooser_item(self.plot_x_scale)
         config["plot_y_scale"] = \
-            self.plot_y_scale.get_selected_item().get_string()
+            utilities.get_selected_chooser_item(self.plot_y_scale)
         config["plot_top_scale"] = \
-            self.plot_top_scale.get_selected_item().get_string()
+            utilities.get_selected_chooser_item(self.plot_top_scale)
         config["plot_right_scale"] = \
-            self.plot_right_scale.get_selected_item().get_string()
+            utilities.get_selected_chooser_item(self.plot_right_scale)
         config["plot_x_position"] = \
-            self.plot_x_position.get_selected_item().get_string()
+            utilities.get_selected_chooser_item(self.plot_x_position)
         config["plot_y_position"] = \
-            self.plot_y_position.get_selected_item().get_string()
+            utilities.get_selected_chooser_item(self.plot_y_position)
         config["plot_legend"] = self.plot_legend.get_enable_expansion()
         config["plot_legend_position"] = \
-            self.plot_legend_position.get_selected_item().get_string().lower()
+            utilities.get_selected_chooser_item(
+                self.plot_legend_position).lower()
         config["plot_use_custom_style"] = \
             self.plot_use_custom_style.get_enable_expansion()
         config["plot_custom_style"] = \
-            self.plot_custom_style.get_selected_item().get_string()
+            utilities.get_selected_chooser_item(self.plot_custom_style)
 
     def on_close(self, _, parent):
         self.apply_configuration()

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 import os
+from gettext import gettext as _
 from pathlib import Path
 
 from gi.repository import Gdk, Gio, Gtk
@@ -78,32 +79,25 @@ def add_new_config_keys(config, template):
 
 def set_chooser(chooser, choice):
     """Set the value of a dropdown menu to the choice parameter string"""
-    model = chooser.get_model()
-    for index, option in enumerate(model):
-        if option.get_string() == choice:
+    for index, item in enumerate(chooser.untranslated_items):
+        if item == choice:
             chooser.set_selected(index)
 
 
-def empty_chooser(chooser):
-    """Remove all the values in a dropdown menu"""
-    model = chooser.get_model()
-    for _index in model:
-        model.remove(0)
-
-
-def populate_chooser(chooser, chooser_list, clear=True):
+def populate_chooser(chooser, chooser_list, translate=True):
     """Fill the dropdown menu with the strings in a chooser_list"""
-    model = chooser.get_model()
-    if clear:
-        for _item in model:
-            model.remove(0)
+    chooser.untranslated_items = []
+    model = Gtk.StringList()
     for item in chooser_list:
-        if item != "nothing":
-            model.append(str(item))
+        chooser.untranslated_items.append(item)
+        if translate:
+            item = _(item)
+        model.append(item)
+    chooser.set_model(model)
 
 
-def get_chooser_list(chooser):
-    return [item.get_string() for item in chooser.get_model()]
+def get_selected_chooser_item(chooser):
+    return chooser.untranslated_items[int(chooser.get_selected())]
 
 
 def get_all_names(parent):


### PR DESCRIPTION
Allows choosers to be translatable.
A few technical changes:
- Populating a chooser now creates a new model (removed option for keeping old ones as it wasn't used)
- Choosers need to be defined in code for set_chooser and get_selected_chooser_item (new function) to work properly
- When populating a chooser provide translatable values, querying and setting via afore mentioned values is done via the english strings
- Removed empty_chooser as it wasn't used
- Removed get_chooser_list (substituted via chooser.untranslated_items call)

All text should now be translatable, if not I'll consider it a bug.
Fixes https://github.com/Sjoerd1993/Graphs/issues/232 properly.