### PR TITLE
Rework clipboard and view navigation

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -25,7 +25,7 @@ version = meson.project_version()
 project_name = meson.project_name()
 pkgdatadir = join_paths(prefix, datadir, meson.project_name())
 localedir = join_paths(prefix, get_option('localedir'))
-debug = get_option('buildtype') == 'debug'
+debug = get_option('buildtype') == 'debuag'
 
 if debug
   version += '-' + run_command('git', 'rev-parse', '--short', 'HEAD', check: true).stdout().strip()

--- a/src/actions.py
+++ b/src/actions.py
@@ -84,6 +84,7 @@ def view_forward_action(_action, _target, self):
         self.canvas.apply_limits()
         graphs.refresh(self)
 
+
 def export_data_action(_action, _target, self):
     ui.export_data_dialog(self)
 

--- a/src/actions.py
+++ b/src/actions.py
@@ -71,18 +71,18 @@ def optimize_limits_action(_action, _target, self):
 
 
 def view_back_action(_action, _target, self):
-    if self.canvas.toolbar.back_enabled:
-        self.canvas.toolbar.back()
+    if self.main_window.view_back_button.get_sensitive():
+        self.ViewClipboard.undo()
         self.canvas.apply_limits()
         # Fix weird view on back
         graphs.refresh(self)
 
 
 def view_forward_action(_action, _target, self):
-    if self.canvas.toolbar.forward_enabled:
-        self.canvas.toolbar.forward()
+    if self.main_window.view_forward_button.get_sensitive():
+        self.ViewClipboard.redo()
         self.canvas.apply_limits()
-
+        graphs.refresh(self)
 
 def export_data_action(_action, _target, self):
     ui.export_data_dialog(self)

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -289,6 +289,7 @@ class DummyToolbar(NavigationToolbar2):
     def push_current(self):
         super().push_current()
         self.canvas.apply_limits()
+        self.canvas.application.ViewClipboard.add()
 
     # Overwritten function - do not change name
     def set_history_buttons(self):

--- a/src/clipboard.py
+++ b/src/clipboard.py
@@ -39,7 +39,6 @@ class DataClipboard(BaseClipboard):
         Appends the latest state to the clipboard.
         """
         super().add(copy.deepcopy(self.application.datadict))
-
         # Keep clipboard length limited to preference values
         if len(self.clipboard) > \
                 int(self.application.preferences["clipboard_length"]) + 1:
@@ -63,7 +62,8 @@ class DataClipboard(BaseClipboard):
                 self.application.main_window.redo_button.set_sensitive(True)
             graphs.check_open_data(self.application)
             ui.reload_item_menu(self.application)
-            self.application.ViewClipboard.undo()
+            if self.application.ViewClipboard.view_changed:
+                self.application.ViewClipboard.undo()
 
     def redo(self):
 
@@ -82,8 +82,8 @@ class DataClipboard(BaseClipboard):
             self.application.main_window.redo_button.set_sensitive(False)
         graphs.check_open_data(self.application)
         ui.reload_item_menu(self.application)
-        self.application.ViewClipboard.redo()
-
+        if self.application.ViewClipboard.view_changed:
+            self.application.ViewClipboard.redo()
 
     def clear(self):
 
@@ -100,6 +100,7 @@ class ViewClipboard(BaseClipboard):
         self.clipboard = [self.application.canvas.get_limits()]
         self.undo_button = self.application.main_window.view_back_button
         self.redo_button = self.application.main_window.view_forward_button
+        self.view_changed = False
 
     def add(self):
 
@@ -107,13 +108,14 @@ class ViewClipboard(BaseClipboard):
         Add the latest view to the clipboard, skip in case the new view is
         the same as previous one (e.g. if an action does not change the limits)
         """
+        self.view_changed = False
         if self.application.canvas.get_limits() != self.clipboard[-1]:
             super().add(self.application.canvas.get_limits())
+            self.view_changed = True
 
     def undo(self):
 
         """Go back to the previous view"""
-
         if abs(self.clipboard_pos) < len(self.clipboard):
             self.clipboard_pos -= 1
             self.application.canvas.set_limits(

--- a/src/clipboard.py
+++ b/src/clipboard.py
@@ -126,7 +126,6 @@ class ViewClipboard(BaseClipboard):
 
     def redo(self):
         """Go back to the next view"""
-
         if self.clipboard_pos < -1:
             self.clipboard_pos += 1
             self.application.canvas.set_limits(

--- a/src/clipboard.py
+++ b/src/clipboard.py
@@ -64,10 +64,8 @@ class DataClipboard(BaseClipboard):
                 self.application.main_window.redo_button.set_sensitive(True)
             graphs.check_open_data(self.application)
             ui.reload_item_menu(self.application)
-            if self.application.ViewClipboard.view_changed:
-                self.application.ViewClipboard.add()
-                self.application.canvas.set_limits(
-                    self.clipboard[self.clipboard_pos]["view"])
+            self.application.canvas.set_limits(
+                self.clipboard[self.clipboard_pos]["view"])
 
     def redo(self):
         """
@@ -85,10 +83,8 @@ class DataClipboard(BaseClipboard):
             self.application.main_window.redo_button.set_sensitive(False)
         graphs.check_open_data(self.application)
         ui.reload_item_menu(self.application)
-        if self.application.ViewClipboard.view_changed:
-            self.application.ViewClipboard.add()
-            self.application.canvas.set_limits(
-                self.clipboard[self.clipboard_pos]["view"])
+        self.application.canvas.set_limits(
+            self.clipboard[self.clipboard_pos]["view"])
 
     def clear(self):
         """Clear the clipboard to the initial state"""
@@ -105,17 +101,14 @@ class ViewClipboard(BaseClipboard):
         self.clipboard = [self.application.canvas.get_limits()]
         self.undo_button = self.application.main_window.view_back_button
         self.redo_button = self.application.main_window.view_forward_button
-        self.view_changed = False
 
     def add(self):
         """
         Add the latest view to the clipboard, skip in case the new view is
         the same as previous one (e.g. if an action does not change the limits)
         """
-        self.view_changed = False
         if self.application.canvas.get_limits() != self.clipboard[-1]:
             super().add(self.application.canvas.get_limits())
-            self.view_changed = True
 
     def undo(self):
         """Go back to the previous view"""

--- a/src/clipboard.py
+++ b/src/clipboard.py
@@ -56,15 +56,17 @@ class DataClipboard(BaseClipboard):
             self.clipboard_pos -= 1
             self.application.datadict = \
                 copy.deepcopy(self.clipboard[self.clipboard_pos]["datadict"])
-            self.application.canvas.set_limits(
-                self.clipboard[self.clipboard_pos]["view"])
+
             if abs(self.clipboard_pos) >= len(self.clipboard):
                 self.application.main_window.undo_button.set_sensitive(False)
             if self.clipboard_pos < -1:
                 self.application.main_window.redo_button.set_sensitive(True)
             graphs.check_open_data(self.application)
             ui.reload_item_menu(self.application)
-            self.application.ViewClipboard.add()
+        if self.application.ViewClipboard.view_changed:
+            self.application.canvas.set_limits(
+                self.clipboard[self.clipboard_pos]["view"])
+        self.application.ViewClipboard.add()
 
 
 
@@ -86,6 +88,9 @@ class DataClipboard(BaseClipboard):
             self.application.main_window.redo_button.set_sensitive(False)
         graphs.check_open_data(self.application)
         ui.reload_item_menu(self.application)
+        if self.application.ViewClipboard.view_changed:
+            self.application.canvas.set_limits(
+                self.clipboard[self.clipboard_pos]["view"])
         self.application.ViewClipboard.add()
 
     def clear(self):

--- a/src/clipboard.py
+++ b/src/clipboard.py
@@ -20,7 +20,7 @@ class BaseClipboard:
         self.clipboard.append(new_state)
         self.redo_button.set_sensitive(False)
 
-    def __setitem__(self, key: str):
+    def __setitem__(self, key, value):
         """Allow to set the attributes in the Clipboard like a dictionary"""
         setattr(self, key, value)
 
@@ -28,10 +28,8 @@ class BaseClipboard:
 class DataClipboard(BaseClipboard):
     def __init__(self, application):
         super().__init__(application)
-        self.clipboard = [{
-                           "datadict": {},
-                           "view": self.application.canvas.get_limits()
-                          }]
+        self.clipboard = [{"datadict": {},
+                           "view": self.application.canvas.get_limits()}]
         self.undo_button = self.application.main_window.undo_button
         self.redo_button = self.application.main_window.redo_button
 
@@ -67,9 +65,9 @@ class DataClipboard(BaseClipboard):
             graphs.check_open_data(self.application)
             ui.reload_item_menu(self.application)
             if self.application.ViewClipboard.view_changed:
+                self.application.ViewClipboard.add()
                 self.application.canvas.set_limits(
                     self.clipboard[self.clipboard_pos]["view"])
-
 
     def redo(self):
         """
@@ -88,13 +86,14 @@ class DataClipboard(BaseClipboard):
         graphs.check_open_data(self.application)
         ui.reload_item_menu(self.application)
         if self.application.ViewClipboard.view_changed:
+            self.application.ViewClipboard.add()
             self.application.canvas.set_limits(
                 self.clipboard[self.clipboard_pos]["view"])
 
-
     def clear(self):
         """Clear the clipboard to the initial state"""
-        self.clipboard = [{}]
+        self.clipboard = [{"datadict": {},
+                           "view": self.application.canvas.get_limits()}]
         self.clipboard_pos = -1
 
 

--- a/src/clipboard.py
+++ b/src/clipboard.py
@@ -1,6 +1,5 @@
 import copy
 from graphs import graphs, ui
-from typing import Any
 
 
 class BaseClipboard:
@@ -21,7 +20,7 @@ class BaseClipboard:
         self.clipboard.append(new_state)
         self.redo_button.set_sensitive(False)
 
-    def __setitem__(self, key: str, value: Any) -> None:
+    def __setitem__(self, key: str) -> None:
         """Allow to set the attributes in the Clipboard like a dictionary"""
         setattr(self, key, value)
 
@@ -66,7 +65,6 @@ class DataClipboard(BaseClipboard):
                 self.application.ViewClipboard.undo()
 
     def redo(self):
-
         """
         Redo an action, moves the clipboard position forwards by one and
         changes the dataset to the state before the previous action was undone
@@ -86,7 +84,6 @@ class DataClipboard(BaseClipboard):
             self.application.ViewClipboard.redo()
 
     def clear(self):
-
         """Clear the clipboard to the initial state"""
         self.clipboard = [{}]
         self.clipboard_pos = -1
@@ -103,7 +100,6 @@ class ViewClipboard(BaseClipboard):
         self.view_changed = False
 
     def add(self):
-
         """
         Add the latest view to the clipboard, skip in case the new view is
         the same as previous one (e.g. if an action does not change the limits)
@@ -114,7 +110,6 @@ class ViewClipboard(BaseClipboard):
             self.view_changed = True
 
     def undo(self):
-
         """Go back to the previous view"""
         if abs(self.clipboard_pos) < len(self.clipboard):
             self.clipboard_pos -= 1
@@ -130,7 +125,6 @@ class ViewClipboard(BaseClipboard):
             self.clipboard[self.clipboard_pos])
 
     def redo(self):
-
         """Go back to the next view"""
 
         if self.clipboard_pos < -1:

--- a/src/clipboard.py
+++ b/src/clipboard.py
@@ -52,20 +52,21 @@ class DataClipboard(BaseClipboard):
         changes the dataset to the state before the previous action was
         performed
         """
-
         if abs(self.clipboard_pos) < len(self.clipboard):
             self.clipboard_pos -= 1
             self.application.datadict = \
                 copy.deepcopy(self.clipboard[self.clipboard_pos]["datadict"])
-
+            self.application.canvas.set_limits(
+                self.clipboard[self.clipboard_pos]["view"])
             if abs(self.clipboard_pos) >= len(self.clipboard):
                 self.application.main_window.undo_button.set_sensitive(False)
             if self.clipboard_pos < -1:
                 self.application.main_window.redo_button.set_sensitive(True)
             graphs.check_open_data(self.application)
             ui.reload_item_menu(self.application)
-            self.application.canvas.set_limits(
-                self.clipboard[self.clipboard_pos]["view"])
+            self.application.ViewClipboard.add()
+
+
 
     def redo(self):
         """
@@ -77,14 +78,15 @@ class DataClipboard(BaseClipboard):
             self.clipboard_pos += 1
             self.application.datadict = \
                 copy.deepcopy(self.clipboard[self.clipboard_pos]["datadict"])
+            self.application.canvas.set_limits(
+                self.clipboard[self.clipboard_pos]["view"])
             self.application.main_window.undo_button.set_sensitive(True)
 
         if self.clipboard_pos >= -1:
             self.application.main_window.redo_button.set_sensitive(False)
         graphs.check_open_data(self.application)
         ui.reload_item_menu(self.application)
-        self.application.canvas.set_limits(
-            self.clipboard[self.clipboard_pos]["view"])
+        self.application.ViewClipboard.add()
 
     def clear(self):
         """Clear the clipboard to the initial state"""
@@ -101,14 +103,17 @@ class ViewClipboard(BaseClipboard):
         self.clipboard = [self.application.canvas.get_limits()]
         self.undo_button = self.application.main_window.view_back_button
         self.redo_button = self.application.main_window.view_forward_button
+        self.view_changed = False
 
     def add(self):
         """
         Add the latest view to the clipboard, skip in case the new view is
         the same as previous one (e.g. if an action does not change the limits)
         """
+        self.view_changed = False
         if self.application.canvas.get_limits() != self.clipboard[-1]:
             super().add(self.application.canvas.get_limits())
+            self.view_changed = True
 
     def undo(self):
         """Go back to the previous view"""
@@ -122,8 +127,6 @@ class ViewClipboard(BaseClipboard):
         if self.clipboard_pos < -1:
             self.application.main_window.view_forward_button.set_sensitive(
                 True)
-        self.application.canvas.set_limits(
-            self.clipboard[self.clipboard_pos])
 
     def redo(self):
         """Go back to the next view"""

--- a/src/file_io.py
+++ b/src/file_io.py
@@ -52,12 +52,13 @@ def read_project(file):
     # Load empty values if attribute does not exist in Project file, to
     # ensure backwards compatibility with older project files
     project_items = ["plot_settings", "data", "data_clipboard",
-        "view_clipboard", "version"]
+                     "view_clipboard", "version"]
 
     project.update({key: None for key in project_items if key not in project})
     return \
         project["plot_settings"], project["data"], \
-        project["data_clipboard"], project["view_clipboard"], project["version"]
+        project["data_clipboard"], project["view_clipboard"], \
+        project["version"]
 
 
 def save_item(file, item):

--- a/src/file_io.py
+++ b/src/file_io.py
@@ -19,17 +19,26 @@ from matplotlib.style.core import STYLE_BLACKLIST
 import numpy
 
 
-def save_project(file, plot_settings, datadict, clipboard, version):
+def save_project(file, plot_settings, datadict, data_clipboard, view_clipboard,
+                 version):
 
-    clipboard_dict = {
-        "datadict_clipboard": clipboard.datadict_clipboard,
-        "limits_clipboard": clipboard.limits_clipboard,
-        "clipboard_pos": clipboard.clipboard_pos,
+    # Clipboards are saved as dictionaries because our custom classes cannot
+    # be pickled
+    data_clipboard_dict = {
+        "datadict_clipboard": data_clipboard.clipboard,
+        "data_clipboard_pos": data_clipboard.clipboard_pos,
     }
+
+    view_clipboard_dict = {
+        "view_clipboard": view_clipboard.clipboard,
+        "view_clipboard_pos": view_clipboard.clipboard_pos,
+    }
+
     project_data = {
         "plot_settings": plot_settings,
         "data": datadict,
-        "clipboard": clipboard_dict,
+        "data_clipboard": data_clipboard_dict,
+        "view_clipboard": view_clipboard_dict,
         "version": version,
     }
     stream = _get_write_stream(file)
@@ -39,11 +48,16 @@ def save_project(file, plot_settings, datadict, clipboard, version):
 
 def read_project(file):
     project = pickle.loads(_read_file(file, None))
-    project_items = ["plot_settings", "data", "clipboard", "version"]
-    project.extend({key: None for key in project_items if key not in project})
+
+    # Load empty values if attribute does not exist in Project file, to
+    # ensure backwards compatibility with older project files
+    project_items = ["plot_settings", "data", "data_clipboard",
+        "view_clipboard", "version"]
+
+    project.update({key: None for key in project_items if key not in project})
     return \
         project["plot_settings"], project["data"], \
-        project["clipboard"], project["version"]
+        project["data_clipboard"], project["view_clipboard"], project["version"]
 
 
 def save_item(file, item):

--- a/src/file_io.py
+++ b/src/file_io.py
@@ -25,14 +25,12 @@ def save_project(file, plot_settings, datadict, data_clipboard, view_clipboard,
     # Clipboards are saved as dictionaries because our custom classes cannot
     # be pickled
     data_clipboard_dict = {
-        "datadict_clipboard": data_clipboard.clipboard,
-        "data_clipboard_pos": data_clipboard.clipboard_pos,
+        "clipboard": data_clipboard.clipboard,
+        "clipboard_pos": data_clipboard.clipboard_pos,
     }
 
-    view_clipboard_dict = {
-        "view_clipboard": view_clipboard.clipboard,
-        "view_clipboard_pos": view_clipboard.clipboard_pos,
-    }
+    view_clipboard_dict = {"clipboard": view_clipboard.clipboard,
+                           "clipboard_pos": view_clipboard.clipboard_pos}
 
     project_data = {
         "plot_settings": plot_settings,

--- a/src/graphs.py
+++ b/src/graphs.py
@@ -42,6 +42,7 @@ def open_project(self, file):
         self.main_window.add_toast(message)
         logging.exception(message)
 
+
 def add_items(self, items):
     if not items:
         return

--- a/src/graphs.py
+++ b/src/graphs.py
@@ -18,6 +18,7 @@ def open_project(self, file):
         new_plot_settings, new_datadict, data_clipboard, view_clipboard, \
             version = file_io.read_project(file)
         utilities.set_attributes(new_plot_settings, self.plot_settings)
+
         self.Clipboard.clear()
         self.ViewClipboard.clear()
         self.plot_settings = new_plot_settings

--- a/src/graphs.py
+++ b/src/graphs.py
@@ -15,27 +15,32 @@ def open_project(self, file):
     for key in self.datadict.copy():
         delete_item(self, key)
     try:
-        new_plot_settings, new_datadict, clipboard, version = \
-            file_io.read_project(file)
+        new_plot_settings, new_datadict, data_clipboard, view_clipboard, \
+            version = file_io.read_project(file)
         utilities.set_attributes(new_plot_settings, self.plot_settings)
         self.Clipboard.clear()
+        self.ViewClipboard.clear()
         self.plot_settings = new_plot_settings
         self.datadict = {}
         add_items(self,
                   [utilities.check_item(self, item)
                    for item in new_datadict.values()])
 
-        # Set clipboard
-        if clipboard is not None:
-            for key, value in clipboard.items():
+        # Set clipboards
+        if data_clipboard is not None:
+            for key, value in data_clipboard.items():
                 self.Clipboard[key] = value
-        self.canvas.set_limits(self.Clipboard.limits_clipboard[-1])
+        if view_clipboard is not None:
+            for key, value in view_clipboard.items():
+                self.ViewClipboard[key] = value
+
+        self.canvas.set_limits(self.ViewClipboard.clipboard[-1])
+        ui.set_clipboard_buttons(self)
         refresh(self)
     except (EOFError, UnpicklingError):
         message = _("Could not open project")
         self.main_window.add_toast(message)
         logging.exception(message)
-
 
 def add_items(self, items):
     if not items:

--- a/src/item_box.py
+++ b/src/item_box.py
@@ -45,6 +45,7 @@ class ItemBox(Gtk.Box):
             self.application.datadict, drop_target.key, value)
         ui.reload_item_menu(self.application)
         self.application.Clipboard.add()
+        self.application.ViewClipboard.add()
         graphs.refresh(self.application)
 
     def on_dnd_prepare(self, drag_source, x, y):
@@ -81,6 +82,7 @@ class ItemBox(Gtk.Box):
                 self.item.alpha = color.alpha
                 self.update_color()
                 self.application.Clipboard.add()
+                self.application.ViewClipboard.add()
                 graphs.refresh(self.application)
 
     @Gtk.Template.Callback()

--- a/src/main.py
+++ b/src/main.py
@@ -9,7 +9,7 @@ from gi.repository import Adw, GLib, Gio
 
 from graphs import actions, file_io, plot_styles, plotting_tools, ui
 from graphs.canvas import Canvas
-from graphs.clipboard import Clipboard
+from graphs.clipboard import DataClipboard, ViewClipboard
 from graphs.misc import InteractionMode, PlotSettings
 from graphs.preferences import Preferences
 from graphs.window import GraphsWindow
@@ -120,7 +120,8 @@ class GraphsApplication(Adw.Application):
         pyplot.rcParams.update(
             file_io.parse_style(plot_styles.get_preferred_style(self)))
         self.canvas = Canvas(self)
-        self.Clipboard = Clipboard(self)
+        self.Clipboard = DataClipboard(self)
+        self.ViewClipboard = ViewClipboard(self)
         self.main_window.toast_overlay.set_child(self.canvas)
         self.main_window.redo_button.set_sensitive(False)
         self.main_window.undo_button.set_sensitive(False)
@@ -182,3 +183,4 @@ def main(args):
     app = GraphsApplication(args)
 
     return app.run(sys.argv)
+

--- a/src/main.py
+++ b/src/main.py
@@ -183,4 +183,3 @@ def main(args):
     app = GraphsApplication(args)
 
     return app.run(sys.argv)
-

--- a/src/plot_settings.py
+++ b/src/plot_settings.py
@@ -161,6 +161,6 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
             graphs.reload(self.props.application)
             ui.reload_item_menu(self.props.application)
         else:
-            self.props.application.canvas.toolbar.push_current()
             graphs.refresh(self.props.application)
         self.props.application.Clipboard.add()
+        self.props.application.ViewClipboard.add()

--- a/src/plotting_tools.py
+++ b/src/plotting_tools.py
@@ -6,6 +6,8 @@ from matplotlib import pyplot
 
 
 def optimize_limits(self):
+    self.Clipboard.clipboard[self.Clipboard.clipboard_pos]["view"] = \
+        self.canvas.get_limits()
     used_axes, items = utilities.get_used_axes(self)
     axis_map = {
         "left": self.canvas.axis,
@@ -59,7 +61,7 @@ def optimize_limits(self):
         limits[f"min_{direction}"] = min_all
         limits[f"max_{direction}"] = max_all
     self.canvas.set_limits(limits)
-    self.canvas.toolbar.push_current()
+    self.canvas.application.ViewClipboard.add()
 
 
 def hide_unused_axes(self, canvas):

--- a/src/ui.py
+++ b/src/ui.py
@@ -25,7 +25,8 @@ def set_clipboard_buttons(self):
 
     if abs(self.Clipboard.clipboard_pos) >= len(self.Clipboard.clipboard):
         self.main_window.undo_button.set_sensitive(False)
-    if abs(self.ViewClipboard.clipboard_pos) >= len(self.ViewClipboard.clipboard):
+    if abs(self.ViewClipboard.clipboard_pos) \
+            >= len(self.ViewClipboard.clipboard):
         self.main_window.view_back_button.set_sensitive(False)
 
     if self.Clipboard.clipboard_pos >= -1:

--- a/src/ui.py
+++ b/src/ui.py
@@ -13,6 +13,27 @@ def on_style_change(_shortcut, _theme, _widget, self):
     graphs.reload(self)
 
 
+def set_clipboard_buttons(self):
+    """
+    Enable and disable the buttons for the undo and redo buttons and backwards
+    and forwards view.
+    """
+    self.main_window.view_forward_button.set_sensitive(True)
+    self.main_window.view_back_button.set_sensitive(True)
+    self.main_window.undo_button.set_sensitive(True)
+    self.main_window.redo_button.set_sensitive(True)
+
+    if abs(self.Clipboard.clipboard_pos) >= len(self.Clipboard.clipboard):
+        self.main_window.undo_button.set_sensitive(False)
+    if abs(self.ViewClipboard.clipboard_pos) >= len(self.ViewClipboard.clipboard):
+        self.main_window.view_back_button.set_sensitive(False)
+
+    if self.Clipboard.clipboard_pos >= -1:
+        self.main_window.redo_button.set_sensitive(False)
+    if self.ViewClipboard.clipboard_pos >= -1:
+        self.main_window.view_forward_button.set_sensitive(False)
+
+
 def enable_data_dependent_buttons(self):
     enabled = False
     for item in self.datadict.values():
@@ -48,12 +69,11 @@ def add_data_dialog(self):
 
 def save_project_dialog(self):
     def on_response(dialog, response):
-        self.Clipboard.limits_clipboard[-1] = self.canvas.get_limits()
         with contextlib.suppress(GLib.GError):
             file = dialog.save_finish(response)
             file_io.save_project(
                 file, self.plot_settings, self.datadict, self.Clipboard,
-                self.version)
+                self.ViewClipboard, self.version)
     dialog = Gtk.FileDialog()
     dialog.set_filters(
         utilities.create_file_filters([(_("Graphs Project File"),


### PR DESCRIPTION
Reworks the clipboard as well as the view navigation. 

The clipboard is now one class, where two subclasses are used that inherit from the base class, one for the data and one for the view. This allows us to couple the view navigation to this custom clipboard instead of using the navigationtoolbar build-in. This also allows us to store the view clipboard in project files, and load the latest view upon loading in a less hacky way. 

The other thing that has been changed in behaviour, is that undo/redo now sets the views to whatever the status was on the previous/next action. Any suggestions on what exact behaviour would be preferred are always welcome :)

Also, there's some potential for further refactors into the clipboard classes eventually. There's still some duplication going on.