### PR TITLE
Fix plotstyle checkmark

### DIFF
--- a/src/plot_styles.py
+++ b/src/plot_styles.py
@@ -382,7 +382,7 @@ class PlotStylesWindow(Adw.Window):
         for style, file in \
                 sorted(get_user_styles(self.props.application).items()):
             box = StyleBox(self, style)
-            if not custom_style and \
+            if custom_style and \
                     not file.equal(
                         get_preferred_style(self.props.application)):
                 box.check_mark.hide()


### PR DESCRIPTION
The conditional for checking if a custom style was used was reversed. The result was that all styles got a checkmark when a custom style was selected. This fixes that.