### PR TITLE
Drop shift+letter shortcuts

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -115,11 +115,11 @@ class GraphsApplication(Adw.Application):
         self.add_action(self.toggle_sidebar)
         self.set_accels_for_action("app.toggle_sidebar", ["F9"])
 
-        self.create_mode_action("mode_pan", ["<shift>P", "F1"],
+        self.create_mode_action("mode_pan", ["F1"],
                                 InteractionMode.PAN)
-        self.create_mode_action("mode_zoom", ["<shift>Z", "F2"],
+        self.create_mode_action("mode_zoom",  ["F2"],
                                 InteractionMode.ZOOM)
-        self.create_mode_action("mode_select", ["<shift>S", "F3"],
+        self.create_mode_action("mode_select", ["F3"],
                                 InteractionMode.SELECT)
 
     def do_activate(self):

--- a/src/main.py
+++ b/src/main.py
@@ -117,7 +117,7 @@ class GraphsApplication(Adw.Application):
 
         self.create_mode_action("mode_pan", ["F1"],
                                 InteractionMode.PAN)
-        self.create_mode_action("mode_zoom",  ["F2"],
+        self.create_mode_action("mode_zoom", ["F2"],
                                 InteractionMode.ZOOM)
         self.create_mode_action("mode_select", ["F3"],
                                 InteractionMode.SELECT)


### PR DESCRIPTION
Drops the keyboard shortcuts that are shift+letter. 
The reason behind this, is because these shortcuts get triggered while creating axes labels as well. Making it currently impossible to write an axis label with a capital S for intance. The effected commands do have an alternative shortcut in the F-keys.

An alternative solution be to disable all shortcuts when an EntryRow is selected, but I am not sure if that's possible. That would be the nicest solution though I think.

In the same note, we should consider removing the following shortcuts as well, as they do interfere with writing labels/titles as well:
 - Delete (deletes the selected items, currently while renaming something. If I press delete to remove the character in front of the cursor, it deletes the selected items instead of the character)
 - Ctrl+A (selects all data, this is something a user potentially wants to do when renaming a label or equation, to highlight everything and start typing)
 - Ctrl+shift+A (deselects all data, less important)
 
 For these last three, we can consider using alternative shortcuts as well. Currenlty kept those untouched in this PR.
 