### PR TITLE
WIP: fix scaling in plot settings

### DIFF
--- a/data/ui/window.blp
+++ b/data/ui/window.blp
@@ -562,7 +562,7 @@ menu view_menu {
     item (_("Optimize Limits"), "app.optimize_limits")
   }
   section {
-    submenu {
+    submenu top_scale {
       label: _("Top X Scale");
       item {
         label: _("Logarithmic");
@@ -575,7 +575,7 @@ menu view_menu {
         target: "linear";
       }
     }
-    submenu {
+    submenu bottom_scale {
       label: _("Bottom X Scale");
       item {
         label: _("Logarithmic");
@@ -588,7 +588,7 @@ menu view_menu {
         target: "linear";
       }
     }
-    submenu {
+    submenu left_scale {
       label: _("Left Y Scale");
       item {
         label: _("Logarithmic");
@@ -601,7 +601,7 @@ menu view_menu {
         target: "linear";
       }
     }
-    submenu {
+    submenu right_scale {
       label: _("Right Y Scale");
       item {
         label: _("Logarithmic");

--- a/src/plot_settings.py
+++ b/src/plot_settings.py
@@ -106,6 +106,15 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
             != utilities.get_selected_chooser_item(self.custom_plot_style) \
             and self.props.application.preferences["override_style_change"]
 
+        self.scale_changed = \
+            plot_settings.xscale \
+            != utilities.get_selected_chooser_item(self.plot_x_scale) \
+            or plot_settings.yscale \
+            != utilities.get_selected_chooser_item(self.plot_y_scale) \
+            or plot_settings.top_scale \
+            != utilities.get_selected_chooser_item(self.plot_top_scale) \
+            or plot_settings.right_scale \
+            != utilities.get_selected_chooser_item(self.plot_right_scale) \
         # Set new plot settings
         plot_settings.title = self.plot_title.get_text()
         plot_settings.xlabel = self.plot_x_label.get_text()
@@ -158,6 +167,10 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
             clipboard.add(self.props.application)
             graphs.reload(self.props.application)
             ui.reload_item_menu(self.props.application)
+        elif self.scale_changed:
+            self.props.application.canvas.toolbar.push_current()
+            # Trigger axis change and set correct value in menu!
+            graphs.reload(self.props.application)
         else:
             self.props.application.canvas.toolbar.push_current()
             graphs.refresh(self.props.application)

--- a/src/window.py
+++ b/src/window.py
@@ -27,6 +27,10 @@ class GraphsWindow(Adw.ApplicationWindow):
     translate_y_entry = Gtk.Template.Child()
     multiply_x_entry = Gtk.Template.Child()
     multiply_y_entry = Gtk.Template.Child()
+    top_scale = Gtk.Template.Child()
+    left_scale = Gtk.Template.Child()
+    bottom_scale = Gtk.Template.Child()
+    right_scale = Gtk.Template.Child()
     toast_overlay = Gtk.Template.Child()
 
     def add_toast(self, title):


### PR DESCRIPTION
Currently when the scaling of an item is set in the Plot Settings menu, the new scale is not automatically loaded, because it only refreshes the graph.

Even when triggering a reload of the graph however, the scale items in the view menu are not automatically set to the correct scaling either. This is where I needed to dig a bit into the documentation, as I couldn't immediately find out how to programmatically set a new value for these items.

However, I was also considering removing these scalings from the plot settings all together, as these scalings are also directly available in the menu itself, which you need to click anyway to get to that scaling. Opinions on that (or suggestions how to set the scaling in the view menu programmatically) are welcome of course.