### PR TITLE
install to python site packages

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -16,7 +16,7 @@ description_short = 'Plot and manipulate data in a breeze'
 
 i18n = import('i18n')
 gnome = import('gnome')
-python = import('python')
+python = import('python').find_installation('python3')
 
 prefix = get_option('prefix')
 datadir = get_option('datadir')
@@ -43,7 +43,7 @@ conf.set('LOCALEDIR', localedir)
 conf.set('NAME', name)
 conf.set('PKGDATADIR', pkgdatadir)
 conf.set('PROJECT_NAME', project_name)
-conf.set('PYTHON', python.find_installation('python3').full_path())
+conf.set('PYTHON', python.full_path())
 conf.set('VERSION', version)
 conf.set('HOMEPAGE_URL', homepage_url)
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -35,5 +35,4 @@ graphs_sources = [
   'window.py',
 ]
 
-moduledir = join_paths(pkgdatadir, meson.project_name())
-install_data(graphs_sources, install_dir: moduledir, install_mode: 'rwxrwxrwx')
+python.install_sources(graphs_sources, subdir: project_name)


### PR DESCRIPTION
Install using the python meson module. This defaults to the pythons site_packages directory. This is more inline with what most projects do. This also allows to use the python.bytecompile option once meson 1.2 is available for the flatpak buildchain, improving startuptime app.