### PR TITLE
Fix skip rows

### DIFF
--- a/data/se.sjoerd.Graphs.appdata.xml.in.in
+++ b/data/se.sjoerd.Graphs.appdata.xml.in.in
@@ -47,6 +47,14 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="1.6.2" date="2023-06-14">
+      <description>
+        <p>Bugfixes:</p>
+        <ul>
+	  <li>Fixes a bug where the first data point would not be loaded</li>
+        </ul>
+      </description>
+    </release>
     <release version="1.6.1" date="2023-06-14">
         <p>Minor patch with some bug fixes:</p>
         <ul>

--- a/data/whats_new
+++ b/data/whats_new
@@ -24,6 +24,7 @@
 	  <li>Fixed a bug where the legend styles could not be deleted</li>
 	  <li>Fixed a bug where the legend styles could not be reset to defaults</li>
 	  <li>Fixed a bug where the legend would remain when all data is removed</li>
+	  <li>Fixes a bug where the first data point would not be loaded</li>
 	  <li>Fixed a bug where Graphs would crash when the name of an item is changed and a new item is selected from the dropdown.</li>
 	  <li>Fixed a bug all styles in the style manager had a check-mark if the system preferred style was used.</li>
 	  <li>Fixed a bug where the legend would not be removed from the graph when toggled off, until it was completely reloaded.</li>

--- a/src/file_io.py
+++ b/src/file_io.py
@@ -127,7 +127,7 @@ def import_from_columns(self, import_settings):
     content = file.load_bytes(None)[0].get_data().decode("utf-8")
     params = import_settings.params
     for i, line in enumerate(content.splitlines()):
-        if i > params["skip_rows"]:
+        if i >= params["skip_rows"]:
             line = line.strip()
             data_line = re.split(str(params["delimiter"]), line)
             if params["separator"] == ",":


### PR DESCRIPTION
Currently when importing columns, it only loads if the iteration index is larger than the amount of rows to be skipped. At the first iteration, the index is zero. Meaning that it skips the first iteration when skip_rows = 0. So basically, the first data point is skipped currently.

It should of course compare to skip_rows >= index. 