### PR TITLE
Minor transparency improvements

### DIFF
--- a/src/item_box.py
+++ b/src/item_box.py
@@ -56,11 +56,16 @@ class ItemBox(Gtk.Box):
 
     def update_color(self):
         self.provider.load_from_data(
-            f"button {{ color: {self.item.color}; }}", -1)
+            ("button {"
+             f" color: {self.item.color};"
+             f" opacity: {self.item.alpha};"
+             "}"),
+            -1)
 
     @Gtk.Template.Callback()
     def choose_color(self, _):
         color = utilities.hex_to_rgba(self.item.color)
+        color.alpha = self.item.alpha
         dialog = Gtk.ColorDialog()
         dialog.set_with_alpha(False)
         dialog.choose_rgba(


### PR DESCRIPTION
- Set the transparency in the color button as well
- Load the transparency correctly when choosing a new color. In the current main branch, when the color button is clicked, the actively selected colour is the non-transparent one. So pressing OK without doing any changes will make the item lose its transparency.