### PR TITLE
Update changelist

### DIFF
--- a/data/se.sjoerd.Graphs.appdata.xml.in.in
+++ b/data/se.sjoerd.Graphs.appdata.xml.in.in
@@ -47,6 +47,15 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="1.6.1" data="2023-06-15">
+        <p>Minor patch with some bug fixes:</p>
+        <ul>
+	  <li>Fixed a bug all styles in the style manager had a checkmark if the system preffered style was used.</li>
+	  <li>Fixed a bug where the legend would not be removed from the graph when toggled off, until it was completely reloaded.</li>
+	  <li>Automatic axes limits are no longer rounded, which used to lead to problems with the scaling when using data span with a large amount of significant digits.</li>
+	  <li>Removed some shortcuts that were overlapping with typing a capital character, making it difficult to write a capital for the respective characters in titles and labels.</li>
+        </ul>
+    </release>
     <release version="1.6.0" date="2023-06-13">
       <description>
 	<p>New in Graphs:

--- a/data/whats_new
+++ b/data/whats_new
@@ -23,4 +23,8 @@
 	  <li>Fixed a bug where the legend styles could not be reset to defaults</li>
 	  <li>Fixed a bug where the legend would remain when all data is removed</li>
 	  <li>Fixed a bug where Graphs would crash when the name of an item is changed and a new item is selected from the dropdown.</li>
+	  <li>Fixed a bug all styles in the style manager had a checkmark if the system preffered style was used.</li>
+	  <li>Fixed a bug where the legend would not be removed from the graph when toggled off, until it was completely reloaded.</li>
+	  <li>Automatic axes limits are no longer rounded, which used to lead to problems with the scaling when using data span with a large amount of significant digits.</li>
+	  <li>Removed some shortcuts that were overlapping with typing a capital character, making it difficult to write a capital for the respective characters in titles and labels.</li>
         </ul>


### PR DESCRIPTION
Update the changelist for the 1.6.1 patch with the latest bug fixes. I don't think I will push this release today although I am not directly opposed. Currently I have tomorrow as preliminary release date there. Either way, I think it's fine to push bug fix patches on relatively short intervals, as they don't really add anything but just solve existing issues.

Whenever it may release, I thought it's good to start updating the changelist now before I forget some parts.
Decided to add the information on top of the whats new section. Resetting it with major releases.