### PR TITLE
Fix export button

### DIFF
--- a/src/export_figure.py
+++ b/src/export_figure.py
@@ -37,7 +37,7 @@ class ExportFigureWindow(Adw.Window):
             utilities.set_chooser(self.file_format, default_format)
         self.present()
 
-    def on_accept(self, _):
+    def on_accept(self, _button):
         dpi = int(self.dpi.get_value())
         fmt = self.file_format.get_selected_item().get_string()
         file_suffix = None


### PR DESCRIPTION
The export button was broken, as _ was an argument in the on_accept function it clashed with the new translation string variable. It's been bugging me for a while. but didn't have the time to take a look at it.

This should fix this issue.