### PR TITLE
Fix appdata changelist

### DIFF
--- a/data/se.sjoerd.Graphs.appdata.xml.in.in
+++ b/data/se.sjoerd.Graphs.appdata.xml.in.in
@@ -60,14 +60,13 @@
     </release>
     <release version="1.6.0" date="2023-06-13">
       <description>
-	<p>New in Graphs:
+	<p>New in Graphs:</p>
 	<ul>
 	  <li>Data can now be opened directly from project files.</li>
 	  <li>Adds Dutch translation for Graphs.</li>
 	  <li>Adds Turkish translation for Graphs.</li>
 	  <li>Adds Swedish translation for Graphs.</li>
 	</ul>
-	</p>
         <p>Changes:</p>
         <ul>
 	  <li>Graphs now always follows the preset system style, unless custom style is set</li>


### PR DESCRIPTION
There's a slight syntax error in the changelist, making the latest changelist not show up in GNOME Software (at least for the latest release). Fixing it would require tagging and pushing an entire new release and it doesn't really change the user experience, so that may not be worth to fix it in this version (the info is still there in whats new also), but it's good to fix it anyway so that it will show up in the history after next patch.

I guess this syntax error is why the changelist for 1.6.1 doesn't show up at least... I tried validating the xml file and couldn't detect any more errors.