### PR TITLE
properly fix remaining legend

### DIFF
--- a/src/canvas.py
+++ b/src/canvas.py
@@ -215,6 +215,8 @@ class Canvas(FigureCanvas):
                     new_lines, labels,
                     loc=self.parent.plot_settings.legend_position,
                     frameon=True, reverse=True)
+            else:
+                self.top_right_axis.get_legend().remove()
 
 
 class DummyToolbar(NavigationToolbar2):

--- a/src/graphs.py
+++ b/src/graphs.py
@@ -107,14 +107,9 @@ def delete_item(self, key, give_toast=False):
 
 
 def check_open_data(self):
-    if self.datadict:
-        self.main_window.item_list.set_visible(True)
-        refresh(self)
-        ui.enable_data_dependent_buttons(self)
-    else:
-        reload(self)
-        self.main_window.item_list.set_visible(False)
-        ui.enable_data_dependent_buttons(self)
+    self.main_window.item_list.set_visible(self.datadict)
+    refresh(self)
+    ui.enable_data_dependent_buttons(self)
 
 
 def reload(self):


### PR DESCRIPTION
Properly fix the issue, when deleting items, that the legend would remain displaying the last deleted item. Before we used a forced reload which mitigated this. 
This implementation also fixes the legend when only text is present.