### PR TITLE
Fix edit item

### DIFF
--- a/src/edit_item.py
+++ b/src/edit_item.py
@@ -30,9 +30,9 @@ class EditItemWindow(Adw.PreferencesWindow):
         utilities.populate_chooser(self.markers, sorted(misc.MARKERS.keys()))
         self.load_values()
         utilities.populate_chooser(self.item_selector, names)
-
-        self.item_selector.set_selected(names.index(self.item.name))
+        self.item_selector.set_selected(names.index(item.name))
         self.set_transient_for(self.props.application.main_window)
+        self.connect("close-request", self.on_close)
         self.present()
 
     def on_close(self, *_args):


### PR DESCRIPTION
Fixes two issues in the edit item window:

- When the window was closed, the changes were not applied
- In the latest build, when clicking on a gear icon it would always just open the edit window of the top item. Regardless of which one was open.