### PR TITLE
Connect from blueprint

### DIFF
--- a/blueprint-compiler.json
+++ b/blueprint-compiler.json
@@ -5,8 +5,8 @@
     {
       "type": "git",
       "url": "https://gitlab.gnome.org/jwestman/blueprint-compiler",
-      "commit": "6ac798ea6ff17aec17c9be1064572eda2b67db6c",
-      "tag": "0.8.1"
+      "commit": "aa7679618e864748f4f4d8f15283906e712752fe",
+      "tag": "v0.8.1"
     }
   ]
 }

--- a/blueprint-compiler.json
+++ b/blueprint-compiler.json
@@ -5,7 +5,8 @@
     {
       "type": "git",
       "url": "https://gitlab.gnome.org/jwestman/blueprint-compiler",
-      "commit": "9adcab2d225fd6435edc85c72a0b67e33880e00b"
+      "commit": "6ac798ea6ff17aec17c9be1064572eda2b67db6c",
+      "tag": "0.8.1"
     }
   ]
 }

--- a/data/meson.build
+++ b/data/meson.build
@@ -60,6 +60,7 @@ blueprints = custom_target('blueprints',
   input: files(
     'ui/add_equation_window.blp',
     'ui/add_style.blp',
+    'ui/dialogs.blp',
     'ui/edit_item.blp',
     'ui/export_figure.blp',
     'ui/import.blp',

--- a/data/se.sjoerd.Graphs.gresource.xml
+++ b/data/se.sjoerd.Graphs.gresource.xml
@@ -28,9 +28,9 @@
     <file compressed="True">styles/solarized-light.mplstyle</file>
     <file compressed="True">styles/tableau-colorblind10.mplstyle</file>
     <file compressed="True">styles/thesis.mplstyle</file>
-
     <file preprocess="xml-stripblanks">ui/add_equation_window.ui</file>
     <file preprocess="xml-stripblanks">ui/add_style.ui</file>
+    <file preprocess="xml-stripblanks">ui/dialogs.ui</file>
     <file preprocess="xml-stripblanks">ui/edit_item.ui</file>
     <file preprocess="xml-stripblanks">ui/export_figure.ui</file>
     <file preprocess="xml-stripblanks">ui/import.ui</file>

--- a/data/ui/add_equation_window.blp
+++ b/data/ui/add_equation_window.blp
@@ -1,7 +1,7 @@
 using Gtk 4.0;
 using Adw 1;
 
-template AddEquationWindow : Adw.Window {
+template $AddEquationWindow : Adw.Window {
   modal: true;
   default-width: 450;
   title: _("Add Equation");

--- a/data/ui/add_equation_window.blp
+++ b/data/ui/add_equation_window.blp
@@ -77,12 +77,13 @@ template $AddEquationWindow : Adw.Window {
               }
             }
 
-            Button confirm_button {
+            Button {
               halign: center;
               margin-top: 24;
               margin-bottom: 12;
               label: _("Add Equation");
               styles ["suggested-action", "pill"]
+              clicked => $on_accept();
             }
           }
         };

--- a/data/ui/add_style.blp
+++ b/data/ui/add_style.blp
@@ -30,6 +30,7 @@ template $AddStyleWindow : Adw.Window {
         Adw.ComboRow plot_style_templates {
           title: _("Template");
           subtitle: _("The template style used for the new style");
+          notify::selected => $on_template_changed();
         }
 
         Adw.EntryRow new_style_name {
@@ -39,11 +40,12 @@ template $AddStyleWindow : Adw.Window {
           halign: center;
           orientation: horizontal;
 
-          Button confirm_button {
+          Button {
             halign: center;
 	          margin-top: 24;
 	          margin-bottom: 12;
             label: _("Add New Style");
+            clicked => $on_accept();
             styles ["suggested-action", "pill"]
           }
         }

--- a/data/ui/add_style.blp
+++ b/data/ui/add_style.blp
@@ -1,7 +1,7 @@
 using Gtk 4.0;
 using Adw 1;
 
-template AddStyleWindow : Adw.Window {
+template $AddStyleWindow : Adw.Window {
   modal: true;
   default-width: 450;
   title: _("Add new style");
@@ -35,17 +35,17 @@ template AddStyleWindow : Adw.Window {
         Adw.EntryRow new_style_name {
           title: _("New Style Name");
         }
-      Box {
-        halign: center;
-        orientation: horizontal;
-
-        Button confirm_button {
+        Box {
           halign: center;
-	        margin-top: 24;
-	        margin-bottom: 12;
-          label: _("Add New Style");
-          styles ["suggested-action", "pill"]
-        }
+          orientation: horizontal;
+
+          Button confirm_button {
+            halign: center;
+	          margin-top: 24;
+	          margin-bottom: 12;
+            label: _("Add New Style");
+            styles ["suggested-action", "pill"]
+          }
         }
       }
     }

--- a/data/ui/dialogs.blp
+++ b/data/ui/dialogs.blp
@@ -1,0 +1,34 @@
+using Gtk 4.0;
+using Adw 1;
+
+Adw.MessageDialog discard_data {
+  heading: _("Discard Data?");
+  body: _("Opening a project will discard all open data.");
+  responses [
+    cancel_open_project: _("Cancel"),
+    discard: _("Discard") destructive,
+  ]
+  close-response: "cancel_open_project";
+  default-response: "discard";
+}
+
+Adw.MessageDialog delete_style {
+  heading: _("Delete style?");
+  responses [
+    cancel_delete_style: _("Cancel"),
+    delete: _("Delete") destructive,
+  ]
+  close-response: "cancel_delete_style";
+  default-response: "delete";
+}
+
+Adw.MessageDialog reset_styles {
+  heading: _("Reset to defaults?");
+  body: _("Are you sure you want to reset to the default styles?");
+  responses [
+    cancel_reset_styles: _("Cancel"),
+    reset: _("Reset") destructive,
+  ]
+  close-response: "cancel_reset_styles";
+  default-response: "reset";
+}

--- a/data/ui/edit_item.blp
+++ b/data/ui/edit_item.blp
@@ -1,7 +1,7 @@
 using Gtk 4.0;
 using Adw 1;
 
-template EditItemWindow : Adw.PreferencesWindow {
+template $EditItemWindow : Adw.PreferencesWindow {
   modal: true;
   ShortcutController {
     Shortcut {

--- a/data/ui/edit_item.blp
+++ b/data/ui/edit_item.blp
@@ -3,6 +3,7 @@ using Adw 1;
 
 template $EditItemWindow : Adw.PreferencesWindow {
   modal: true;
+  close-request => $on_close();
   ShortcutController {
     Shortcut {
       trigger: "Escape";
@@ -15,6 +16,7 @@ template $EditItemWindow : Adw.PreferencesWindow {
       Adw.ComboRow item_selector {
         title: _("Selected Item");
         subtitle: _("Choose which item to edit");
+        notify::selected => $on_select();
       }
     }
 
@@ -55,6 +57,10 @@ template $EditItemWindow : Adw.PreferencesWindow {
         Scale linewidth {
           draw-value: true;
           width-request: 200;
+          adjustment: Adjustment {
+            lower: 0;
+            upper: 10;
+          };
         }
       }
 
@@ -70,6 +76,10 @@ template $EditItemWindow : Adw.PreferencesWindow {
         Scale markersize {
           draw-value: true;
           width-request: 200;
+          adjustment: Adjustment {
+            lower: 0;
+            upper: 10;
+          };
         }
       }
     }

--- a/data/ui/export_figure.blp
+++ b/data/ui/export_figure.blp
@@ -57,12 +57,13 @@ template $ExportFigureWindow : Adw.Window {
           }
         }
 
-        Button confirm_button {
+        Button {
           margin-top: 24;
           margin-bottom: 12;
           label: _("Export");
           halign: center;
           styles ["suggested-action", "pill"]
+          clicked => $on_accept();
         }
       }
     }

--- a/data/ui/export_figure.blp
+++ b/data/ui/export_figure.blp
@@ -1,7 +1,7 @@
 using Gtk 4.0;
 using Adw 1;
 
-template ExportFigureWindow : Adw.Window {
+template $ExportFigureWindow : Adw.Window {
   modal: true;
   title: _("Export Figure");
   default-width: 575;

--- a/data/ui/import.blp
+++ b/data/ui/import.blp
@@ -1,7 +1,7 @@
 using Gtk 4.0;
 using Adw 1;
 
-template ImportWindow : Adw.Window {
+template $ImportWindow : Adw.Window {
   modal: true;
   default-width: 650;
   default-height: 125;

--- a/data/ui/import.blp
+++ b/data/ui/import.blp
@@ -6,6 +6,7 @@ template $ImportWindow : Adw.Window {
   default-width: 650;
   default-height: 125;
   title: _("Modify import Parameters");
+  close-request => $on_close();
 
   ShortcutController {
     Shortcut {
@@ -88,6 +89,7 @@ template $ImportWindow : Adw.Window {
           margin-bottom: 12;
           label: _("Confirm");
           styles ["suggested-action", "pill"]
+          clicked => $on_accept();
         }
       }
     }

--- a/data/ui/item_box.blp
+++ b/data/ui/item_box.blp
@@ -1,7 +1,7 @@
 using Gtk 4.0;
 using Adw 1;
 
-template ItemBox : Box {
+template $ItemBox : Box {
   margin-start: 6;
   margin-end: 6;
   margin-bottom: 9;

--- a/data/ui/item_box.blp
+++ b/data/ui/item_box.blp
@@ -11,6 +11,7 @@ template $ItemBox : Box {
     halign: start;
     hexpand: false;
     styles ["selection-mode"]
+    toggled => $on_toggle();
   }
 
   Label label {
@@ -20,9 +21,10 @@ template $ItemBox : Box {
     hexpand: true;
   }
 
-  Button edit_button {
+  Button {
     tooltip-text: _("Edit Item");
     styles ["flat"]
+    clicked => $edit();
     Image {
       hexpand: false;
       icon-name: "settings-symbolic";
@@ -33,6 +35,7 @@ template $ItemBox : Box {
   Button color_button {
     tooltip-text: _("Pick a color");
     styles ["flat"]
+    clicked => $choose_color();
     Image {
       hexpand: false;
       icon-name: "color-picker-symbolic";
@@ -40,9 +43,10 @@ template $ItemBox : Box {
     }
   }
 
-  Button delete_button {
+  Button {
     tooltip-text: _("Remove");
     styles ["flat"]
+    clicked => $delete();
     Image {
       hexpand: false;
       icon-name: "edit-delete-symbolic";

--- a/data/ui/plot_settings.blp
+++ b/data/ui/plot_settings.blp
@@ -1,7 +1,7 @@
 using Gtk 4.0;
 using Adw 1;
 
-template PlotSettingsWindow : Adw.PreferencesWindow {
+template $PlotSettingsWindow : Adw.PreferencesWindow {
   modal: true;
   can-navigate-back: true;
   title: _("Plot Settings");

--- a/data/ui/plot_settings.blp
+++ b/data/ui/plot_settings.blp
@@ -5,6 +5,7 @@ template $PlotSettingsWindow : Adw.PreferencesWindow {
   modal: true;
   can-navigate-back: true;
   title: _("Plot Settings");
+  close-request => $on_close();
 
   ShortcutController {
     Shortcut {

--- a/data/ui/plot_styles.blp
+++ b/data/ui/plot_styles.blp
@@ -1,7 +1,7 @@
 using Gtk 4.0;
 using Adw 1;
 
-template PlotStylesWindow : Adw.Window {
+template $PlotStylesWindow : Adw.Window {
   modal: true;
   default-width: 650;
   default-height: 400;

--- a/data/ui/plot_styles.blp
+++ b/data/ui/plot_styles.blp
@@ -5,6 +5,8 @@ template $PlotStylesWindow : Adw.Window {
   modal: true;
   default-width: 650;
   default-height: 400;
+  title: _("Plot Styles");
+  close-request => $on_close();
 
   ShortcutController {
     Shortcut {
@@ -20,14 +22,16 @@ template $PlotStylesWindow : Adw.Window {
     Box {
       orientation: vertical;
       Adw.HeaderBar {
-        Button add_button {
+        Button {
           icon-name: "list-add-symbolic";
           tooltip-text: _("Add new style");
+          clicked => $add_style();
         }
         [end]
-        Button reset_button {
+        Button {
           icon-name: "history-undo-symbolic";
           tooltip-text: _("Reset to default styles");
+          clicked => $reset_styles();
         }
         styles ["flat"]
       }
@@ -53,8 +57,9 @@ template $PlotStylesWindow : Adw.Window {
     Box {
       orientation: vertical;
       Adw.HeaderBar {
-        Button back_button {
+        Button {
           icon-name: "left-symbolic";
+          clicked => $back();
         }
         styles ["flat"]
       }
@@ -85,6 +90,7 @@ template $PlotStylesWindow : Adw.Window {
                 FontDialogButton font_chooser {
                   valign: center;
                   dialog: FontDialog {};
+                  use-font: true;
                 }
               }
             }
@@ -105,6 +111,10 @@ template $PlotStylesWindow : Adw.Window {
                 Scale linewidth {
                   draw-value: true;
                   width-request: 200;
+                  adjustment: Adjustment {
+                    lower: 0;
+                    upper: 10;
+                  };
                 }
               }
 
@@ -120,6 +130,10 @@ template $PlotStylesWindow : Adw.Window {
                 Scale markersize {
                   draw-value: true;
                   width-request: 200;
+                  adjustment: Adjustment {
+                    lower: 0;
+                    upper: 10;
+                  };
                 }
               }
             }
@@ -150,6 +164,10 @@ template $PlotStylesWindow : Adw.Window {
                 Scale major_tick_width {
                   draw-value: true;
                   width-request: 200;
+                  adjustment: Adjustment {
+                    lower: 0;
+                    upper: 4;
+                  };
                 }
               }
 
@@ -161,6 +179,10 @@ template $PlotStylesWindow : Adw.Window {
                 Scale minor_tick_width {
                   draw-value: true;
                   width-request: 200;
+                  adjustment: Adjustment {
+                    lower: 0;
+                    upper: 4;
+                  };
                 }
               }
 
@@ -171,6 +193,10 @@ template $PlotStylesWindow : Adw.Window {
                 Scale major_tick_length {
                   draw-value: true;
                   width-request: 200;
+                  adjustment: Adjustment {
+                    lower: 0;
+                    upper: 20;
+                  };
                 }
               }
 
@@ -182,6 +208,10 @@ template $PlotStylesWindow : Adw.Window {
                 Scale minor_tick_length {
                   draw-value: true;
                   width-request: 200;
+                  adjustment: Adjustment {
+                    lower: 0;
+                    upper: 20;
+                  };
                 }
               }
 
@@ -248,6 +278,10 @@ template $PlotStylesWindow : Adw.Window {
                 Scale grid_linewidth {
                   draw-value: true;
                   width-request: 200;
+                  adjustment: Adjustment {
+                    lower: 0;
+                    upper: 4;
+                  };
                 }
               }
 
@@ -259,6 +293,10 @@ template $PlotStylesWindow : Adw.Window {
                 Scale grid_transparency {
                   draw-value: true;
                   width-request: 200;
+                  adjustment: Adjustment {
+                    lower: 0;
+                    upper: 1;
+                  };
                 }
               }
             }
@@ -274,6 +312,10 @@ template $PlotStylesWindow : Adw.Window {
                 Scale value_padding {
                   draw-value: true;
                   width-request: 200;
+                  adjustment: Adjustment {
+                    lower: 0;
+                    upper: 40;
+                  };
                 }
               }
 
@@ -284,6 +326,10 @@ template $PlotStylesWindow : Adw.Window {
                 Scale label_padding {
                   draw-value: true;
                   width-request: 200;
+                  adjustment: Adjustment {
+                    lower: 0;
+                    upper: 40;
+                  };
                 }
               }
 
@@ -294,6 +340,10 @@ template $PlotStylesWindow : Adw.Window {
                 Scale title_padding {
                   draw-value: true;
                   width-request: 200;
+                  adjustment: Adjustment {
+                    lower: 0;
+                    upper: 40;
+                  };
                 }
               }
             }
@@ -459,6 +509,7 @@ template $PlotStylesWindow : Adw.Window {
                     Button line_colors {
                       tooltip-text: _("Edit Colors");
                       valign: center;
+                      clicked => $edit_line_colors();
                       styles ["flat"]
                       Image {
                         icon-name: "right-symbolic";
@@ -479,6 +530,10 @@ template $PlotStylesWindow : Adw.Window {
                 Scale axis_width {
                   draw-value: true;
                   width-request: 200;
+                  adjustment: Adjustment {
+                    lower: 0;
+                    upper: 4;
+                  };
                 }
               }
             }
@@ -490,8 +545,9 @@ template $PlotStylesWindow : Adw.Window {
     Box {
       orientation: vertical;
       Adw.HeaderBar {
-        Button line_colors_back_button {
+        Button {
           icon-name: "left-symbolic";
+          clicked => $back_line_colors();
         }
         styles ["flat"]
       }
@@ -506,7 +562,8 @@ template $PlotStylesWindow : Adw.Window {
           Adw.PreferencesGroup {
             title: _("Line Colors");
             description: _("The colors which will be used for the lines");
-            header-suffix: Button add_color_button {
+            header-suffix: Button {
+              clicked => $add_color();
               Adw.ButtonContent {
                 halign: center;
                 icon-name: "list-add-symbolic";

--- a/data/ui/preferences.blp
+++ b/data/ui/preferences.blp
@@ -4,6 +4,7 @@ using Adw 1;
 template $PreferencesWindow : Adw.PreferencesWindow {
   can-navigate-back: true;
   modal: true;
+  close-request => $on_close();
 
   Adw.PreferencesPage {
     icon-name: "applications-system-symbolic";

--- a/data/ui/preferences.blp
+++ b/data/ui/preferences.blp
@@ -1,7 +1,7 @@
 using Gtk 4.0;
 using Adw 1;
 
-template PreferencesWindow : Adw.PreferencesWindow {
+template $PreferencesWindow : Adw.PreferencesWindow {
   can-navigate-back: true;
   modal: true;
 

--- a/data/ui/rename_window.blp
+++ b/data/ui/rename_window.blp
@@ -30,11 +30,12 @@ template $RenameWindow : Adw.Window {
           title: _("Label");
         }
 
-        Button confirm_button {
+        Button {
           margin-top: 24;
           margin-bottom: 12;
           label: _("Rename");
           halign: center;
+          clicked => $on_accept();
           styles ["suggested-action", "pill"]
         }
       }

--- a/data/ui/rename_window.blp
+++ b/data/ui/rename_window.blp
@@ -1,7 +1,7 @@
 using Gtk 4.0;
 using Adw 1;
 
-template RenameWindow : Adw.Window {
+template $RenameWindow : Adw.Window {
   modal: true;
   default-width: 575;
   default-height: 125;

--- a/data/ui/style_box.blp
+++ b/data/ui/style_box.blp
@@ -19,8 +19,9 @@ template $StyleBox : Box {
     hexpand: true;
     }
 
-  Button edit_button {
+  Button {
     tooltip-text: _("Edit");
+    clicked => $on_edit();
     styles ["flat"]
     Image {
       hexpand: false;
@@ -28,8 +29,9 @@ template $StyleBox : Box {
     }
   }
 
-  Button delete_button {
+  Button {
     tooltip-text: _("Remove");
+    clicked => $on_delete();
     styles ["flat"]
     Image {
       hexpand: false;

--- a/data/ui/style_box.blp
+++ b/data/ui/style_box.blp
@@ -1,7 +1,7 @@
 using Gtk 4.0;
 using Adw 1;
 
-template StyleBox : Box {
+template $StyleBox : Box {
   margin-start: 6;
   margin-end: 6;
   margin-bottom: 9;

--- a/data/ui/style_color_box.blp
+++ b/data/ui/style_color_box.blp
@@ -1,7 +1,7 @@
 using Gtk 4.0;
 using Adw 1;
 
-template StyleColorBox : Box {
+template $StyleColorBox : Box {
   margin-start: 6;
   margin-end: 6;
   margin-bottom: 9;

--- a/data/ui/style_color_box.blp
+++ b/data/ui/style_color_box.blp
@@ -24,8 +24,9 @@ template $StyleColorBox : Box {
     }
   }
 
-  Button delete_button {
+  Button {
     tooltip-text: _("Remove");
+    clicked => $on_delete();
     styles ["flat"]
     Image {
       hexpand: false;

--- a/data/ui/transform_window.blp
+++ b/data/ui/transform_window.blp
@@ -1,7 +1,7 @@
 using Gtk 4.0;
 using Adw 1;
 
-template TransformWindow : Adw.Window {
+template $TransformWindow : Adw.Window {
   modal: true;
   default-width: 450;
   title: _("Transform Data");

--- a/data/ui/transform_window.blp
+++ b/data/ui/transform_window.blp
@@ -16,20 +16,20 @@ template $TransformWindow : Adw.Window {
   Box {
     orientation: vertical;
     Adw.HeaderBar {
-    Button help_button {
-      Adw.ButtonContent {
-      halign: center;
-      icon-name: "info-symbolic";
-      Popover help_popover {
-        position: bottom;
-        Label help_info {
-        label: _("The transformation tool uses Numpy notation, with capital letters for the coordinates.\nTransformations are done piece-wise, if you want access to the entire range use X_range or Y_range. \n e.g. Y = Y/max(X_range) divides each Y value by the largest value of X.\n\nTo convert a value from degrees into radians use radians(value), e.g. Y = sin(radians(X)).");
-      	}
-      }
-      }
-      halign: end;
-      tooltip-text: _("More info");
-      styles ["flat"]
+      Button help_button {
+        Adw.ButtonContent {
+          halign: center;
+          icon-name: "info-symbolic";
+          Popover help_popover {
+            position: bottom;
+            Label help_info {
+              label: _("The transformation tool uses Numpy notation, with capital letters for the coordinates.\nTransformations are done piece-wise, if you want access to the entire range use X_range or Y_range. \n e.g. Y = Y/max(X_range) divides each Y value by the largest value of X.\n\nTo convert a value from degrees into radians use radians(value), e.g. Y = sin(radians(X)).");
+          	}
+          }
+        }
+        halign: end;
+        tooltip-text: _("More info");
+        styles ["flat"]
       }
       styles ["flat"]
     }
@@ -59,11 +59,12 @@ template $TransformWindow : Adw.Window {
           }
         }
 
-        Button confirm_button {
+        Button {
           halign: center;
           margin-top: 24;
           margin-bottom: 12;
           label: _("Transform");
+          clicked => $on_accept();
           styles ["suggested-action", "pill"]
         }
       }

--- a/data/ui/window.blp
+++ b/data/ui/window.blp
@@ -1,20 +1,20 @@
 using Gtk 4.0;
 using Adw 1;
 
-template GraphsWindow : Adw.ApplicationWindow {
+template $GraphsWindow : Adw.ApplicationWindow {
   default-width: 1200;
   default-height: 700;
   Box {
     orientation: vertical;
     Adw.HeaderBar {
       ToggleButton {
-        visible: bind sidebar_flap.folded;
+        visible: bind-property sidebar_flap.folded;
         action-name: "app.toggle_sidebar";
         icon-name: "sidebar-show-symbolic";
-        active: bind sidebar_flap.reveal_flap;
+        active: bind-property sidebar_flap.reveal-flap;
       }
       Box {
-        visible: bind sidebar_flap.folded inverted;
+        visible: bind-property sidebar_flap.folded inverted;
         Adw.SplitButton add_button {
           icon-name: "list-add-symbolic";
           action-name: "app.add_data";
@@ -42,7 +42,7 @@ template GraphsWindow : Adw.ApplicationWindow {
           action-name: "app.restore_view";
           tooltip-text: _("Restore View / View Options");
           menu-model: view_menu;
-          visible: bind sidebar_flap.folded inverted;
+          visible: bind-property sidebar_flap.folded inverted;
         }
         Separator {styles ["spacer"]}
         MenuButton {
@@ -133,7 +133,7 @@ template GraphsWindow : Adw.ApplicationWindow {
                 hexpand: true;
                 width-request: 240;
                 halign: center;
-                visible: bind item_list.visible inverted;
+                visible: bind-property item_list.visible inverted;
                 title: _("No Data");
                 description: _("Add data from a file or manually as an equation");
                 styles ["compact"]

--- a/data/ui/window.blp
+++ b/data/ui/window.blp
@@ -58,6 +58,7 @@ template $GraphsWindow : Adw.ApplicationWindow {
       fold-policy: auto;
       swipe-to-open: true;
       swipe-to-close: true;
+      notify => $on_sidebar_toggle();
 
       [flap]
       Box {

--- a/src/actions.py
+++ b/src/actions.py
@@ -110,16 +110,8 @@ def open_project_action(_action, _target, self):
         def on_response(_dialog, response):
             if response == "discard":
                 ui.open_project_dialog(self)
-        heading = _("Discard Data?")
-        body = _("Opening a project will discard all open data.")
-        dialog = Adw.MessageDialog.new(
-            self.main_window, heading, body)
-        dialog.add_response("cancel", _("Cancel"))
-        dialog.add_response("discard", _("Discard"))
-        dialog.set_close_response("cancel")
-        dialog.set_default_response("discard")
-        dialog.set_response_appearance(
-            "discard", Adw.ResponseAppearance.DESTRUCTIVE)
+        dialog = ui.build_dialog("discard_data")
+        dialog.set_transient_for(self.main_window)
         dialog.connect("response", on_response)
         dialog.present()
         return

--- a/src/actions.py
+++ b/src/actions.py
@@ -3,8 +3,6 @@
 import logging
 from gettext import gettext as _
 
-from gi.repository import Adw
-
 from graphs import clipboard, graphs, operations, ui
 from graphs.add_equation import AddEquationWindow
 from graphs.export_figure import ExportFigureWindow

--- a/src/add_equation.py
+++ b/src/add_equation.py
@@ -17,32 +17,33 @@ class AddEquationWindow(Adw.Window):
     x_start = Gtk.Template.Child()
     x_stop = Gtk.Template.Child()
     step_size = Gtk.Template.Child()
-    confirm_button = Gtk.Template.Child()
 
     def __init__(self, parent):
         super().__init__()
-        config = parent.preferences.config
+        self.parent = parent
+        config = self.parent.preferences.config
         self.equation.set_text(config["addequation_equation"])
         self.x_start.set_text(config["addequation_x_start"])
         self.x_stop.set_text(config["addequation_x_stop"])
         self.step_size.set_text(config["addequation_step_size"])
-        self.confirm_button.connect("clicked", self.on_accept, parent)
-        self.set_transient_for(parent.main_window)
+        self.set_transient_for(self.parent.main_window)
         self.present()
 
-    def on_accept(self, _widget, parent):
+    @Gtk.Template.Callback()
+    def on_accept(self, _widget):
         """Launched when the accept button is pressed on the equation window"""
-        x_start = self.x_start.get_text()
-        x_stop = self.x_stop.get_text()
-        step_size = self.step_size.get_text()
-        equation = str(self.equation.get_text())
         try:
+            equation = str(self.equation.get_text())
             xdata, ydata = calculation.create_dataset(
-                x_start, x_stop, equation, step_size)
+                self.x_start.get_text(),
+                self.x_stop.get_text(),
+                equation,
+                self.step_size.get_text())
             name = str(self.name.get_text())
             if name == "":
                 name = f"Y = {equation}"
-            graphs.add_items(parent, [Item(parent, xdata, ydata, name)])
+            graphs.add_items(
+                self.parent, [Item(self.parent, xdata, ydata, name)])
             self.destroy()
         except (NameError, SyntaxError) as exception:
             toast = _("{error} - Unable to add data from equation").format(

--- a/src/add_equation.py
+++ b/src/add_equation.py
@@ -49,4 +49,3 @@ class AddEquationWindow(Adw.Window):
                 error=exception.__class__.__name__)
             self.toast_overlay.add_toast(Adw.Toast(title=toast))
             logging.exception(toast)
-

--- a/src/add_equation.py
+++ b/src/add_equation.py
@@ -49,3 +49,4 @@ class AddEquationWindow(Adw.Window):
                 error=exception.__class__.__name__)
             self.toast_overlay.add_toast(Adw.Toast(title=toast))
             logging.exception(toast)
+

--- a/src/edit_item.py
+++ b/src/edit_item.py
@@ -28,20 +28,20 @@ class EditItemWindow(Adw.PreferencesWindow):
         utilities.populate_chooser(self.item_selector, names)
         self.item_selector.set_selected(names.index(self.item.name))
 
-        self.linewidth.set_range(0, 10)
         utilities.populate_chooser(self.plot_x_position, misc.X_POSITIONS)
         utilities.populate_chooser(self.plot_y_position, misc.Y_POSITIONS)
         utilities.populate_chooser(self.linestyle, misc.LINESTYLES)
         utilities.populate_chooser(self.markers, sorted(misc.MARKERS.keys()))
-        self.markersize.set_range(0, 10)
         self.load_values()
-        self.item_selector.connect("notify::selected", self.on_select)
-        self.connect("close-request", self.apply)
         self.set_transient_for(parent.main_window)
         self.present()
 
+    def on_close(self, *_args):
+        self.apply()
+
+    @Gtk.Template.Callback()
     def on_select(self, _action, _target):
-        self.apply(None)
+        self.apply()
         data_list = list(self.parent.datadict.keys())
         index = self.item_selector.get_selected()
         self.item = self.parent.datadict[data_list[index]]
@@ -75,8 +75,7 @@ class EditItemWindow(Adw.PreferencesWindow):
         utilities.set_chooser(self.markers, markerstyle)
         self.markersize.set_value(self.item.markersize)
 
-    def apply(self, _):
-
+    def apply(self):
         self.item.name = self.name_entry.get_text()
 
         # Only change limits when axes change, otherwise this is not needed

--- a/src/export_figure.py
+++ b/src/export_figure.py
@@ -10,7 +10,6 @@ from graphs import utilities
 @Gtk.Template(resource_path="/se/sjoerd/Graphs/ui/export_figure.ui")
 class ExportFigureWindow(Adw.Window):
     __gtype_name__ = "ExportFigureWindow"
-    confirm_button = Gtk.Template.Child()
     file_format = Gtk.Template.Child()
     transparent = Gtk.Template.Child()
     dpi = Gtk.Template.Child()
@@ -19,7 +18,6 @@ class ExportFigureWindow(Adw.Window):
         super().__init__()
         self.parent = parent
         self.set_transient_for(parent.main_window)
-        self.confirm_button.connect("clicked", self.on_accept)
         self.transparent.set_active(
             self.parent.preferences.config["export_figure_transparent"])
         self.items = \
@@ -38,6 +36,7 @@ class ExportFigureWindow(Adw.Window):
             utilities.set_chooser(self.file_format, default_format)
         self.present()
 
+    @Gtk.Template.Callback()
     def on_accept(self, _button):
         dpi = int(self.dpi.get_value())
         fmt = utilities.get_selected_chooser_item(self.file_format)

--- a/src/file_import.py
+++ b/src/file_import.py
@@ -86,7 +86,6 @@ class ImportSettings():
 @Gtk.Template(resource_path="/se/sjoerd/Graphs/ui/import.ui")
 class ImportWindow(Adw.Window):
     __gtype_name__ = "ImportWindow"
-    confirm_button = Gtk.Template.Child()
     columns_group = Gtk.Template.Child()
 
     delimiter = Gtk.Template.Child()
@@ -109,9 +108,7 @@ class ImportWindow(Adw.Window):
             prepare_import_finish(self.parent, self.import_dict)
             self.destroy()
             return
-        self.confirm_button.connect("clicked", self.on_accept)
         self.set_transient_for(parent.main_window)
-        self.connect("close-request", self.on_close)
         self.present()
 
     def load_columns(self):
@@ -124,6 +121,7 @@ class ImportWindow(Adw.Window):
         self.column_y.set_value(int(params["column_y"]))
         self.skip_rows.set_value(int(params["skip_rows"]))
 
+    @Gtk.Template.Callback()
     def on_accept(self, _widget):
         self.param_dict = {}
         if "columns" in self.modes:
@@ -151,6 +149,7 @@ class ImportWindow(Adw.Window):
             "delimiter": self.delimiter.get_text(),
         }
 
+    @Gtk.Template.Callback()
     def on_close(self, _widget):
         prepare_import_finish(self.parent, self.import_dict)
 

--- a/src/item_box.py
+++ b/src/item_box.py
@@ -10,24 +10,18 @@ class ItemBox(Gtk.Box):
     __gtype_name__ = "ItemBox"
     label = Gtk.Template.Child()
     check_button = Gtk.Template.Child()
-    edit_button = Gtk.Template.Child()
     color_button = Gtk.Template.Child()
-    delete_button = Gtk.Template.Child()
 
     def __init__(self, parent, item):
         super().__init__()
         self.item = item
+        self.parent = parent
         self.label.set_text(utilities.shorten_label(item.name))
         self.check_button.set_active(item.selected)
-        self.parent = parent
 
         self.gesture = Gtk.GestureClick()
         self.gesture.set_button(0)
         self.add_controller(self.gesture)
-        self.edit_button.connect("clicked", self.edit)
-        self.color_button.connect("clicked", self.choose_color)
-        self.delete_button.connect("clicked", self.delete)
-        self.check_button.connect("toggled", self.on_toggle)
         self.provider = Gtk.CssProvider()
         self.color_button.get_style_context().add_provider(
             self.provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
@@ -64,6 +58,7 @@ class ItemBox(Gtk.Box):
         self.provider.load_from_data(
             f"button {{ color: {self.item.color}; }}", -1)
 
+    @Gtk.Template.Callback()
     def choose_color(self, _):
         color = utilities.hex_to_rgba(self.item.color)
         dialog = Gtk.ColorDialog()
@@ -82,13 +77,16 @@ class ItemBox(Gtk.Box):
         except GLib.GError:
             pass
 
+    @Gtk.Template.Callback()
     def delete(self, _):
         graphs.delete_item(self.parent, self.item.key, True)
 
+    @Gtk.Template.Callback()
     def on_toggle(self, _):
         self.item.selected = self.check_button.get_active()
         graphs.refresh(self.parent)
         ui.enable_data_dependent_buttons(self.parent)
 
+    @Gtk.Template.Callback()
     def edit(self, _):
         EditItemWindow(self.parent, self.item)

--- a/src/main.py
+++ b/src/main.py
@@ -142,7 +142,6 @@ class GraphsApplication(Adw.Application):
             file_io.parse_style(plot_styles.get_preferred_style(self)))
         self.canvas = Canvas(self)
         win.toast_overlay.set_child(self.canvas)
-        win.sidebar_flap.connect("notify", self.on_sidebar_toggle)
         win.redo_button.set_sensitive(False)
         win.undo_button.set_sensitive(False)
         ui.enable_data_dependent_buttons(self)

--- a/src/plot_styles.py
+++ b/src/plot_styles.py
@@ -6,7 +6,7 @@ from cycler import cycler
 
 from gi.repository import Adw, GLib, Gio, Gtk
 
-from graphs import file_io, graphs, misc, utilities
+from graphs import file_io, graphs, misc, utilities, ui
 
 
 def _styles_in_directory(directory):
@@ -399,16 +399,9 @@ class PlotStylesWindow(Adw.Window):
             if response == "delete":
                 get_user_styles(self)[style].trash(None)
                 self.reload_styles()
-        heading = _("Delete style?")
         body = _("Are you sure you want to delete the {} style?").format(style)
-        dialog = Adw.MessageDialog.new(
-            self, heading, body)
-        dialog.add_response("cancel", _("Cancel"))
-        dialog.add_response("delete", _("Delete"))
-        dialog.set_close_response("cancel")
-        dialog.set_default_response("delete")
-        dialog.set_response_appearance(
-            "delete", Adw.ResponseAppearance.DESTRUCTIVE)
+        dialog = ui.build_dialog("delete_style")
+        dialog.set_transient_for(self)
         dialog.connect("response", remove_style, self)
         dialog.present()
 
@@ -437,17 +430,8 @@ class PlotStylesWindow(Adw.Window):
             if response == "reset":
                 reset_user_styles(self.parent)
                 self.reload_styles()
-
-        heading = _("Reset to defaults?")
-        body = _("Are you sure you want to reset to the default styles?")
-        dialog = Adw.MessageDialog.new(
-            self, heading, body)
-        dialog.add_response("cancel", _("Cancel"))
-        dialog.add_response("reset", _("Reset"))
-        dialog.set_close_response("cancel")
-        dialog.set_default_response("delete")
-        dialog.set_response_appearance(
-            "reset", Adw.ResponseAppearance.DESTRUCTIVE)
+        dialog = ui.build_dialog("reset_styles")
+        dialog.set_transient_for(self)
         dialog.connect("response", on_accept)
         dialog.present()
 

--- a/src/plot_styles.py
+++ b/src/plot_styles.py
@@ -6,7 +6,7 @@ from cycler import cycler
 
 from gi.repository import Adw, GLib, Gio, Gtk
 
-from graphs import file_io, graphs, misc, utilities, ui
+from graphs import file_io, graphs, misc, ui, utilities
 
 
 def _styles_in_directory(directory):
@@ -401,6 +401,7 @@ class PlotStylesWindow(Adw.Window):
                 self.reload_styles()
         body = _("Are you sure you want to delete the {} style?").format(style)
         dialog = ui.build_dialog("delete_style")
+        dialog.set_body(body)
         dialog.set_transient_for(self)
         dialog.connect("response", remove_style, self)
         dialog.present()

--- a/src/plot_styles.py
+++ b/src/plot_styles.py
@@ -450,10 +450,10 @@ class StyleBox(Gtk.Box):
         self.parent.leaflet.navigate(1)
         self.parent.set_title(self.style)
 
-
     @Gtk.Template.Callback()
     def on_delete(self, _button):
         style = self.style
+
         def remove_style(_dialog, response):
             if response == "delete":
                 get_user_styles(self.parent.parent)[style].trash(None)

--- a/src/plot_styles.py
+++ b/src/plot_styles.py
@@ -111,15 +111,9 @@ def get_style(self, stylename):
 @Gtk.Template(resource_path="/se/sjoerd/Graphs/ui/plot_styles.ui")
 class PlotStylesWindow(Adw.Window):
     __gtype_name__ = "PlotStylesWindow"
-    add_button = Gtk.Template.Child()
     leaflet = Gtk.Template.Child()
     styles_box = Gtk.Template.Child()
-    reset_button = Gtk.Template.Child()
-    back_button = Gtk.Template.Child()
     line_colors_box = Gtk.Template.Child()
-    line_colors_back_button = Gtk.Template.Child()
-    line_colors = Gtk.Template.Child()
-    add_color_button = Gtk.Template.Child()
     style_name = Gtk.Template.Child()
     font_chooser = Gtk.Template.Child()
     linestyle = Gtk.Template.Child()
@@ -157,29 +151,11 @@ class PlotStylesWindow(Adw.Window):
         self.styles = []
         self.style = None
         self.reload_styles()
-        self.reset_button.connect("clicked", self.reset_styles)
-        self.add_button.connect("clicked", self.add_data)
-        self.back_button.connect("clicked", self.back)
-        self.connect("close-request", self.on_close)
-        self.set_title(_("Plot Styles"))
 
         # setup editor
-        self.font_chooser.set_use_font(True)
-        self.linewidth.set_range(0, 10)
         utilities.populate_chooser(self.linestyle, misc.LINESTYLES)
         utilities.populate_chooser(self.markers, sorted(misc.MARKERS.keys()))
         utilities.populate_chooser(self.tick_direction, misc.TICK_DIRECTIONS)
-        self.markersize.set_range(0, 10)
-        self.major_tick_width.set_range(0, 4)
-        self.minor_tick_width.set_range(0, 4)
-        self.major_tick_length.set_range(0, 20)
-        self.minor_tick_length.set_range(0, 20)
-        self.grid_linewidth.set_range(0, 4)
-        self.grid_transparency.set_range(0, 1)
-        self.value_padding.set_range(0, 40)
-        self.label_padding.set_range(0, 40)
-        self.title_padding.set_range(0, 40)
-        self.axis_width.set_range(0, 4)
 
         # color actions
         self.color_buttons = [
@@ -197,19 +173,11 @@ class PlotStylesWindow(Adw.Window):
                 button.provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
 
         # line colors
-        self.line_colors.connect("clicked", self.edit_line_colors)
-        self.line_colors_back_button.connect("clicked", self.back_line_colors)
-        self.add_color_button.connect("clicked", self.add_color)
         self.color_boxes = {}
 
         self.present()
 
-    def edit_style(self, _button, style):
-        self.style = get_style(self.parent, style)
-        self.load_style()
-        self.leaflet.navigate(1)
-        self.set_title(style)
-
+    @Gtk.Template.Callback()
     def back(self, _button):
         self.save_style()
         self.reload_styles()
@@ -217,11 +185,13 @@ class PlotStylesWindow(Adw.Window):
         self.leaflet.navigate(0)
         self.set_title(_("Plot Styles"))
 
+    @Gtk.Template.Callback()
     def edit_line_colors(self, _button):
         self.leaflet.navigate(1)
         self.set_title(
             _("{name} - line colors").format(name=self.style.name))
 
+    @Gtk.Template.Callback()
     def back_line_colors(self, _):
         self.leaflet.navigate(0)
         self.set_title(self.style.name)
@@ -383,28 +353,11 @@ class PlotStylesWindow(Adw.Window):
         file = directory.get_child_for_display_name(f"{style.name}.mplstyle")
         file_io.write_style(file, style)
 
-    def delete_color(self, _button, color_box):
-        self.line_colors_box.remove(self.color_boxes[color_box])
-        del self.color_boxes[color_box]
-        if not self.color_boxes:
-            self.add_color(None)
-
+    @Gtk.Template.Callback()
     def add_color(self, _button):
-        box = StyleColorBox(self, "000000")
+        box = StyleColorBox(self, "#000000")
         self.line_colors_box.append(box)
         self.color_boxes[box] = self.line_colors_box.get_last_child()
-
-    def delete_style(self, _button, style):
-        def remove_style(_dialog, response, self):
-            if response == "delete":
-                get_user_styles(self)[style].trash(None)
-                self.reload_styles()
-        body = _("Are you sure you want to delete the {} style?").format(style)
-        dialog = ui.build_dialog("delete_style")
-        dialog.set_body(body)
-        dialog.set_transient_for(self)
-        dialog.connect("response", remove_style, self)
-        dialog.present()
 
     def copy_style(self, _button, style, new_style):
         i = 0
@@ -423,9 +376,11 @@ class PlotStylesWindow(Adw.Window):
         user_styles[style].copy(destination, 0, None)
         self.reload_styles()
 
-    def add_data(self, _button):
+    @Gtk.Template.Callback()
+    def add_style(self, _button):
         AddStyleWindow(self)
 
+    @Gtk.Template.Callback()
     def reset_styles(self, _button):
         def on_accept(_dialog, response):
             if response == "reset":
@@ -450,6 +405,7 @@ class PlotStylesWindow(Adw.Window):
             self.styles.append(box)
             self.styles_box.append(box)
 
+    @Gtk.Template.Callback()
     def on_close(self, _button):
         if self.style is not None:
             self.save_style()
@@ -480,14 +436,34 @@ class StyleBox(Gtk.Box):
     __gtype_name__ = "StyleBox"
     label = Gtk.Template.Child()
     check_mark = Gtk.Template.Child()
-    delete_button = Gtk.Template.Child()
-    edit_button = Gtk.Template.Child()
 
     def __init__(self, parent, style):
         super().__init__()
-        self.label.set_label(utilities.shorten_label(style, 50))
-        self.delete_button.connect("clicked", parent.delete_style, style)
-        self.edit_button.connect("clicked", parent.edit_style, style)
+        self.parent = parent
+        self.style = style
+        self.label.set_label(utilities.shorten_label(self.style, 50))
+
+    @Gtk.Template.Callback()
+    def on_edit(self, _button):
+        self.parent.style = get_style(self.parent.parent, self.style)
+        self.parent.load_style()
+        self.parent.leaflet.navigate(1)
+        self.parent.set_title(self.style)
+
+
+    @Gtk.Template.Callback()
+    def on_delete(self, _button):
+        style = self.style
+        def remove_style(_dialog, response):
+            if response == "delete":
+                get_user_styles(self.parent.parent)[style].trash(None)
+                self.parent.reload_styles()
+        body = _("Are you sure you want to delete the {} style?").format(style)
+        dialog = ui.build_dialog("delete_style")
+        dialog.set_body(body)
+        dialog.set_transient_for(self.parent)
+        dialog.connect("response", remove_style)
+        dialog.present()
 
 
 @Gtk.Template(resource_path="/se/sjoerd/Graphs/ui/style_color_box.ui")
@@ -495,10 +471,10 @@ class StyleColorBox(Gtk.Box):
     __gtype_name__ = "StyleColorBox"
     label = Gtk.Template.Child()
     color_button = Gtk.Template.Child()
-    delete_button = Gtk.Template.Child()
 
     def __init__(self, parent, color):
         super().__init__()
+        self.parent = parent
         self.label.set_label(_("Color {}").format(len(parent.color_boxes) + 1))
         self.color_button.color = color
         self.color_button.provider = Gtk.CssProvider()
@@ -507,14 +483,19 @@ class StyleColorBox(Gtk.Box):
             Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
         self.color_button.provider.load_from_data(
             f"button {{ color: {color}; }}", -1)
-        self.color_button.connect("clicked", parent.on_color_change)
-        self.delete_button.connect("clicked", parent.delete_color, self)
+        self.color_button.connect("clicked", self.parent.on_color_change)
+
+    @Gtk.Template.Callback()
+    def on_delete(self, _button):
+        self.parent.line_colors_box.remove(self.parent.color_boxes[self])
+        del self.parent.color_boxes[self]
+        if not self.parent.color_boxes:
+            self.parent.add_color(None)
 
 
 @Gtk.Template(resource_path="/se/sjoerd/Graphs/ui/add_style.ui")
 class AddStyleWindow(Adw.Window):
     __gtype_name__ = "AddStyleWindow"
-    confirm_button = Gtk.Template.Child()
     new_style_name = Gtk.Template.Child()
     plot_style_templates = Gtk.Template.Child()
 
@@ -524,23 +505,18 @@ class AddStyleWindow(Adw.Window):
         utilities.populate_chooser(
             self.plot_style_templates,
             sorted(get_user_styles(parent).keys()), False)
-        selected_item = \
-            utilities.get_selected_chooser_item(self.plot_style_templates)
-        self.new_style_name.set_text(
-            _("{name} (copy)").format(name=selected_item))
-        self.confirm_button.connect("clicked", self.on_confirm)
-        self.plot_style_templates.connect(
-            "notify::selected", self.on_template_changed)
         self.set_transient_for(parent)
         self.present()
 
+    @Gtk.Template.Callback()
     def on_template_changed(self, _a, _b):
         selected_item = \
             utilities.get_selected_chooser_item(self.plot_style_templates)
         self.new_style_name.set_text(
             _("{name} (copy)").format(name=selected_item))
 
-    def on_confirm(self, _button):
+    @Gtk.Template.Callback()
+    def on_accept(self, _button):
         style = utilities.get_selected_chooser_item(self.plot_style_templates)
         name = self.new_style_name.get_text()
         self.parent.copy_style(self, style, name)

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -118,7 +118,6 @@ class PreferencesWindow(Adw.PreferencesWindow):
             self.plot_custom_style, plot_styles.get_user_styles(parent).keys(),
             translate=False)
         self.load_configuration()
-        self.connect("close-request", self.on_close, self.parent)
         self.set_transient_for(self.parent.main_window)
         self.present()
 
@@ -233,7 +232,8 @@ class PreferencesWindow(Adw.PreferencesWindow):
         config["plot_custom_style"] = \
             utilities.get_selected_chooser_item(self.plot_custom_style)
 
-    def on_close(self, _, parent):
+    @Gtk.Template.Callback()
+    def on_close(self, _):
         self.apply_configuration()
-        parent.preferences.save_config()
-        graphs.refresh(parent)
+        self.parent.preferences.save_config()
+        graphs.refresh(self.parent)

--- a/src/rename.py
+++ b/src/rename.py
@@ -9,42 +9,43 @@ from graphs import graphs
 @Gtk.Template(resource_path="/se/sjoerd/Graphs/ui/rename_window.ui")
 class RenameWindow(Adw.Window):
     __gtype_name__ = "RenameWindow"
-    confirm_button = Gtk.Template.Child()
     text_entry = Gtk.Template.Child()
     preferencegroup = Gtk.Template.Child()
 
     def __init__(self, parent, item):
         super().__init__()
+        self.parent = parent
+        self.item = item
         title = _("Rename Label")
         group_title = _("Change Label")
         group_description = \
             _("Here you can change the label of the selected axis.")
-        text = item.get_text()
-        if item == parent.canvas.title:
+        text = self.item.get_text()
+        if self.item == self.parent.canvas.title:
             title = _("Rename Title")
             group_title = _("Change Title")
             group_description = \
                 _("Here you can change the title of the plot.")
-            text = parent.plot_settings.title
+            text = self.parent.plot_settings.title
         self.set_title(title)
         self.preferencegroup.set_title(group_title)
         self.preferencegroup.set_description(group_description)
         self.text_entry.set_text(text)
-        self.set_transient_for(parent.main_window)
-        self.confirm_button.connect("clicked", self.on_accept, parent, item)
+        self.set_transient_for(self.parent.main_window)
         self.present()
 
-    def on_accept(self, _widget, parent, item):
+    @Gtk.Template.Callback()
+    def on_accept(self, _widget):
         text = self.text_entry.get_text()
-        if item == parent.canvas.top_label:
-            parent.plot_settings.top_label = text
-        if item == parent.canvas.left_label:
-            parent.plot_settings.ylabel = text
-        if item == parent.canvas.bottom_label:
-            parent.plot_settings.xlabel = text
-        if item == parent.canvas.right_label:
-            parent.plot_settings.right_label = text
-        if item == parent.canvas.title:
-            parent.plot_settings.title = text
-        graphs.refresh(parent)
+        if self.item == self.parent.canvas.top_label:
+            self.parent.plot_settings.top_label = text
+        if self.item == self.parent.canvas.left_label:
+            self.parent.plot_settings.ylabel = text
+        if self.item == self.parent.canvas.bottom_label:
+            self.parent.plot_settings.xlabel = text
+        if self.item == self.parent.canvas.right_label:
+            self.parent.plot_settings.right_label = text
+        if self.item == self.parent.canvas.title:
+            self.parent.plot_settings.title = text
+        graphs.refresh(self.parent)
         self.destroy()

--- a/src/transform_data.py
+++ b/src/transform_data.py
@@ -13,7 +13,6 @@ class TransformWindow(Adw.Window):
     __gtype_name__ = "TransformWindow"
     transform_x_entry = Gtk.Template.Child()
     transform_y_entry = Gtk.Template.Child()
-    confirm_button = Gtk.Template.Child()
     discard_row = Gtk.Template.Child()
     discard = Gtk.Template.Child()
     help_button = Gtk.Template.Child()
@@ -21,26 +20,27 @@ class TransformWindow(Adw.Window):
 
     def __init__(self, parent):
         super().__init__()
+        self.parent = parent
         self.transform_x_entry.set_text("X")
         self.transform_y_entry.set_text("Y")
         self.discard_row.set_visible(
-            parent.interaction_mode == InteractionMode.SELECT)
-        self.confirm_button.connect("clicked", self.on_accept, parent)
-        self.set_transient_for(parent.main_window)
+            self.parent.interaction_mode == InteractionMode.SELECT)
+        self.set_transient_for(self.parent.main_window)
         self.present()
-        self.help_button.connect("clicked",
-                                 lambda _x: self.help_popover.popup())
+        self.help_button.connect(
+            "clicked", lambda _x: self.help_popover.popup())
 
-    def on_accept(self, _widget, parent):
+    @Gtk.Template.Callback()
+    def on_accept(self, _widget):
         try:
             input_x = str(self.transform_x_entry.get_text())
             input_y = str(self.transform_y_entry.get_text())
             discard = self.discard.get_active()
             operations.perform_operation(
-                parent, operations.transform, input_x, input_y, discard)
+                self.parent, operations.transform, input_x, input_y, discard)
         except (NameError, SyntaxError) as exception:
             toast = _("{name}: Unable to do transformation, \
 make sure the syntax is correct").format(name=exception.__class__.__name__)
-            parent.main_window.add_toast(toast)
+            self.parent.main_window.add_toast(toast)
             logging.exception(_("Unable to do transformation"))
         self.destroy()

--- a/src/ui.py
+++ b/src/ui.py
@@ -114,6 +114,7 @@ def build_dialog(name):
     return Gtk.Builder.new_from_resource(
         "/se/sjoerd/Graphs/ui/dialogs.ui").get_object(name)
 
+
 def show_about_window(self):
     developers = [
         "Sjoerd Stendahl <contact@sjoerd.se>",

--- a/src/ui.py
+++ b/src/ui.py
@@ -110,6 +110,10 @@ def export_data_dialog(self):
         dialog.save(self.main_window, None, on_response)
 
 
+def build_dialog(name):
+    return Gtk.Builder.new_from_resource(
+        "/se/sjoerd/Graphs/ui/dialogs.ui").get_object(name)
+
 def show_about_window(self):
     developers = [
         "Sjoerd Stendahl <contact@sjoerd.se>",

--- a/src/window.py
+++ b/src/window.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
-from gi.repository import Adw, Gtk
+from gi.repository import Adw, GLib, Gtk
 
 
 @Gtk.Template(resource_path="/se/sjoerd/Graphs/ui/window.ui")
@@ -35,3 +35,8 @@ class GraphsWindow(Adw.ApplicationWindow):
 
     def add_toast(self, title):
         self.toast_overlay.add_toast(Adw.Toast(title=title))
+
+    @Gtk.Template.Callback()
+    def on_sidebar_toggle(self, *_args):
+        self.get_application().toggle_sidebar.change_state(
+            GLib.Variant.new_boolean(self.sidebar_flap.get_reveal_flap()))


### PR DESCRIPTION
Based on https://github.com/Sjoerd1993/Graphs/pull/295

Move signal handlers as well as a few other things to blueprint.
Moving Signal handlers helps remove the need to reference a widget by
name in code in most cases. This makes the code a bit cleaner in this
regard.
In order to accomplish that, a few light refactors have to be done. This
way the code is more consistent.