### PR TITLE
Add language options

### DIFF
--- a/data/config.json
+++ b/data/config.json
@@ -10,6 +10,7 @@
   "export_figure_transparent": true,
   "handle_duplicates": "Auto-rename duplicates",
   "hide_unselected": false,
+  "language": "System default",
   "override_style_change": true,
   "plot_custom_style": "adwaita",
   "plot_legend": true,

--- a/data/ui/preferences.blp
+++ b/data/ui/preferences.blp
@@ -150,6 +150,11 @@ template $PreferencesWindow : Adw.PreferencesWindow {
       title: _("Other");
       description: _("Other general settings");
 
+      Adw.ComboRow language_chooser {
+        title: _("Language");
+        subtitle: _("Set the language that is used (requires restart)");
+      }
+
       Adw.ActionRow {
         title: _("Clipboard length");
         subtitle: _("Choose how many states are stored in the clipboard");

--- a/src/main.py
+++ b/src/main.py
@@ -2,6 +2,7 @@
 """Main application."""
 import logging
 import sys
+import os
 from gettext import gettext as _
 from inspect import getmembers, isfunction
 
@@ -44,6 +45,7 @@ class GraphsApplication(Adw.Application):
             except RuntimeError:
                 logging.warning(_("Could not load %s"), font)
         self.preferences = Preferences()
+        os.environ["LANGUAGE"] = self.preferences.config["language"]
         self.add_actions()
         self.get_style_manager().connect(
             "notify", ui.on_style_change, None, self)

--- a/src/misc.py
+++ b/src/misc.py
@@ -43,6 +43,9 @@ def _(message):
 
 
 SCALES = [_("linear"), _("log")]
+LANGUAGES = [
+    _("System default"), _("English"), _("Dutch"),  _("Swedish"), _("Turkish"),
+]
 LEGEND_POSITIONS = [
     _("Best"), _("Upper right"), _("Upper left"), _("Lower left"),
     _("Lower right"), _("Center left"), _("Center right"), _("Lower center"),
@@ -69,5 +72,4 @@ MARKERS = {
     _("Filled plus"): "P", _("Filled x"): "X", _("Nothing"): "none",
 }
 TICK_DIRECTIONS = [_("in"), _("out")]
-
 del _

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -70,6 +70,7 @@ class PreferencesWindow(Adw.PreferencesWindow):
     export_figure_filetype = Gtk.Template.Child()
     export_figure_transparent = Gtk.Template.Child()
     action_center_data = Gtk.Template.Child()
+    language_chooser = Gtk.Template.Child()
     other_handle_duplicates = Gtk.Template.Child()
     other_hide_unselected = Gtk.Template.Child()
     override_style_change = Gtk.Template.Child()
@@ -112,6 +113,7 @@ class PreferencesWindow(Adw.PreferencesWindow):
         utilities.populate_chooser(
             self.plot_legend_position, misc.LEGEND_POSITIONS)
 
+        utilities.populate_chooser(self.language_chooser, misc.LANGUAGES)
         utilities.populate_chooser(
             self.plot_custom_style,
             plot_styles.get_user_styles(self.props.application).keys(),
@@ -174,6 +176,8 @@ class PreferencesWindow(Adw.PreferencesWindow):
             config["plot_use_custom_style"])
         utilities.set_chooser(
             self.plot_custom_style, config["plot_custom_style"])
+        utilities.set_chooser(
+            self.language_chooser, config["language"])
 
     def apply_configuration(self):
         config = self.props.application.preferences.config
@@ -233,6 +237,8 @@ class PreferencesWindow(Adw.PreferencesWindow):
             self.plot_use_custom_style.get_enable_expansion()
         config["plot_custom_style"] = \
             utilities.get_selected_chooser_item(self.plot_custom_style)
+        config["language"] = \
+            utilities.get_selected_chooser_item(self.language_chooser)
 
     @Gtk.Template.Callback()
     def on_close(self, _):


### PR DESCRIPTION
Adds a chooser to switch languages, regardless of system default. Requires a restart (of the application itself), but works as intended, even from Gnome Builder.