### PR TITLE
Use better Error Handling.

### DIFF
--- a/src/file_import.py
+++ b/src/file_import.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from gi.repository import Adw, Gtk
 
 from graphs import file_io, graphs, misc, utilities
+from graphs.misc import ImportError
 
 
 IMPORT_MODES = ["project", "xrdml", "xry", "columns"]
@@ -42,21 +43,8 @@ def import_from_files(self, import_settings_list):
     for import_settings in import_settings_list:
         try:
             items.extend(_import_from_file(self, import_settings))
-        except IndexError:
-            message = \
-                _("Could not open data, the column index is out of range")
-            self.main_window.add_toast(message)
-            logging.exception(message)
-            continue
-        except UnicodeDecodeError:
-            message = _("Could not open data, wrong filetype")
-            self.main_window.add_toast(message)
-            logging.exception(message)
-            continue
-        except ValueError as error:
-            message = error.message
-            self.main_window.add_toast(message)
-            logging.exception(message)
+        except ImportError as error:
+            self.main_window.add_toast(error.message)
             continue
     graphs.add_items(self, items)
 

--- a/src/file_import.py
+++ b/src/file_import.py
@@ -1,12 +1,10 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
-import logging
-from gettext import gettext as _
 from pathlib import Path
 
 from gi.repository import Adw, Gtk
 
 from graphs import file_io, graphs, misc, utilities
-from graphs.misc import ImportError
+from graphs.misc import ParseError
 
 
 IMPORT_MODES = ["project", "xrdml", "xry", "columns"]
@@ -43,7 +41,7 @@ def import_from_files(self, import_settings_list):
     for import_settings in import_settings_list:
         try:
             items.extend(_import_from_file(self, import_settings))
-        except ImportError as error:
+        except ParseError as error:
             self.main_window.add_toast(error.message)
             continue
     graphs.add_items(self, items)

--- a/src/file_io.py
+++ b/src/file_io.py
@@ -34,7 +34,7 @@ def save_project(file, plot_settings, datadict, datadict_clipboard,
 
 
 def read_project(file):
-    project = pickle.loads(_read_file(file))
+    project = pickle.loads(_read_file(file, None))
     return \
         project["plot_settings"], project["data"], \
         project["datadict_clipboard"], project["clipboard_pos"], \
@@ -266,4 +266,5 @@ def _write_string(stream, line, encoding="utf-8"):
 
 
 def _read_file(file, encoding="utf-8"):
-    return file.load_bytes(None)[0].get_data().decode(encoding)
+    content = file.load_bytes(None)[0].get_data()
+    return content if encoding is None else content.decode(encoding)

--- a/src/file_io.py
+++ b/src/file_io.py
@@ -11,7 +11,7 @@ from gi.repository import GLib
 
 from graphs import utilities
 from graphs.item import Item, TextItem
-from graphs.misc import ImportError
+from graphs.misc import ParseError
 
 from matplotlib import RcParams, cbook
 from matplotlib.style.core import STYLE_BLACKLIST
@@ -92,7 +92,7 @@ def import_from_xry(self, import_settings):
     lines = \
         _read_file(import_settings.file, encoding="ISO-8859-1").splitlines()
     if lines[0].strip() != "XR01":
-        raise ImportError(_("Invalid .xry format"))
+        raise ParseError(_("Invalid .xry format"))
 
     b_params = lines[4].strip().split()
     b_min = float(b_params[0])
@@ -143,7 +143,7 @@ def import_from_columns(self, import_settings):
                         item.xdata.append(float(data_line[params["column_x"]]))
                         item.ydata.append(float(data_line[params["column_y"]]))
                     except IndexError:
-                        raise ImportError(
+                        raise ParseError(
                             _("Import failed, column index out of range"))
             # If not all values in the line are floats, start looking for
             # headers instead
@@ -167,7 +167,7 @@ def import_from_columns(self, import_settings):
                     except IndexError:
                         pass
     if not item.xdata:
-        raise ImportError(_(f"Unable to import from file"))
+        raise ParseError(_("Unable to import from file"))
     return [item]
 
 

--- a/src/file_io.py
+++ b/src/file_io.py
@@ -11,6 +11,7 @@ from gi.repository import GLib
 
 from graphs import utilities
 from graphs.item import Item, TextItem
+from graphs.misc import ImportError
 
 from matplotlib import RcParams, cbook
 from matplotlib.style.core import STYLE_BLACKLIST
@@ -90,6 +91,8 @@ def import_from_xry(self, import_settings):
     """Import data from .xry files used by Leybold X-ray apparatus."""
     lines = \
         _read_file(import_settings.file, encoding="ISO-8859-1").splitlines()
+    if lines[0].strip() != "XR01":
+        raise ImportError(_("Invalid .xry format"))
 
     b_params = lines[4].strip().split()
     b_min = float(b_params[0])
@@ -127,8 +130,7 @@ def import_from_columns(self, import_settings):
     params = import_settings.params
     for i, line in enumerate(_read_file(import_settings.file).splitlines()):
         if i >= params["skip_rows"]:
-            line = line.strip()
-            data_line = re.split(str(params["delimiter"]), line)
+            data_line = re.split(str(params["delimiter"]), line.strip())
             if params["separator"] == ",":
                 for index, value in enumerate(data_line):
                     data_line[index] = utilities.swap(value)
@@ -137,8 +139,12 @@ def import_from_columns(self, import_settings):
                     item.xdata.append(i)
                     item.ydata.append(float(data_line[0]))
                 else:
-                    item.xdata.append(float(data_line[params["column_x"]]))
-                    item.ydata.append(float(data_line[params["column_y"]]))
+                    try:
+                        item.xdata.append(float(data_line[params["column_x"]]))
+                        item.ydata.append(float(data_line[params["column_y"]]))
+                    except IndexError:
+                        raise ImportError(
+                            _("Import failed, column index out of range"))
             # If not all values in the line are floats, start looking for
             # headers instead
             else:
@@ -160,6 +166,8 @@ def import_from_columns(self, import_settings):
                     # If neither heuristic works, we just skip headers
                     except IndexError:
                         pass
+    if not item.xdata:
+        raise ImportError(_(f"Unable to import from file"))
     return [item]
 
 

--- a/src/misc.py
+++ b/src/misc.py
@@ -37,6 +37,12 @@ class InteractionMode(Enum):
     SELECT = 3
 
 
+class ImportError(Exception):
+    def __init__(self, message):
+        self.message = message
+        super().__init__(self.message)
+
+
 # Translatable lists
 def _(message):
     return message

--- a/src/misc.py
+++ b/src/misc.py
@@ -37,7 +37,7 @@ class InteractionMode(Enum):
     SELECT = 3
 
 
-class ImportError(Exception):
+class ParseError(Exception):
     def __init__(self, message):
         self.message = message
         super().__init__(self.message)


### PR DESCRIPTION
Instead of catching every possible Error in the caller function, raise
an ImportError with a translatable message with each respective error.

Signed-off-by: Christoph Matthias Kohnen <christoph.kohnen@disroot.org>
