### PR TITLE
Fix top axis limits

### DIFF
--- a/src/canvas.py
+++ b/src/canvas.py
@@ -122,8 +122,8 @@ class Canvas(FigureCanvas):
         plot_settings = self.application.plot_settings
         plot_settings.min_bottom = min(self.axis.get_xlim())
         plot_settings.max_bottom = max(self.axis.get_xlim())
-        plot_settings.min_top = min(self.top_left_axis.get_ylim())
-        plot_settings.max_top = max(self.top_left_axis.get_ylim())
+        plot_settings.min_top = min(self.top_left_axis.get_xlim())
+        plot_settings.max_top = max(self.top_left_axis.get_xlim())
         plot_settings.min_left = min(self.axis.get_ylim())
         plot_settings.max_left = max(self.axis.get_ylim())
         plot_settings.min_right = min(self.right_axis.get_ylim())


### PR DESCRIPTION
When the top axis limits got set, it tried to set the limits to the Y-axis, but that should be x-axis of course. This lead to broken scaling when e.g. reloading a graph (for instance when changing plot style).

This fixes that bug.