### PR TITLE
Use actual system style.

### DIFF
--- a/src/graphs.py
+++ b/src/graphs.py
@@ -115,7 +115,7 @@ def check_open_data(self):
 def reload(self):
     """Completely reload the plot of the graph"""
     pyplot.rcParams.update(
-        file_io.parse_style(plot_styles.get_preferred_style_path(self)))
+        file_io.parse_style(plot_styles.get_preferred_style(self)))
     self.canvas = Canvas(parent=self)
     self.main_window.toast_overlay.set_child(self.canvas)
     refresh(self)

--- a/src/main.py
+++ b/src/main.py
@@ -139,7 +139,7 @@ class GraphsApplication(Adw.Application):
         config = self.preferences.config
         self.plot_settings = PlotSettings(config)
         pyplot.rcParams.update(
-            file_io.parse_style(plot_styles.get_preferred_style_path(self)))
+            file_io.parse_style(plot_styles.get_preferred_style(self)))
         self.canvas = Canvas(self)
         win.toast_overlay.set_child(self.canvas)
         win.sidebar_flap.connect("notify", self.on_sidebar_toggle)

--- a/src/plot_settings.py
+++ b/src/plot_settings.py
@@ -141,7 +141,7 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
         # Set new item properties
         if self.style_changed:
             pyplot.rcParams.update(file_io.parse_style(
-                plot_styles.get_preferred_style_path(parent)))
+                plot_styles.get_preferred_style(parent)))
             for item in parent.datadict.values():
                 item.color = None
             for item in parent.datadict.values():


### PR DESCRIPTION
When querying for the system preferred style, return the shipped version. This also includes removing the checkmark for the used style if no custom style is set and ensures the style is always available and has the correct values.
Also rename the functions as we are no longer returning a path bur rather a GFile represantation.

I feel this needs a bit of reasoning: In my opinion following the system style should always look like it fits in regardless of what the user experiments or changes in the adwaita styles. If something should be changed, this is either an issue with our style or the user wants to deviate for a specific reason. In the latter case that would mean to set the style to custom, bearing in mind that this is no longer default.
This way we ensure that the default experience always looks like tested and on the screenshots even after version changes, which might include changes to the default styles.