### PR TITLE
Fix export button

### DIFF
--- a/src/export_figure.py
+++ b/src/export_figure.py
@@ -37,7 +37,7 @@ class ExportFigureWindow(Adw.Window):
             utilities.set_chooser(self.file_format, default_format)
         self.present()
 
-    def on_accept(self, _):
+    def on_accept(self, _button):
         dpi = int(self.dpi.get_value())
         fmt = self.file_format.get_selected_item().get_string()
         file_suffix = None

--- a/src/file_io.py
+++ b/src/file_io.py
@@ -46,7 +46,7 @@ def save_file(self, path):
             file_path = f"{path}/{filename}.txt"
             if os.path.exists(file_path):
                 file_path = f"{path}/{filename} (copy).txt"
-            numpy.savetxt(str(file_path, array), delimiter="\t")
+            numpy.savetxt(str(file_path), array, delimiter="\t")
 
 
 def get_xrdml(self, import_settings):


### PR DESCRIPTION
The export button was broken because _ was an argument in the on_accept function. However, using blank underscores clashes with the new translation strings.

This fixes this issue.