### PR TITLE
Add filters to new file dialog

### DIFF
--- a/data/se.sjoerd.Graphs.appdata.xml.in.in
+++ b/data/se.sjoerd.Graphs.appdata.xml.in.in
@@ -50,6 +50,7 @@
     <release version="1.6.1" data="2023-06-15">
         <p>Minor patch with some bug fixes:</p>
         <ul>
+	  <li>Filters have been added for the "New Data" dialog.</li>
 	  <li>Fixed a bug all styles in the style manager had a checkmark if the system preffered style was used.</li>
 	  <li>Fixed a bug where the legend would not be removed from the graph when toggled off, until it was completely reloaded.</li>
 	  <li>Automatic axes limits are no longer rounded, which used to lead to problems with the scaling when using data span with a large amount of significant digits.</li>

--- a/src/export_figure.py
+++ b/src/export_figure.py
@@ -61,6 +61,6 @@ class ExportFigureWindow(Adw.Window):
         dialog = Gtk.FileDialog()
         dialog.set_initial_name(f"{filename}.{file_suffix}")
         dialog.set_accept_label(_("Export"))
-        dialog.set_filters(utilities.create_file_filters([(fmt, file_suffix)]))
+        dialog.set_filters(utilities.create_file_filters([(fmt, [file_suffix])]))
         dialog.save(application.main_window, None, on_response)
         self.destroy()

--- a/src/ui.py
+++ b/src/ui.py
@@ -54,6 +54,9 @@ def add_data_dialog(self):
             file_import.prepare_import(
                 self, dialog.open_multiple_finish(response))
     dialog = Gtk.FileDialog()
+    dialog.set_filters(utilities.create_file_filters([(_('ASCII files'),
+                       ['xy', 'dat', 'txt', 'csv']), (_('PANalytical XRDML'
+                       ), ['xrdml']), (_('Leybold xry'), ['xry'])]))
     dialog.open_multiple(self.main_window, None, on_response)
 
 
@@ -66,7 +69,7 @@ def save_project_dialog(self):
                 self.datadict_clipboard, self.clipboard_pos, self.version)
     dialog = Gtk.FileDialog()
     dialog.set_filters(
-        utilities.create_file_filters([(_("Graphs Project File"), "graphs")]))
+        utilities.create_file_filters([(_("Graphs Project File"), ["graphs"])]))
     dialog.set_initial_name("project.graphs")
     dialog.save(self.main_window, None, on_response)
 
@@ -78,7 +81,7 @@ def open_project_dialog(self):
             graphs.open_project(self, file)
     dialog = Gtk.FileDialog()
     dialog.set_filters(
-        utilities.create_file_filters([(_("Graphs Project File"), "graphs")]))
+        utilities.create_file_filters([(_("Graphs Project File"), ["graphs"])]))
     dialog.open(self.main_window, None, on_response)
 
 
@@ -106,7 +109,7 @@ def export_data_dialog(self):
         filename = f"{list(self.datadict.values())[0].name}.txt"
         dialog.set_initial_name(filename)
         dialog.set_filters(
-            utilities.create_file_filters([(_("Text Files"), "txt")]))
+            utilities.create_file_filters([(_("Text Files"), ["txt"])]))
         dialog.save(self.main_window, None, on_response)
 
 

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -229,10 +229,11 @@ def get_config_directory():
 
 def create_file_filters(filters, add_all=True):
     list_store = Gio.ListStore()
-    for name, suffix in filters:
+    for name, suffix_list in filters:
         file_filter = Gtk.FileFilter()
         file_filter.set_name(name)
-        file_filter.add_suffix(suffix)
+        for suffix in suffix_list:
+            file_filter.add_suffix(suffix)
         list_store.append(file_filter)
     if add_all:
         file_filter = Gtk.FileFilter()


### PR DESCRIPTION
Adds filters to the "Add data from file" dialogs. Also reformats the `create_file_filters` function slightly, to take in a list of suffixes. This way multiple suffixes can be added to a single filetype.