### PR TITLE
Remove sig fig roundings

### DIFF
--- a/src/plotting_tools.py
+++ b/src/plotting_tools.py
@@ -46,11 +46,6 @@ def optimize_limits(self):
         elif direction in ["left", "right"]:
             min_all *= 0.5
             max_all *= 2
-        try:
-            min_all = utilities.sig_fig_round(min_all, 3)
-            max_all = utilities.sig_fig_round(max_all, 3)
-        except ValueError:
-            pass
         match direction:
             case "bottom":
                 self.plot_settings.min_bottom = min_all

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -14,16 +14,6 @@ def remove_unused_config_keys(config, template):
     return config
 
 
-def sig_fig_round(number, digits):
-    """Round a number to the specified number of significant digits."""
-    try:
-        # Convert to scientific notation, and get power
-        power = "{:e}".format(float(number)).split("e")[1]
-    except IndexError:
-        return None
-    return round(float(number), -(int(power) - digits + 1))
-
-
 def change_key_position(dictionary, key1, key2):
     """Change key position of key2 to that of key1."""
     keys = list(dictionary.keys())


### PR DESCRIPTION
Remove the rounding of the limits based on significant digits. This was originally introduced to gaurantee "Clean" figures when looking at the axis limits in the plot settings.

But I have realized this causes more issues than it's worth. Specifically, this causes issue when working with data sets with large numbers, where the minimum and maximum value are relatively close  to eachother. As an example, if the X-axis goes from 2000 to 2023, then this rounds this all to three significant digits. Meaning it will round this to 2E3 (so 2000) and 2.02E3 (so 2020), cutting off the last 3 values from the X-axis. These are not even obscure cases, as this is just with years.

When working with even bigger ranges (12312331 and 12312339 for instance), it will make the entire limits just unusable (rounding to 12300000 and 12300000 for both limits). 

I think it's probably best to just don't round these limits, and accept that the initial axes limits in the plot settings can look a bit messy at  times.