### PR TITLE
Limit workflow runs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,10 @@
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 name: CI
 jobs:
   flatpak:


### PR DESCRIPTION
Currently workflows are run on every push and every pr. This changes that to only run for pushes directly to main and any pr that is targeted to main. This eliminates duplicate workflows, when pushing to a branch, that is already a pr