### PR TITLE
more refactors

### DIFF
--- a/src/canvas.py
+++ b/src/canvas.py
@@ -3,8 +3,10 @@ import time
 from contextlib import nullcontext
 
 from gi.repository import Gtk
+
 from graphs import file_io, plot_styles, plotting_tools, utilities
 from graphs.rename import RenameWindow
+
 from matplotlib import pyplot
 from matplotlib.backend_bases import NavigationToolbar2
 from matplotlib.backends.backend_gtk4cairo import FigureCanvas
@@ -60,7 +62,6 @@ class Canvas(FigureCanvas):
             self._renderer.height = allocation.height * scale
             self._renderer.dpi = self.figure.dpi
             self.figure.draw(self._renderer)
-
 
     def plot(self, item):
         x_axis = item.plot_x_position

--- a/src/file_io.py
+++ b/src/file_io.py
@@ -19,7 +19,7 @@ from matplotlib.style.core import STYLE_BLACKLIST
 import numpy
 
 
-def save_project(path, plot_settings, datadict, datadict_clipboard,
+def save_project(file, plot_settings, datadict, datadict_clipboard,
                  clipboard_pos, version):
     project_data = {
         "plot_settings": plot_settings,
@@ -28,16 +28,20 @@ def save_project(path, plot_settings, datadict, datadict_clipboard,
         "clipboard_pos": clipboard_pos,
         "version": version,
     }
-    with open(path, "wb") as file:
-        pickle.dump(project_data, file)
+    if file.query_exists(None):
+        stream = file.replace(None, False, 0, None)
+    else:
+        stream = file.create(0, None)
+    stream.write_bytes(GLib.Bytes(pickle.dumps(project_data)))
+    stream.close()
 
 
-def load_project(path):
-    with open(path, "rb") as file:
-        project = pickle.load(file)
-        return project["plot_settings"], project["data"], \
-            project["datadict_clipboard"], project["clipboard_pos"], \
-            project["version"]
+def read_project(file):
+    project = pickle.loads(file.load_bytes(None)[0].get_data())
+    return \
+        project["plot_settings"], project["data"], \
+        project["datadict_clipboard"], project["clipboard_pos"], \
+        project["version"]
 
 
 def save_file(self, path):

--- a/src/graphs.py
+++ b/src/graphs.py
@@ -8,12 +8,12 @@ from graphs.canvas import Canvas
 from graphs.item import Item
 
 
-def open_project(self, path):
+def open_project(self, file):
     for key in self.datadict.copy():
         delete_item(self, key)
     try:
         new_plot_settings, new_datadict, datadict_clipboard, clipboard_pos, \
-            _version = file_io.load_project(path)
+            _version = file_io.read_project(file)
         utilities.set_attributes(new_plot_settings, self.plot_settings)
         self.plot_settings = new_plot_settings
         self.clipboard_pos = clipboard_pos

--- a/src/plot_styles.py
+++ b/src/plot_styles.py
@@ -164,7 +164,7 @@ class PlotStylesWindow(Adw.Window):
         self.styles = []
         self.style = None
         self.reload_styles()
-        self.reset_button.connect("clicked", self.on_reset_button)
+        self.reset_button.connect("clicked", self.reset_styles)
         self.add_button.connect("clicked", self.add_data)
         self.back_button.connect("clicked", self.back)
         self.connect("close-request", self.on_close)
@@ -210,25 +210,6 @@ class PlotStylesWindow(Adw.Window):
         self.color_boxes = {}
 
         self.present()
-
-    def on_reset_button(self, _button):
-        heading = "Reset to defaults?"
-        body = "Are you sure you want to reset to the default styles?"
-        dialog = Adw.MessageDialog.new(self,
-                                       heading,
-                                       body)
-        dialog.add_response("cancel", _("Cancel"))
-        dialog.add_response("reset", _("Reset"))
-        dialog.set_close_response("cancel")
-        dialog.set_default_response("delete")
-        dialog.set_response_appearance("reset",
-                                       Adw.ResponseAppearance.DESTRUCTIVE)
-        dialog.connect("response", self.on_reset_button_press)
-        dialog.present()
-
-    def on_reset_button_press(self, _, response):
-        if response == "reset":
-            self.reset_styles(self.parent)
 
     def edit_style(self, _, style):
         self.style = get_style(self.parent, style)
@@ -422,23 +403,8 @@ class PlotStylesWindow(Adw.Window):
         self.color_boxes[box] = self.line_colors_box.get_last_child()
 
     def delete_style(self, _button, style):
-        def remove_style(_, response, self):
-            if response == "delete":
-                get_user_styles(self)[style].trash(None)
-                self.reload_styles()
-        heading = "Delete style?"
-        body = f"Are you sure you want to delete the {style} style?"
-        dialog = Adw.MessageDialog.new(self,
-                                       heading,
-                                       body)
-        dialog.add_response("cancel", _("Cancel"))
-        dialog.add_response("delete", _("Delete"))
-        dialog.set_close_response("cancel")
-        dialog.set_default_response("delete")
-        dialog.set_response_appearance("delete",
-                                       Adw.ResponseAppearance.DESTRUCTIVE)
-        dialog.connect("response", remove_style, self)
-        dialog.present()
+        get_user_styles(self)[style].trash(None)
+        self.reload_styles()
 
     def copy_style(self, _, style, new_style):
         loop = True

--- a/src/plot_styles.py
+++ b/src/plot_styles.py
@@ -403,8 +403,22 @@ class PlotStylesWindow(Adw.Window):
         self.color_boxes[box] = self.line_colors_box.get_last_child()
 
     def delete_style(self, _button, style):
-        get_user_styles(self)[style].trash(None)
-        self.reload_styles()
+        def remove_style(_, response, self):
+            if response == "delete":
+                get_user_styles(self)[style].trash(None)
+                self.reload_styles()
+        heading = "Delete style?"
+        body = f"Are you sure you want to delete the {style} style?"
+        dialog = Adw.MessageDialog.new(
+            self, heading, body)
+        dialog.add_response("cancel", _("Cancel"))
+        dialog.add_response("delete", _("Delete"))
+        dialog.set_close_response("cancel")
+        dialog.set_default_response("delete")
+        dialog.set_response_appearance(
+            "delete", Adw.ResponseAppearance.DESTRUCTIVE)
+        dialog.connect("response", remove_style, self)
+        dialog.present()
 
     def copy_style(self, _, style, new_style):
         loop = True
@@ -430,8 +444,23 @@ class PlotStylesWindow(Adw.Window):
         AddStyleWindow(self)
 
     def reset_styles(self, _button):
-        reset_user_styles(self.parent)
-        self.reload_styles()
+        def on_accept(_dialog, response):
+            if response == "reset":
+                reset_user_styles(self.parent)
+                self.reload_styles()
+
+        heading = "Reset to defaults?"
+        body = "Are you sure you want to reset to the default styles?"
+        dialog = Adw.MessageDialog.new(
+            self, heading, body)
+        dialog.add_response("cancel", _("Cancel"))
+        dialog.add_response("reset", _("Reset"))
+        dialog.set_close_response("cancel")
+        dialog.set_default_response("delete")
+        dialog.set_response_appearance(
+            "reset", Adw.ResponseAppearance.DESTRUCTIVE)
+        dialog.connect("response", on_accept)
+        dialog.present()
 
     def reload_styles(self):
         for box in self.styles.copy():

--- a/src/plot_styles.py
+++ b/src/plot_styles.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
-import os
 from gettext import gettext as _
 from pathlib import Path
 
@@ -56,7 +55,7 @@ def reset_user_styles(self):
             loop = False
             continue
         file = enumerator.get_child(file_info)
-        file.delete(None)
+        file.trash(None)
     enumerator.close(None)
     for style, file in get_system_styles(self).items():
         style_file = directory.get_child_for_display_name(f"{style}.mplstyle")
@@ -411,21 +410,21 @@ class PlotStylesWindow(Adw.Window):
         file = directory.get_child_for_display_name(f"{style.name}.mplstyle")
         file_io.write_style(file, style)
 
-    def delete_color(self, _, color_box):
+    def delete_color(self, _button, color_box):
         self.line_colors_box.remove(self.color_boxes[color_box])
         del self.color_boxes[color_box]
         if not self.color_boxes:
             self.add_color(None)
 
-    def add_color(self, _):
+    def add_color(self, _button):
         box = StyleColorBox(self, "000000")
         self.line_colors_box.append(box)
         self.color_boxes[box] = self.line_colors_box.get_last_child()
 
-    def delete_style(self, _, style):
+    def delete_style(self, _button, style):
         def remove_style(_, response, self):
             if response == "delete":
-                os.remove(get_user_styles(self)[style])
+                get_user_styles(self)[style].trash(None)
                 self.reload_styles()
         heading = "Delete style?"
         body = f"Are you sure you want to delete the {style} style?"
@@ -461,10 +460,10 @@ class PlotStylesWindow(Adw.Window):
         user_styles[style].copy(destination, 0, None)
         self.reload_styles()
 
-    def add_data(self, _):
+    def add_data(self, _button):
         AddStyleWindow(self)
 
-    def reset_styles(self, _):
+    def reset_styles(self, _button):
         reset_user_styles(self.parent)
         self.reload_styles()
 
@@ -480,7 +479,7 @@ class PlotStylesWindow(Adw.Window):
             self.styles.append(box)
             self.styles_box.append(box)
 
-    def on_close(self, _):
+    def on_close(self, _button):
         if self.style is not None:
             self.save_style()
         graphs.reload(self.parent, reset_limits=False)

--- a/src/plot_styles.py
+++ b/src/plot_styles.py
@@ -72,9 +72,9 @@ def get_system_preferred_style_path(self):
         self.main_window.add_toast(f"{system_style} not found, recreating it")
         config_dir = utilities.get_config_directory()
         directory = config_dir.get_child_for_display_name("styles")
-        destination = directory.get_child_for_display_name(
+        stylepath = directory.get_child_for_display_name(
             f"{system_style}.mplstyle")
-        get_system_styles(self)[system_style].copy(destination, 0, None)
+        get_system_styles(self)[system_style].copy(stylepath, 0, None)
     return stylepath
 
 
@@ -211,7 +211,7 @@ class PlotStylesWindow(Adw.Window):
 
         self.present()
 
-    def edit_style(self, _, style):
+    def edit_style(self, _button, style):
         self.style = get_style(self.parent, style)
         self.load_style()
         self.leaflet.navigate(1)
@@ -403,12 +403,12 @@ class PlotStylesWindow(Adw.Window):
         self.color_boxes[box] = self.line_colors_box.get_last_child()
 
     def delete_style(self, _button, style):
-        def remove_style(_, response, self):
+        def remove_style(_dialog, response, self):
             if response == "delete":
                 get_user_styles(self)[style].trash(None)
                 self.reload_styles()
-        heading = "Delete style?"
-        body = f"Are you sure you want to delete the {style} style?"
+        heading = _("Delete style?")
+        body = _("Are you sure you want to delete the {} style?").format(style)
         dialog = Adw.MessageDialog.new(
             self, heading, body)
         dialog.add_response("cancel", _("Cancel"))
@@ -420,14 +420,14 @@ class PlotStylesWindow(Adw.Window):
         dialog.connect("response", remove_style, self)
         dialog.present()
 
-    def copy_style(self, _, style, new_style):
+    def copy_style(self, _button, style, new_style):
         loop = True
         i = 0
         user_styles = get_user_styles(self.parent)
         while loop:
             for style_1 in user_styles.keys():
-                i += 1
                 if new_style == style_1:
+                    i += 1
                     loop = True
                     new_style = f"{new_style} ({i})"
                     continue
@@ -546,7 +546,8 @@ class AddStyleWindow(Adw.Window):
         super().__init__()
         self.parent = parent
         utilities.populate_chooser(
-            self.plot_style_templates, get_user_styles(parent).keys(), False)
+            self.plot_style_templates,
+            sorted(get_user_styles(parent).keys()), False)
         selected_item = \
             utilities.get_selected_chooser_item(self.plot_style_templates)
         self.new_style_name.set_text(
@@ -557,13 +558,13 @@ class AddStyleWindow(Adw.Window):
         self.set_transient_for(parent)
         self.present()
 
-    def on_template_changed(self, _, __):
+    def on_template_changed(self, _a, _b):
         selected_item = \
             utilities.get_selected_chooser_item(self.plot_style_templates)
         self.new_style_name.set_text(
             _("{name} (copy)").format(name=selected_item))
 
-    def on_confirm(self, _):
+    def on_confirm(self, _button):
         style = utilities.get_selected_chooser_item(self.plot_style_templates)
         name = self.new_style_name.get_text()
         self.parent.copy_style(self, style, name)

--- a/src/ui.py
+++ b/src/ui.py
@@ -70,8 +70,8 @@ def on_export_data_response(dialog, response, self, multiple):
 
 def on_open_project_response(dialog, response, self):
     try:
-        path = dialog.open_finish(response).peek_path()
-        graphs.open_project(self, path)
+        file = dialog.open_finish(response)
+        graphs.open_project(self, file)
     except GLib.GError:
         pass
 
@@ -80,7 +80,7 @@ def on_save_project_response(dialog, response, self):
     try:
         file = dialog.save_finish(response)
         file_io.save_project(
-            file.get_path(),
+            file,
             self.plot_settings,
             self.datadict,
             self.datadict_clipboard,

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [flake8]
 count = True
 #default_ignorelist: E121,E123,E126,E226,E24,E704,W503,W504
-ignore = U101, SCS109, SCS101
+ignore = U101, SCS109, SCS101, SCS113
 	# temporarily disable docstring related stuff
 	D100, D101, D102, D103, D107, D204, D205, D400, D401
 inline-quotes = double


### PR DESCRIPTION
- Small fixes
- Port opening and saving projects to GFile
- Remove confirm dialog in plot styles editor in favour of the actual trashcan

Exporting to two-column files will be a bit trickier. We'll have to create a temporary file which can be accessed via "normal" python methods, since numpy only accepts a filename or pathlike instead of a ioclass for files (the latter being the proper way to my knowledge). This file can than be moved to the location the user specified. This should still work with all locations we can get a GFile from. Will put that in the next pr however, just a heads up what is needed for that