### PR TITLE
Fix advanced import + headers

### DIFF
--- a/src/file_import.py
+++ b/src/file_import.py
@@ -100,6 +100,7 @@ class ImportWindow(Adw.Window):
         self.import_dict = import_dict
         self.import_params = parent.preferences.import_params
         visible = False
+        self.param_dict = {}
         if "columns" in self.modes:
             self.load_columns()
             visible = True
@@ -123,7 +124,7 @@ class ImportWindow(Adw.Window):
         self.skip_rows.set_value(int(params["skip_rows"]))
 
     def on_accept(self, _widget):
-        self.param_dict = {}
+        self.param_dict = self.get_columns()
         if "columns" in self.modes:
             self.load_columns()
         import_settings_list = []
@@ -148,6 +149,7 @@ class ImportWindow(Adw.Window):
             "separator": utilities.get_selected_chooser_item(self.separator),
             "delimiter": self.delimiter.get_text(),
         }
+        return self.param_dict
 
     def on_close(self, _widget):
         prepare_import_finish(self.parent, self.import_dict)

--- a/src/file_import.py
+++ b/src/file_import.py
@@ -124,9 +124,8 @@ class ImportWindow(Adw.Window):
         self.skip_rows.set_value(int(params["skip_rows"]))
 
     def on_accept(self, _widget):
-        self.param_dict = self.get_columns()
         if "columns" in self.modes:
-            self.load_columns()
+            self.get_columns()
         import_settings_list = []
         for mode in IMPORT_MODES:
             try:
@@ -142,6 +141,7 @@ class ImportWindow(Adw.Window):
         self.destroy()
 
     def get_columns(self):
+        print("WOOPS")
         self.param_dict["columns"] = {
             "column_x": int(self.column_x.get_value()),
             "column_y": int(self.column_y.get_value()),

--- a/src/file_io.py
+++ b/src/file_io.py
@@ -157,7 +157,7 @@ def import_from_columns(self, import_settings):
                     item.ylabel = headers[params["column_y"]]
                 except IndexError:
                     try:
-                        headers = re.split(params.delimiter, line)
+                        headers = re.split(params["delimiter"], line)
                         item.xlabel = headers[params["column_x"]]
                         item.ylabel = headers[params["column_y"]]
                     # If neither heuristic works, we just skip headers


### PR DESCRIPTION
Advanced import did not work because it loaded the column values into the GUI, instead of getting it from the GUI.
Also the headers were broken, as it was looking for an object attribute while the params are stored as dict.