### PR TITLE
Fix deleting multiple items

### DIFF
--- a/src/actions.py
+++ b/src/actions.py
@@ -117,12 +117,10 @@ def open_project_action(_action, _target, self):
 
 
 def delete_selected_action(_action, _target, self):
-    delete_list = []
-    for item in self.datadict.values():
-        if item.selected:
-            delete_list.append(item)
-    for item in delete_list:
-        graphs.delete_item(self, item.key, True)
+    selected_keys = [key for key, item in self.datadict.items()
+        if item.selected]
+    for key in selected_keys:
+        graphs.delete_item(self, key, True)
 
 
 def translate_x_action(_action, _target, self):

--- a/src/actions.py
+++ b/src/actions.py
@@ -118,7 +118,7 @@ def open_project_action(_action, _target, self):
 
 def delete_selected_action(_action, _target, self):
     selected_keys = [key for key, item in self.datadict.items()
-        if item.selected]
+                     if item.selected]
     for key in selected_keys:
         graphs.delete_item(self, key, True)
 

--- a/src/actions.py
+++ b/src/actions.py
@@ -121,6 +121,7 @@ def delete_selected_action(_action, _target, self):
         if item.selected:
             graphs.delete_item(self, item.key, True)
 
+
 def translate_x_action(_action, _target, self):
     win = self.main_window
     try:

--- a/src/actions.py
+++ b/src/actions.py
@@ -117,11 +117,9 @@ def open_project_action(_action, _target, self):
 
 
 def delete_selected_action(_action, _target, self):
-    selected_keys = [key for key, item in self.datadict.items()
-                     if item.selected]
-    for key in selected_keys:
-        graphs.delete_item(self, key, True)
-
+    for item in self.datadict.copy().values():
+        if item.selected:
+            graphs.delete_item(self, item.key, True)
 
 def translate_x_action(_action, _target, self):
     win = self.main_window

--- a/src/actions.py
+++ b/src/actions.py
@@ -117,9 +117,12 @@ def open_project_action(_action, _target, self):
 
 
 def delete_selected_action(_action, _target, self):
+    delete_list = []
     for item in self.datadict.values():
         if item.selected:
-            graphs.delete_item(self, item.key, True)
+            delete_list.append(item)
+    for item in delete_list:
+        graphs.delete_item(self, item.key, True)
 
 
 def translate_x_action(_action, _target, self):


### PR DESCRIPTION
In the latest build, only the top item gets deleted when pressing the delete button. The reason for this is that it loops through the dictionary itself in actions.py, changing the dictionary size upon iteration which is not allowed. This solves this by looping through the selected keys instead like in previous releases.