### PR TITLE
Refactor clipboard

### DIFF
--- a/src/actions.py
+++ b/src/actions.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 """Main actions."""
-from graphs import clipboard, graphs, plotting_tools, ui
+from graphs import graphs, plotting_tools, ui
 from graphs.add_equation import AddEquationWindow
 from graphs.export_figure import ExportFigureWindow
 from graphs.plot_settings import PlotSettingsWindow
@@ -58,11 +58,11 @@ def select_none_action(_action, _target, self):
 
 
 def undo_action(_action, _target, self):
-    clipboard.undo(self)
+    self.Clipboard.undo()
 
 
 def redo_action(_action, _target, self):
-    clipboard.redo(self)
+    self.Clipboard.redo()
 
 
 def optimize_limits_action(_action, _target, self):

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -52,7 +52,7 @@ class Canvas(FigureCanvas):
                      self.top_right_axis]:
             axis.get_xaxis().set_visible(False)
             axis.get_yaxis().set_visible(False)
-        self.dummy_toolbar = DummyToolbar(self)
+        DummyToolbar(self)
         self.highlight = Highlight(self)
 
     # Temporarily overwritten function, see

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -136,7 +136,7 @@ class Canvas(FigureCanvas):
         plot_settings.max_right = max(self.right_axis.get_ylim())
 
     def get_limits(self):
-        limits = {
+        return {
             "min_bottom": min(self.axis.get_xlim()),
             "max_bottom": max(self.axis.get_xlim()),
             "min_top": min(self.top_left_axis.get_xlim()),
@@ -146,7 +146,6 @@ class Canvas(FigureCanvas):
             "min_right": min(self.right_axis.get_ylim()),
             "max_right": max(self.right_axis.get_ylim()),
         }
-        return limits
 
     def set_axis_properties(self):
         """Set the properties that are related to the axes."""

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -52,7 +52,7 @@ class Canvas(FigureCanvas):
                      self.top_right_axis]:
             axis.get_xaxis().set_visible(False)
             axis.get_yaxis().set_visible(False)
-        DummyToolbar(self)
+        self.dummy_toolbar = DummyToolbar(self)
         self.highlight = Highlight(self)
 
     # Temporarily overwritten function, see

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -135,6 +135,19 @@ class Canvas(FigureCanvas):
         plot_settings.min_right = min(self.right_axis.get_ylim())
         plot_settings.max_right = max(self.right_axis.get_ylim())
 
+    def get_limits(self):
+        limits = {
+            "min_bottom": min(self.axis.get_xlim()),
+            "max_bottom": max(self.axis.get_xlim()),
+            "min_top": min(self.top_left_axis.get_xlim()),
+            "max_top": max(self.top_left_axis.get_xlim()),
+            "min_left": min(self.axis.get_ylim()),
+            "max_left": max(self.axis.get_ylim()),
+            "min_right": min(self.right_axis.get_ylim()),
+            "max_right": max(self.right_axis.get_ylim()),
+        }
+        return limits
+
     def set_axis_properties(self):
         """Set the properties that are related to the axes."""
         plot_settings = self.application.plot_settings

--- a/src/clipboard.py
+++ b/src/clipboard.py
@@ -61,7 +61,7 @@ class Clipboard:
             self.application.main_window.redo_button.set_sensitive(True)
         graphs.check_open_data(self.application)
         ui.reload_item_menu(self.application)
-        self.application.canvas.dummy_toolbar.push_current()
+        self.application.canvas.toolbar.push_current()
 
     def redo(self):
         """

--- a/src/clipboard.py
+++ b/src/clipboard.py
@@ -61,6 +61,7 @@ class Clipboard:
             self.application.main_window.redo_button.set_sensitive(True)
         graphs.check_open_data(self.application)
         ui.reload_item_menu(self.application)
+        self.application.canvas.dummy_toolbar.push_current()
 
     def redo(self):
         """
@@ -79,6 +80,7 @@ class Clipboard:
             self.application.main_window.redo_button.set_sensitive(False)
         graphs.check_open_data(self.application)
         ui.reload_item_menu(self.application)
+        self.application.canvas.dummy_toolbar.push_current()
 
     def clear(self):
         """Clear the clipboard to the initial state"""

--- a/src/clipboard.py
+++ b/src/clipboard.py
@@ -81,9 +81,7 @@ class Clipboard:
         ui.reload_item_menu(self.application)
 
     def clear(self):
-        """
-        Clear the clipboard to the initial state
-        """
+        """Clear the clipboard to the initial state"""
         self.datadict_clipboard = [{}]
         self.limits_clipboard = [self.application.canvas.get_limits()]
         self.clipboard_pos = -1

--- a/src/clipboard.py
+++ b/src/clipboard.py
@@ -12,6 +12,7 @@ class Clipboard:
         self.clipboard_pos = -1
 
     def __setitem__(self, key, value):
+        """Allow to set the attributes in the Clipboard like a dictionary"""
         setattr(self, key, value)
 
     def add(self):

--- a/src/clipboard.py
+++ b/src/clipboard.py
@@ -4,60 +4,82 @@ import copy
 from graphs import graphs, ui
 
 
-def add(self):
-    """
-    Add data to the clipboard, is performed whenever an action is performed.
-    Appends the latest state to the clipboard.
-    """
-    self.main_window.undo_button.set_sensitive(True)
+class Clipboard:
+    def __init__(self, application):
+        self.application = application
+        self.datadict_clipboard = [{}]
+        self.limits_clipboard = [self.application.canvas.get_limits()]
+        self.clipboard_pos = -1
 
-    # If a couple of redo"s were performed previously, it deletes the clipboard
-    # data that is located after the current clipboard position and disables
-    # the redo button
-    if self.clipboard_pos != -1:
-        self.datadict_clipboard = \
-            self.datadict_clipboard[:self.clipboard_pos + 1]
+    def add(self):
+        """
+        Add data to the clipboard, is performed whenever an action is performed
+        Appends the latest state to the clipboard.
+        """
+        self.application.main_window.undo_button.set_sensitive(True)
 
-    self.clipboard_pos = -1
-    self.datadict_clipboard.append(copy.deepcopy(self.datadict))
-    if len(self.datadict_clipboard) > \
-            int(self.preferences["clipboard_length"]) + 1:
-        self.datadict_clipboard = \
-            self.datadict_clipboard[1:]
+        # If a couple of redo"s were performed previously, it deletes the
+        # clipboard data that is located after the current clipboard position
+        # and disables the redo button
+        if self.clipboard_pos != -1:
+            self.datadict_clipboard = \
+                self.datadict_clipboard[:self.clipboard_pos + 1]
+            self.limits_clipboard = \
+                self.limits_clipboard[:self.clipboard_pos + 1]
 
-    self.main_window.redo_button.set_sensitive(False)
+        self.clipboard_pos = -1
+        self.limits_clipboard.append(self.application.canvas.get_limits())
+        self.datadict_clipboard.append(
+            copy.deepcopy(self.application.datadict))
+        if len(self.datadict_clipboard) > \
+                int(self.application.preferences["clipboard_length"]) + 1:
+            self.datadict_clipboard = self.datadict_clipboard[1:]
+            self.limits_clipboard = self.limits_clipboard[1:]
 
+        self.application.main_window.redo_button.set_sensitive(False)
 
-def undo(self):
-    """
-    Undo an action, moves the clipboard position backwards by one and changes
-    the dataset to the state before the previous action was performed
-    """
-    if abs(self.clipboard_pos) < len(self.datadict_clipboard):
-        self.clipboard_pos -= 1
-        self.datadict = \
-            copy.deepcopy(self.datadict_clipboard[self.clipboard_pos])
+    def undo(self):
+        """
+        Undo an action, moves the clipboard position backwards by one and
+        changes the dataset to the state before the previous action was
+        performed
+        """
+        if abs(self.clipboard_pos) < len(self.datadict_clipboard):
+            self.clipboard_pos -= 1
+            self.application.canvas.set_limits(
+                self.limits_clipboard[self.clipboard_pos])
+            self.application.datadict = \
+                copy.deepcopy(self.datadict_clipboard[self.clipboard_pos])
 
-    if abs(self.clipboard_pos) >= len(self.datadict_clipboard):
-        self.main_window.undo_button.set_sensitive(False)
-    if self.clipboard_pos < -1:
-        self.main_window.redo_button.set_sensitive(True)
-    graphs.check_open_data(self)
-    ui.reload_item_menu(self)
+        if abs(self.clipboard_pos) >= len(self.datadict_clipboard):
+            self.application.main_window.undo_button.set_sensitive(False)
+        if self.clipboard_pos < -1:
+            self.application.main_window.redo_button.set_sensitive(True)
+        graphs.check_open_data(self.application)
+        ui.reload_item_menu(self.application)
 
+    def redo(self):
+        """
+        Redo an action, moves the clipboard position forwards by one and
+        changes the dataset to the state before the previous action was undone
+        """
+        if self.clipboard_pos < -1:
+            self.clipboard_pos += 1
+            self.application.datadict = \
+                copy.deepcopy(self.datadict_clipboard[self.clipboard_pos])
+            self.application.canvas.set_limits(
+                self.limits_clipboard[self.clipboard_pos])
+            self.application.main_window.undo_button.set_sensitive(True)
 
-def redo(self):
-    """
-    Redo an action, moves the clipboard position forwards by one and changes
-    the dataset to the state before the previous action was undone
-    """
-    if self.clipboard_pos < -1:
-        self.clipboard_pos += 1
-        self.datadict = \
-            copy.deepcopy(self.datadict_clipboard[self.clipboard_pos])
-        self.main_window.undo_button.set_sensitive(True)
+        if self.clipboard_pos >= -1:
+            self.application.main_window.redo_button.set_sensitive(False)
+        graphs.check_open_data(self.application)
+        ui.reload_item_menu(self.application)
 
-    if self.clipboard_pos >= -1:
-        self.main_window.redo_button.set_sensitive(False)
-    graphs.check_open_data(self)
-    ui.reload_item_menu(self)
+    def clear(self):
+        """
+        Clear the clipboard to the initial state
+        """
+        self.datadict_clipboard = [{}]
+        self.limits_clipboard = [self.application.canvas.get_limits()]
+        self.clipboard_pos = -1

--- a/src/clipboard.py
+++ b/src/clipboard.py
@@ -80,7 +80,7 @@ class Clipboard:
             self.application.main_window.redo_button.set_sensitive(False)
         graphs.check_open_data(self.application)
         ui.reload_item_menu(self.application)
-        self.application.canvas.dummy_toolbar.push_current()
+        self.application.canvas.toolbar.push_current()
 
     def clear(self):
         """Clear the clipboard to the initial state"""

--- a/src/clipboard.py
+++ b/src/clipboard.py
@@ -11,6 +11,9 @@ class Clipboard:
         self.limits_clipboard = [self.application.canvas.get_limits()]
         self.clipboard_pos = -1
 
+    def __setitem__(self, key, value):
+        setattr(self, key, value)
+
     def add(self):
         """
         Add data to the clipboard, is performed whenever an action is performed

--- a/src/edit_item.py
+++ b/src/edit_item.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 from gi.repository import Adw, Gtk
 
-from graphs import clipboard, graphs, misc, plotting_tools, ui, utilities
+from graphs import graphs, misc, plotting_tools, ui, utilities
 from graphs.item import Item
 
 
@@ -52,8 +52,6 @@ class EditItemWindow(Adw.PreferencesWindow):
         if set(names) != set(self.item_selector.untranslated_items):
             utilities.populate_chooser(self.item_selector, names, False)
             self.item_selector.set_selected(index)
-            self.props.application.datadict_clipboard = \
-                self.props.application.datadict_clipboard[:-1]
 
     def load_values(self):
         self.set_title(self.item.name)
@@ -92,7 +90,7 @@ class EditItemWindow(Adw.PreferencesWindow):
         if isinstance(self.item, Item):
             self.apply_item_values()
         ui.reload_item_menu(self.props.application)
-        clipboard.add(self.props.application)
+        self.props.application.Clipboard.add()
         graphs.refresh(self.props.application)
         if set_limits:
             plotting_tools.optimize_limits(self.props.application)

--- a/src/file_io.py
+++ b/src/file_io.py
@@ -40,9 +40,7 @@ def save_project(file, plot_settings, datadict, clipboard, version):
 def read_project(file):
     project = pickle.loads(_read_file(file, None))
     project_items = ["plot_settings", "data", "clipboard", "version"]
-    for item in project_items:
-        if item not in project:
-            project[item] = None
+    project.extend({key, None for key in project_items if key not in project})
     return \
         project["plot_settings"], project["data"], \
         project["clipboard"], project["version"]

--- a/src/file_io.py
+++ b/src/file_io.py
@@ -40,7 +40,7 @@ def save_project(file, plot_settings, datadict, clipboard, version):
 def read_project(file):
     project = pickle.loads(_read_file(file, None))
     project_items = ["plot_settings", "data", "clipboard", "version"]
-    project.extend({key, None for key in project_items if key not in project})
+    project.extend({key: None for key in project_items if key not in project})
     return \
         project["plot_settings"], project["data"], \
         project["clipboard"], project["version"]

--- a/src/file_io.py
+++ b/src/file_io.py
@@ -19,13 +19,11 @@ from matplotlib.style.core import STYLE_BLACKLIST
 import numpy
 
 
-def save_project(file, plot_settings, datadict, datadict_clipboard,
-                 clipboard_pos, version):
+def save_project(file, plot_settings, datadict, clipboard, version):
     project_data = {
         "plot_settings": plot_settings,
         "data": datadict,
-        "datadict_clipboard": datadict_clipboard,
-        "clipboard_pos": clipboard_pos,
+        "clipboard": clipboard,
         "version": version,
     }
     stream = _get_write_stream(file)
@@ -35,10 +33,13 @@ def save_project(file, plot_settings, datadict, datadict_clipboard,
 
 def read_project(file):
     project = pickle.loads(_read_file(file, None))
+    project_items = ["plot_settings", "data", "clipboard", "version"]
+    for item in project_items:
+        if item not in project:
+            project[item] = None
     return \
         project["plot_settings"], project["data"], \
-        project["datadict_clipboard"], project["clipboard_pos"], \
-        project["version"]
+        project["clipboard"], project["version"]
 
 
 def save_item(file, item):

--- a/src/file_io.py
+++ b/src/file_io.py
@@ -20,10 +20,16 @@ import numpy
 
 
 def save_project(file, plot_settings, datadict, clipboard, version):
+
+    clipboard_dict = {
+        "datadict_clipboard": clipboard.datadict_clipboard,
+        "limits_clipboard": clipboard.limits_clipboard,
+        "clipboard_pos": clipboard.clipboard_pos,
+    }
     project_data = {
         "plot_settings": plot_settings,
         "data": datadict,
-        "clipboard": clipboard,
+        "clipboard": clipboard_dict,
         "version": version,
     }
     stream = _get_write_stream(file)

--- a/src/graphs.py
+++ b/src/graphs.py
@@ -18,19 +18,19 @@ def open_project(self, file):
         new_plot_settings, new_datadict, clipboard, version = \
             file_io.read_project(file)
         utilities.set_attributes(new_plot_settings, self.plot_settings)
-
-        # Set attributes
-        if clipboard is None:
-            # Use empty clipboard if not in project file for older versions
-            # of Graphs
-            self.Clipboard.clear()
-        else:
-            self.Clipboard = clipboard
+        self.Clipboard.clear()
         self.plot_settings = new_plot_settings
         self.datadict = {}
         add_items(self,
                   [utilities.check_item(self, item)
                    for item in new_datadict.values()])
+
+        # Set attributes
+        if clipboard is not None:
+            for key, value in clipboard.items():
+                self.Clipboard[key] = value
+        self.canvas.set_limits(self.Clipboard.limits_clipboard[-1])
+        refresh(self)
     except (EOFError, UnpicklingError):
         message = _("Could not open project")
         self.main_window.add_toast(message)

--- a/src/graphs.py
+++ b/src/graphs.py
@@ -25,7 +25,7 @@ def open_project(self, file):
                   [utilities.check_item(self, item)
                    for item in new_datadict.values()])
 
-        # Set attributes
+        # Set clipboard
         if clipboard is not None:
             for key, value in clipboard.items():
                 self.Clipboard[key] = value

--- a/src/item_box.py
+++ b/src/item_box.py
@@ -3,7 +3,7 @@ import contextlib
 
 from gi.repository import GLib, Gdk, Gtk
 
-from graphs import clipboard, graphs, ui, utilities
+from graphs import graphs, ui, utilities
 from graphs.edit_item import EditItemWindow
 
 
@@ -44,7 +44,7 @@ class ItemBox(Gtk.Box):
         self.application.datadict = utilities.change_key_position(
             self.application.datadict, drop_target.key, value)
         ui.reload_item_menu(self.application)
-        clipboard.add(self.application)
+        self.application.Clipboard.add()
         graphs.refresh(self.application)
 
     def on_dnd_prepare(self, drag_source, x, y):
@@ -80,7 +80,7 @@ class ItemBox(Gtk.Box):
                 self.item.color = utilities.rgba_to_hex(color).upper()
                 self.item.alpha = color.alpha
                 self.update_color()
-                clipboard.add(self.application)
+                self.application.Clipboard.add()
                 graphs.refresh(self.application)
 
     @Gtk.Template.Callback()

--- a/src/main.py
+++ b/src/main.py
@@ -9,6 +9,7 @@ from gi.repository import Adw, GLib, Gio
 
 from graphs import actions, file_io, plot_styles, plotting_tools, ui
 from graphs.canvas import Canvas
+from graphs.clipboard import Clipboard
 from graphs.misc import InteractionMode, PlotSettings
 from graphs.preferences import Preferences
 from graphs.window import GraphsWindow
@@ -31,9 +32,6 @@ class GraphsApplication(Adw.Application):
         self.issues = args[5]
         self.author = args[6]
         self.pkgdatadir = args[7]
-        self.datadict = {}
-        self.datadict_clipboard = [{}]
-        self.clipboard_pos = -1
         self.highlight = None
         font_list = font_manager.findSystemFonts(fontpaths=None, fontext="ttf")
         for font in font_list:
@@ -121,6 +119,7 @@ class GraphsApplication(Adw.Application):
         pyplot.rcParams.update(
             file_io.parse_style(plot_styles.get_preferred_style(self)))
         self.canvas = Canvas(self)
+        self.Clipboard = Clipboard(self)
         self.main_window.toast_overlay.set_child(self.canvas)
         self.main_window.redo_button.set_sensitive(False)
         self.main_window.undo_button.set_sensitive(False)

--- a/src/main.py
+++ b/src/main.py
@@ -33,6 +33,7 @@ class GraphsApplication(Adw.Application):
         self.author = args[6]
         self.pkgdatadir = args[7]
         self.highlight = None
+        self.datadict = {}
         font_list = font_manager.findSystemFonts(fontpaths=None, fontext="ttf")
         for font in font_list:
             try:

--- a/src/operations.py
+++ b/src/operations.py
@@ -2,7 +2,7 @@
 import logging
 from gettext import gettext as _
 
-from graphs import calculation, clipboard, graphs, plotting_tools
+from graphs import calculation, graphs, plotting_tools
 from graphs.item import Item
 from graphs.misc import InteractionMode
 
@@ -83,10 +83,9 @@ def perform_operation(self, callback, *args):
     if not data_selected:
         self.main_window.add_toast(
             _("No data found within the highlighted area"))
-
-    clipboard.add(self)
     graphs.refresh(self)
     plotting_tools.optimize_limits(self)
+    self.Clipboard.add()
 
 
 def translate_x(_item, xdata, ydata, offset):

--- a/src/plot_settings.py
+++ b/src/plot_settings.py
@@ -163,4 +163,4 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
         else:
             self.props.application.canvas.toolbar.push_current()
             graphs.refresh(self.props.application)
-        self.props.application.Clipboard.add()        
+        self.props.application.Clipboard.add()

--- a/src/plot_settings.py
+++ b/src/plot_settings.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 from gi.repository import Adw, Gtk
 
-from graphs import (clipboard, file_io, graphs, misc, plot_styles,
+from graphs import (file_io, graphs, misc, plot_styles,
                     plotting_tools, ui, utilities)
 
 from matplotlib import pyplot
@@ -158,9 +158,9 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
                 item.markerstyle = pyplot.rcParams["lines.marker"]
                 item.markersize = \
                     float(pyplot.rcParams["lines.markersize"])
-            clipboard.add(self.props.application)
             graphs.reload(self.props.application)
             ui.reload_item_menu(self.props.application)
+            self.Clipboard.add()
         else:
             self.props.application.canvas.toolbar.push_current()
             graphs.refresh(self.props.application)

--- a/src/plot_settings.py
+++ b/src/plot_settings.py
@@ -160,7 +160,7 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
                     float(pyplot.rcParams["lines.markersize"])
             graphs.reload(self.props.application)
             ui.reload_item_menu(self.props.application)
-            self.Clipboard.add()
         else:
             self.props.application.canvas.toolbar.push_current()
             graphs.refresh(self.props.application)
+        self.props.application.Clipboard.add()        

--- a/src/ui.py
+++ b/src/ui.py
@@ -48,6 +48,7 @@ def add_data_dialog(self):
 
 def save_project_dialog(self):
     def on_response(dialog, response):
+        self.Clipboard.limits_clipboard[-1] = self.canvas.get_limits()
         with contextlib.suppress(GLib.GError):
             file = dialog.save_finish(response)
             file_io.save_project(

--- a/src/ui.py
+++ b/src/ui.py
@@ -51,8 +51,8 @@ def save_project_dialog(self):
         with contextlib.suppress(GLib.GError):
             file = dialog.save_finish(response)
             file_io.save_project(
-                file, self.plot_settings, self.datadict,
-                self.datadict_clipboard, self.clipboard_pos, self.version)
+                file, self.plot_settings, self.datadict, self.Clipboard,
+                self.version)
     dialog = Gtk.FileDialog()
     dialog.set_filters(
         utilities.create_file_filters([(_("Graphs Project File"),


### PR DESCRIPTION
This refactors the clipboard into its own class. The main reasoning was that this allowed to save the associated limits for each state to the clipboard state. This way, when undoing a certain action, the axes reset also to the state that was present at the time before that action was performed.

See old behaviour here: https://github-production-user-asset-6210df.s3.amazonaws.com/68477016/247573650-9c9dbaaf-b8d3-459b-8c68-0210445b2c33.webm

And new behaviour in this PR here:
[Screencast from 2023-04-02 21-15-03.webm](https://github.com/Sjoerd1993/Graphs/assets/68477016/bbc035d5-ef6b-4310-9951-0f3858b89d8a)

Another thing in the behaviour that has changed is that when opening a project, it automatically reloads the limits that were set during the previous session. See video:

[Screencast from 2023-07-31 12-46-57.webm](https://github.com/Sjoerd1993/Graphs/assets/68477016/b9aca9cf-aa0b-4a56-a588-0d8e672b7347)
