### PR TITLE
Fix crash with chooser change

### DIFF
--- a/src/edit_item.py
+++ b/src/edit_item.py
@@ -49,8 +49,10 @@ class EditItemWindow(Adw.PreferencesWindow):
 
         # If item_selector no longer matches with name, repopulate it
         names = utilities.get_all_names(self.parent)
-        if set(names) != set(self.item_selector.untranslated_items):
-            utilities.populate_chooser(self.item_selector, names, False)
+        if set(names) != \
+                set(utilities.get_chooser_list(self.item_selector)):
+            utilities.repopulate_chooser_from_list(
+                self.item_selector, names)
             self.item_selector.set_selected(index)
             self.parent.datadict_clipboard = \
                 self.parent.datadict_clipboard[:-1]

--- a/src/edit_item.py
+++ b/src/edit_item.py
@@ -47,11 +47,9 @@ class EditItemWindow(Adw.PreferencesWindow):
         self.load_values()
 
         # If item_selector no longer matches with name, repopulate it
-        names = utilities.get_all_names(self.parent)
-        if set(names) != \
-                set(utilities.get_chooser_list(self.item_selector)):
-            utilities.repopulate_chooser_from_list(
-                self.item_selector, names)
+        names = utilities.get_all_names(self.props.application)
+        if set(names) != set(self.item_selector.untranslated_items):
+            utilities.populate_chooser(self.item_selector, names, False)
             self.item_selector.set_selected(index)
             self.props.application.datadict_clipboard = \
                 self.props.application.datadict_clipboard[:-1]

--- a/src/edit_item.py
+++ b/src/edit_item.py
@@ -24,14 +24,14 @@ class EditItemWindow(Adw.PreferencesWindow):
         super().__init__(application=application)
         self.item = item
         names = utilities.get_all_names(self.props.application)
-        utilities.populate_chooser(self.item_selector, names)
-        self.item_selector.set_selected(names.index(self.item.name))
-
         utilities.populate_chooser(self.plot_x_position, misc.X_POSITIONS)
         utilities.populate_chooser(self.plot_y_position, misc.Y_POSITIONS)
         utilities.populate_chooser(self.linestyle, misc.LINESTYLES)
         utilities.populate_chooser(self.markers, sorted(misc.MARKERS.keys()))
         self.load_values()
+        utilities.populate_chooser(self.item_selector, names)
+
+        self.item_selector.set_selected(names.index(self.item.name))
         self.set_transient_for(self.props.application.main_window)
         self.present()
 
@@ -96,7 +96,7 @@ class EditItemWindow(Adw.PreferencesWindow):
         clipboard.add(self.props.application)
         graphs.refresh(self.props.application)
         if set_limits:
-            plotting_tools.optimize_limits(self)
+            plotting_tools.optimize_limits(self.props.application)
 
     def apply_item_values(self):
         self.item.linestyle = \

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -96,6 +96,20 @@ def populate_chooser(chooser, chooser_list, translate=True):
     chooser.set_model(model)
 
 
+def repopulate_chooser_from_list(chooser, chooser_list):
+    """Fill the dropdown menu with the strings from a given list"""
+    model = chooser.get_model()
+    for _item in model:
+        model.remove(0)
+    for item in chooser_list:
+        if item != "nothing":
+            model.append(str(item))
+
+
+def get_chooser_list(chooser):
+    return [item.get_string() for item in chooser.get_model()]
+
+
 def get_selected_chooser_item(chooser):
     return chooser.untranslated_items[int(chooser.get_selected())]
 

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -86,8 +86,14 @@ def set_chooser(chooser, choice):
 
 def populate_chooser(chooser, chooser_list, translate=True):
     """Fill the dropdown menu with the strings in a chooser_list"""
+    if chooser.get_model():
+        model = chooser.get_model()
+        for _item in model:
+            model.remove(0)
+    else:
+        model = Gtk.StringList()
+
     chooser.untranslated_items = []
-    model = Gtk.StringList()
     for item in chooser_list:
         chooser.untranslated_items.append(item)
         if translate:
@@ -96,6 +102,7 @@ def populate_chooser(chooser, chooser_list, translate=True):
     chooser.set_model(model)
 
 
+<<<<<<< Updated upstream
 def repopulate_chooser_from_list(chooser, chooser_list):
     """Fill the dropdown menu with the strings from a given list"""
     model = chooser.get_model()
@@ -109,6 +116,8 @@ def repopulate_chooser_from_list(chooser, chooser_list):
 def get_chooser_list(chooser):
     return [item.get_string() for item in chooser.get_model()]
 
+=======
+>>>>>>> Stashed changes
 
 def get_selected_chooser_item(chooser):
     return chooser.untranslated_items[int(chooser.get_selected())]

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -102,22 +102,6 @@ def populate_chooser(chooser, chooser_list, translate=True):
     chooser.set_model(model)
 
 
-<<<<<<< Updated upstream
-def repopulate_chooser_from_list(chooser, chooser_list):
-    """Fill the dropdown menu with the strings from a given list"""
-    model = chooser.get_model()
-    for _item in model:
-        model.remove(0)
-    for item in chooser_list:
-        if item != "nothing":
-            model.append(str(item))
-
-
-def get_chooser_list(chooser):
-    return [item.get_string() for item in chooser.get_model()]
-
-=======
->>>>>>> Stashed changes
 
 def get_selected_chooser_item(chooser):
     return chooser.untranslated_items[int(chooser.get_selected())]


### PR DESCRIPTION
In the current build (as well as with the latest stable Flatpak build), the Edit Item window crashes when the name of an item is changed, and then a new item is loaded.

This bug is triggered somewhere on the repopulation on the chooser, but I have not been able to pin down the exact cause of this. As I'm pressed on time, I decided to put this current workaround (which is to use the old implementation) here as a WIP PR, but I think it's probably for the better if we try and fix the current repopulation function instead.

Not sure when I have time to look closely into that behaviour, but at the latest early next week (PhD defense is on Friday, that is my last big deadline for a while).

There are a few bugs that got introduced when we added localization support. Most of them are fixed in the latest builds, but this is one of them. I noticed another small issue with the dots in the menu not changing colours when loading new styles. Next week I will look closely exclusively at fixing bugs. Then we may can release a new build so those fixes make it into stable.