### PR TITLE
Remove redundant lines of codes

### DIFF
--- a/src/plotting_tools.py
+++ b/src/plotting_tools.py
@@ -81,11 +81,6 @@ def hide_unused_axes(self, canvas):
     if used_axes["bottom"]:
         canvas.axis.get_xaxis().set_visible(True)
 
-    canvas.top_right_axis.get_xaxis().set_visible(False)
-    canvas.right_axis.get_xaxis().set_visible(False)
-    canvas.top_right_axis.get_yaxis().set_visible(False)
-    canvas.top_left_axis.get_yaxis().set_visible(False)
-
 
 def change_left_yscale(action, target, self):
     self.canvas.axis.set_yscale(target.get_string())

--- a/src/plotting_tools.py
+++ b/src/plotting_tools.py
@@ -73,17 +73,13 @@ def hide_unused_axes(self, canvas):
         axis.get_yaxis().set_visible(False)
     used_axes = utilities.get_used_axes(self)[0]
     if used_axes["left"]:
-        canvas.top_left_axis.get_yaxis().set_visible(True)
         canvas.axis.get_yaxis().set_visible(True)
     if used_axes["right"]:
-        canvas.top_right_axis.get_yaxis().set_visible(True)
         canvas.right_axis.get_yaxis().set_visible(True)
     if used_axes["top"]:
-        canvas.top_right_axis.get_xaxis().set_visible(True)
         canvas.top_left_axis.get_xaxis().set_visible(True)
     if used_axes["bottom"]:
         canvas.axis.get_xaxis().set_visible(True)
-        canvas.right_axis.get_xaxis().set_visible(True)
 
     canvas.top_right_axis.get_xaxis().set_visible(False)
     canvas.right_axis.get_xaxis().set_visible(False)


### PR DESCRIPTION
Because these parts of the axes always are turned off anyway (line 84 and down), it makes no sense turning them visible first. So these lines can be removed without losing anything