### PR TITLE
Update help_overlay.blp

### DIFF
--- a/data/ui/help_overlay.blp
+++ b/data/ui/help_overlay.blp
@@ -119,6 +119,12 @@ ShortcutsWindow help_overlay {
       }
 
       ShortcutsShortcut {
+        title: C_("shortcut window", "Optimize Limits");
+        action-name: "app.optimize_limits";
+      }
+
+
+      ShortcutsShortcut {
         title: C_("shortcut window", "Toggle Sidebar");
         action-name: "app.toggle_sidebar";
       }

--- a/data/ui/help_overlay.blp
+++ b/data/ui/help_overlay.blp
@@ -68,11 +68,6 @@ ShortcutsWindow help_overlay {
         action-name: "app.add_data";
       }
 
-      ShortcutsShortcut {
-        title: C_("shortcut window", "Open new File (Advanced)");
-        action-name: "app.add_data_advanced";
-      }
-
        ShortcutsShortcut {
         title: C_("shortcut window", "Open Project");
         action-name: "app.open_project";


### PR DESCRIPTION
I noticed the help overlay still contained the add data (advanced) option, and didn't have the optimize limits option yet. This fixes that.

Will put this in with Release 1.6.0. Any other changes can probably be submitted as a patch