### PR TITLE
Set view back/forward on undo/redo

### DIFF
--- a/src/clipboard.py
+++ b/src/clipboard.py
@@ -43,7 +43,7 @@ def undo(self):
     if self.clipboard_pos < -1:
         self.main_window.redo_button.set_sensitive(True)
     graphs.check_open_data(self)
-    actions.view_back_action(None,None,self)
+    actions.view_back_action(None, None, self)
     ui.reload_item_menu(self)
 
 
@@ -61,5 +61,5 @@ def redo(self):
     if self.clipboard_pos >= -1:
         self.main_window.redo_button.set_sensitive(False)
     graphs.check_open_data(self)
-    actions.view_forward_action(None,None,self)
+    actions.view_forward_action(None, None, self)
     ui.reload_item_menu(self)

--- a/src/clipboard.py
+++ b/src/clipboard.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 import copy
 
-from graphs import graphs, ui
+from graphs import actions, graphs, ui
 
 
 def add(self):
@@ -43,6 +43,7 @@ def undo(self):
     if self.clipboard_pos < -1:
         self.main_window.redo_button.set_sensitive(True)
     graphs.check_open_data(self)
+    actions.view_back_action(None,None,self)
     ui.reload_item_menu(self)
 
 
@@ -60,4 +61,5 @@ def redo(self):
     if self.clipboard_pos >= -1:
         self.main_window.redo_button.set_sensitive(False)
     graphs.check_open_data(self)
+    actions.view_forward_action(None,None,self)
     ui.reload_item_menu(self)


### PR DESCRIPTION
Sets the view back or forwards on an undo and redo action, so that the view is also reset to the state before the action was performed. 