### PR TITLE
Fix plot style checkmarks

### DIFF
--- a/src/plot_styles.py
+++ b/src/plot_styles.py
@@ -382,9 +382,7 @@ class PlotStylesWindow(Adw.Window):
         for style, file in \
                 sorted(get_user_styles(self.props.application).items()):
             box = StyleBox(self, style)
-            if custom_style and \
-                    not file.equal(
-                        get_preferred_style(self.props.application)):
+            if not file.equal(get_preferred_style(self.props.application)):
                 box.check_mark.hide()
                 box.label.set_hexpand(True)
             self.styles.append(box)


### PR DESCRIPTION
The fix in PR #315 made everything work great when a custom style was selected, but introduced a bug where all plot styles got a check mark when the system prefered style were used. This fixes it such that it works for all.

I've also started to take a look into the slight color difference between the plot and the sidebar in the dark mode of the Snap version. You can retrieve the system theme color quite well code-wise using the following pieces of code:
```
        styles = application.main_window.get_style_context()
        rgba = styles.lookup_color('theme_bg_color')[1]
        rgba_tuple = (round(rgba.red*255), round(rgba.green*255), round(rgba.blue*255), round(rgba.alpha*255))
        color_hex = '#{:02x}{:02x}{:02x}'.format(*rgba_tuple)
```

And then you can just set the facecolor of the figure (not the axes) to that color_hex value. This works well enough, but gets wrong when you toggle dark mode when the application is open. (When switching from light to dark, the figure gets reloaded, the color is set from the above code (giving it a light background), and then the dark mode is actually applied. Meaning the dark and light modes will be inversed)

I feel a better solution there may be to check the system `theme_bg_color` when launching the application, and setting that value in the system preferred stylesheet upon launch. This would also solve potential issues when someone uses custom theming for whatever reason.

**EDIT:** Since the system preferred style is static, that may not be a great idea. Will have to rethink to come up with a better solution. 