### PR TITLE
Fix overlapping ticks

### DIFF
--- a/src/canvas.py
+++ b/src/canvas.py
@@ -148,7 +148,7 @@ class Canvas(FigureCanvas):
         self.top_right_axis.set_yscale(plot_settings.right_scale)
 
     def set_ticks(self):
-        """ Set the tick parameters for the axes in the plot."""
+        """Set the tick parameters for the axes in the plot"""
         bottom = pyplot.rcParams["xtick.bottom"]
         left = pyplot.rcParams["ytick.left"]
         top = pyplot.rcParams["xtick.top"]
@@ -167,14 +167,14 @@ class Canvas(FigureCanvas):
         for axis, directions in axes.items():
             # Set tick where requested, as long as that axis is not occupied
             tick_params = {
-                "bottom": bottom and
-                ("bottom" in directions or not used_axes["bottom"]),
-                "left": left and
-                ("left" in directions or not used_axes["left"]),
-                "top": top and
-                ("top" in directions or not used_axes["top"]),
-                "right": right and
-                ("right" in directions or not used_axes["right"]),
+                "bottom": bottom and ("bottom" in directions or
+                                      not used_axes["bottom"]),
+                "left": left and ("left" in directions or
+                                  not used_axes["left"]),
+                "top": top and ("top" in directions or
+                                not used_axes["top"]),
+                "right": right and ("right" in directions or
+                                    not used_axes["right"])
             }
             axis.tick_params(which=ticks, **tick_params)
 

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -167,14 +167,14 @@ class Canvas(FigureCanvas):
         for axis, directions in axes.items():
             # Set tick where requested, as long as that axis is not occupied
             tick_params = {
-                "bottom": bottom and
-                          ("bottom" in directions or not used_axes["bottom"]),
-                "left": left and
-                        ("left" in directions or not used_axes["left"]),
-                "top": top and
-                       ("top" in directions or not used_axes["top"]),
-                "right": right and
-                         ("right" in directions or not used_axes["right"]),
+                "bottom": bottom
+                and ("bottom" in directions or not used_axes["bottom"]),
+                "left": left
+                and ("left" in directions or not used_axes["left"]),
+                "top": top
+                and ("top" in directions or not used_axes["top"]),
+                "right": right
+                and ("right" in directions or not used_axes["right"]),
             }
             axis.tick_params(which=ticks, **tick_params)
 

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -167,14 +167,14 @@ class Canvas(FigureCanvas):
         for axis, directions in axes.items():
             # Set tick where requested, as long as that axis is not occupied
             tick_params = {
-                "bottom": bottom
-                and ("bottom" in directions or not used_axes["bottom"]),
-                "left": left
-                and ("left" in directions or not used_axes["left"]),
-                "top": top
-                and ("top" in directions or not used_axes["top"]),
-                "right": right
-                and ("right" in directions or not used_axes["right"]),
+                "bottom": bottom and (
+                    "bottom" in directions or not used_axes["bottom"]),
+                "left": left and (
+                    "left" in directions or not used_axes["left"]),
+                "top": top and (
+                    "top" in directions or not used_axes["top"]),
+                "right": right and (
+                    "right" in directions or not used_axes["right"]),
             }
             axis.tick_params(which=ticks, **tick_params)
 

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -148,9 +148,7 @@ class Canvas(FigureCanvas):
         self.top_right_axis.set_yscale(plot_settings.right_scale)
 
     def set_ticks(self):
-        """
-        Set the tick parameters for the axes in the plot.
-        """
+        """ Set the tick parameters for the axes in the plot."""
         bottom = pyplot.rcParams["xtick.bottom"]
         left = pyplot.rcParams["ytick.left"]
         top = pyplot.rcParams["xtick.top"]
@@ -158,25 +156,25 @@ class Canvas(FigureCanvas):
         ticks = "both" if pyplot.rcParams["xtick.minor.visible"] else "major"
         used_axes = utilities.get_used_axes(self.application)[0]
 
-        #Define axes and their directions
+        # Define axes and their directions
         axes = {
             self.axis: ["bottom", "left"],
             self.top_right_axis: ["top", "right"],
             self.top_left_axis: ["top", "left"],
-            self.right_axis: ["bottom", "right"]
+            self.right_axis: ["bottom", "right"],
         }
 
         for axis, directions in axes.items():
-            # Set tick parameters if
+            # Set tick where requested, as long as that axis is not occupied
             tick_params = {
-                "bottom": bottom
-                and ("bottom" in directions or not used_axes["bottom"]),
-                "left": left
-                and ("left" in directions or not used_axes["left"]),
-                "top": top
-                and ("top" in directions or not used_axes["top"]),
-                "right": right
-                and ("right" in directions or not used_axes["right"])
+                "bottom": bottom and
+                ("bottom" in directions or not used_axes["bottom"]),
+                "left": left and
+                ("left" in directions or not used_axes["left"]),
+                "top": top and
+                ("top" in directions or not used_axes["top"]),
+                "right": right and
+                ("right" in directions or not used_axes["right"]),
             }
             axis.tick_params(which=ticks, **tick_params)
 

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -167,17 +167,16 @@ class Canvas(FigureCanvas):
         for axis, directions in axes.items():
             # Set tick where requested, as long as that axis is not occupied
             tick_params = {
-                "bottom": bottom and
-                          ("bottom" in directions or not used_axes["bottom"]),
-                "left": left and
-                        ("left" in directions or not used_axes["left"]),
-                "top": top and
-                       ("top" in directions or not used_axes["top"]),
-                "right": right and
-                         ("right" in directions or not used_axes["right"]),
+                "bottom": bottom and("bottom" in directions or not used_axes[
+                    "bottom"]),
+                "left": left and("left" in directions or not used_axes[
+                    "left"]),
+                "top": top and("top" in directions or not used_axes[
+                    "top"]),
+                "right": right and("right" in directions or not used_axes[
+                    "right"])
             }
-            axis.tick_params(which=ticks, **tick_params)
-
+            axis.tick_params(which = ticks, ** tick_params)
     # Overwritten function - do not change name
     def __call__(self, event):
         """

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -167,16 +167,17 @@ class Canvas(FigureCanvas):
         for axis, directions in axes.items():
             # Set tick where requested, as long as that axis is not occupied
             tick_params = {
-                "bottom": bottom and("bottom" in directions or not used_axes[
-                    "bottom"]),
-                "left": left and("left" in directions or not used_axes[
-                    "left"]),
-                "top": top and("top" in directions or not used_axes[
-                    "top"]),
-                "right": right and("right" in directions or not used_axes[
-                    "right"])
+                "bottom": bottom and
+                          ("bottom" in directions or not used_axes["bottom"]),
+                "left": left and
+                        ("left" in directions or not used_axes["left"]),
+                "top": top and
+                       ("top" in directions or not used_axes["top"]),
+                "right": right and
+                         ("right" in directions or not used_axes["right"]),
             }
-            axis.tick_params(which = ticks, ** tick_params)
+            axis.tick_params(which=ticks, **tick_params)
+
     # Overwritten function - do not change name
     def __call__(self, event):
         """

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -31,7 +31,7 @@ class Canvas(FigureCanvas):
         self.top_left_axis = self.axis.twiny()
         self.top_right_axis = self.top_left_axis.twinx()
         self.set_axis_properties()
-        self.set_ticks(application)
+        self.set_ticks()
         color_rgba = utilities.lookup_color(self.application, "accent_color")
         self.rubberband_edge_color = utilities.rgba_to_tuple(color_rgba, True)
         color_rgba.alpha = 0.3
@@ -75,6 +75,7 @@ class Canvas(FigureCanvas):
             self.figure.draw(self._renderer)
 
     def plot(self, item):
+        self.set_ticks()
         x_axis = item.plot_x_position
         y_axis = item.plot_y_position
         if y_axis == "left":
@@ -147,7 +148,7 @@ class Canvas(FigureCanvas):
         self.top_right_axis.set_xscale(plot_settings.top_scale)
         self.top_right_axis.set_yscale(plot_settings.right_scale)
 
-    def set_ticks(self, application):
+    def set_ticks(self):
         bottom = pyplot.rcParams["xtick.bottom"]
         left = pyplot.rcParams["ytick.left"]
         top = pyplot.rcParams["xtick.top"]
@@ -156,7 +157,7 @@ class Canvas(FigureCanvas):
             ticks = "both"
         else:
             ticks = "major"
-        used_axes = utilities.get_used_axes(application)[0]
+        used_axes = utilities.get_used_axes(self.application)[0]
         left_ticks = right_ticks = top_ticks = bottom_ticks = False
 
         if right and not used_axes["right"]:
@@ -171,7 +172,7 @@ class Canvas(FigureCanvas):
         if bottom and not used_axes["bottom"]:
             bottom_ticks = True
         self.top_right_axis.tick_params(bottom=bottom_ticks, left=left_ticks,
-                                        top=top_ticks, right=right, which=ticks)
+                                        top=top, right=right, which=ticks)
 
         if right and not used_axes["right"]:
             right_ticks = True

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -31,7 +31,7 @@ class Canvas(FigureCanvas):
         self.top_left_axis = self.axis.twiny()
         self.top_right_axis = self.top_left_axis.twinx()
         self.set_axis_properties()
-        self.set_ticks()
+        self.set_ticks(application)
         color_rgba = utilities.lookup_color(self.application, "accent_color")
         self.rubberband_edge_color = utilities.rgba_to_tuple(color_rgba, True)
         color_rgba.alpha = 0.3
@@ -147,7 +147,7 @@ class Canvas(FigureCanvas):
         self.top_right_axis.set_xscale(plot_settings.top_scale)
         self.top_right_axis.set_yscale(plot_settings.right_scale)
 
-    def set_ticks(self):
+    def set_ticks(self, application):
         bottom = pyplot.rcParams["xtick.bottom"]
         left = pyplot.rcParams["ytick.left"]
         top = pyplot.rcParams["xtick.top"]
@@ -156,10 +156,36 @@ class Canvas(FigureCanvas):
             ticks = "both"
         else:
             ticks = "major"
-        for axis in [self.top_right_axis, self.axis, self.top_left_axis,
-                     self.right_axis]:
-            axis.tick_params(bottom=bottom, left=left, top=top,
-                             right=right, which=ticks)
+        used_axes = utilities.get_used_axes(application)[0]
+        left_ticks = right_ticks = top_ticks = bottom_ticks = False
+
+        if right and not used_axes["right"]:
+            right_ticks = True
+        if top and not used_axes["top"]:
+            top_ticks = True
+        self.axis.tick_params(bottom=bottom, left=left, top=top_ticks,
+                              right=right_ticks, which=ticks)
+
+        if left and not used_axes["left"]:
+            left_ticks = True
+        if bottom and not used_axes["bottom"]:
+            bottom_ticks = True
+        self.top_right_axis.tick_params(bottom=bottom_ticks, left=left_ticks,
+                                        top=top_ticks, right=right, which=ticks)
+
+        if right and not used_axes["right"]:
+            right_ticks = True
+        if bottom and not used_axes["bottom"]:
+            bottom_ticks = True
+        self.top_left_axis.tick_params(bottom=bottom_ticks, left=left, top=top,
+                                       right=right_ticks, which=ticks)
+
+        if left and not used_axes["left"]:
+            left_ticks = True
+        if top and not used_axes["top"]:
+            top_ticks = True
+        self.right_axis.tick_params(bottom=bottom, left=left_ticks,
+                                    top=top_ticks, right=right, which=ticks)
 
     # Overwritten function - do not change name
     def __call__(self, event):

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -75,7 +75,6 @@ class Canvas(FigureCanvas):
             self.figure.draw(self._renderer)
 
     def plot(self, item):
-        self.set_ticks()
         x_axis = item.plot_x_position
         y_axis = item.plot_y_position
         if y_axis == "left":
@@ -149,44 +148,37 @@ class Canvas(FigureCanvas):
         self.top_right_axis.set_yscale(plot_settings.right_scale)
 
     def set_ticks(self):
+        """
+        Set the tick parameters for the axes in the plot.
+        """
         bottom = pyplot.rcParams["xtick.bottom"]
         left = pyplot.rcParams["ytick.left"]
         top = pyplot.rcParams["xtick.top"]
         right = pyplot.rcParams["ytick.right"]
-        if pyplot.rcParams["xtick.minor.visible"]:
-            ticks = "both"
-        else:
-            ticks = "major"
+        ticks = "both" if pyplot.rcParams["xtick.minor.visible"] else "major"
         used_axes = utilities.get_used_axes(self.application)[0]
-        left_ticks = right_ticks = top_ticks = bottom_ticks = False
 
-        if right and not used_axes["right"]:
-            right_ticks = True
-        if top and not used_axes["top"]:
-            top_ticks = True
-        self.axis.tick_params(bottom=bottom, left=left, top=top_ticks,
-                              right=right_ticks, which=ticks)
+        #Define axes and their directions
+        axes = {
+            self.axis: ["bottom", "left"],
+            self.top_right_axis: ["top", "right"],
+            self.top_left_axis: ["top", "left"],
+            self.right_axis: ["bottom", "right"]
+        }
 
-        if left and not used_axes["left"]:
-            left_ticks = True
-        if bottom and not used_axes["bottom"]:
-            bottom_ticks = True
-        self.top_right_axis.tick_params(bottom=bottom_ticks, left=left_ticks,
-                                        top=top, right=right, which=ticks)
-
-        if right and not used_axes["right"]:
-            right_ticks = True
-        if bottom and not used_axes["bottom"]:
-            bottom_ticks = True
-        self.top_left_axis.tick_params(bottom=bottom_ticks, left=left, top=top,
-                                       right=right_ticks, which=ticks)
-
-        if left and not used_axes["left"]:
-            left_ticks = True
-        if top and not used_axes["top"]:
-            top_ticks = True
-        self.right_axis.tick_params(bottom=bottom, left=left_ticks,
-                                    top=top_ticks, right=right, which=ticks)
+        for axis, directions in axes.items():
+            # Set tick parameters if
+            tick_params = {
+                "bottom": bottom
+                and ("bottom" in directions or not used_axes["bottom"]),
+                "left": left
+                and ("left" in directions or not used_axes["left"]),
+                "top": top
+                and ("top" in directions or not used_axes["top"]),
+                "right": right
+                and ("right" in directions or not used_axes["right"])
+            }
+            axis.tick_params(which=ticks, **tick_params)
 
     # Overwritten function - do not change name
     def __call__(self, event):

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -167,14 +167,14 @@ class Canvas(FigureCanvas):
         for axis, directions in axes.items():
             # Set tick where requested, as long as that axis is not occupied
             tick_params = {
-                "bottom": bottom and ("bottom" in directions or
-                                      not used_axes["bottom"]),
-                "left": left and ("left" in directions or
-                                  not used_axes["left"]),
-                "top": top and ("top" in directions or
-                                not used_axes["top"]),
-                "right": right and ("right" in directions or
-                                    not used_axes["right"])
+                "bottom": bottom and
+                          ("bottom" in directions or not used_axes["bottom"]),
+                "left": left and
+                        ("left" in directions or not used_axes["left"]),
+                "top": top and
+                       ("top" in directions or not used_axes["top"]),
+                "right": right and
+                         ("right" in directions or not used_axes["right"]),
             }
             axis.tick_params(which=ticks, **tick_params)
 

--- a/src/graphs.py
+++ b/src/graphs.py
@@ -137,6 +137,7 @@ def refresh(self):
     if len(self.datadict) > 0:
         plotting_tools.hide_unused_axes(self, self.canvas)
     self.canvas.set_axis_properties()
+    self.canvas.set_ticks()
     for item in reversed(self.datadict.values()):
         if (item is not None) and not \
                 (self.preferences["hide_unselected"] and not item.selected):


### PR DESCRIPTION
When multiple axes are used, the ticks from each axes are overlapping. See screenshot:

![image](https://github.com/Sjoerd1993/Graphs/assets/68477016/7ad9c6bc-3d71-451f-9255-dde4f6ea0310)


This is never something you want in an actual graph. Basically, the change in this PR is that for a specific axis, opposite ticks are not plotted now when the opposite axis is already in use by a data set. This does mean that the condition for each axis needs to be checked separately with slightly different conditions, so I could not get it to work in a single loop. But it's readable enough. See screenshot for the same data after this PR:

![image](https://github.com/Sjoerd1993/Graphs/assets/68477016/bc295d26-a1d4-451b-b68a-16cf94371fa7)
