### PR TITLE
Refactor clipboard

### DIFF
--- a/src/clipboard.py
+++ b/src/clipboard.py
@@ -128,4 +128,3 @@ class ViewClipboard(BaseClipboard):
 
     def set_clipboard_state(self):
         self.application.canvas.limits = self.clipboard[self.clipboard_pos]
-

--- a/src/clipboard.py
+++ b/src/clipboard.py
@@ -21,35 +21,9 @@ class BaseClipboard:
         self.clipboard.append(new_state)
         self.redo_button.set_sensitive(False)
 
-    def undo(self):
-        if abs(self.clipboard_pos) < len(self.clipboard):
-            self.clipboard_pos -= 1
-            self.set_clipboard_state()
-
-        if abs(self.clipboard_pos) >= len(self.clipboard):
-            self.undo_button.set_sensitive(False)
-        if self.clipboard_pos < -1:
-            self.redo_button.set_sensitive(True)
-
-    def redo(self):
-        """
-        Redo an action, moves the clipboard position forwards by one and
-        changes the dataset to the state before the previous action was undone
-        """
-        if self.clipboard_pos < -1:
-            self.clipboard_pos += 1
-            self.set_clipboard_state()
-            self.undo_button.set_sensitive(True)
-
-        if self.clipboard_pos >= -1:
-            self.redo_button.set_sensitive(False)
-
     def __setitem__(self, key, value):
         """Allow to set the attributes in the Clipboard like a dictionary"""
         setattr(self, key, value)
-
-    def clear(self):
-        self.__init__(self.application)
 
 
 class DataClipboard(BaseClipboard):
@@ -79,9 +53,20 @@ class DataClipboard(BaseClipboard):
         changes the dataset to the state before the previous action was
         performed
         """
-        super().undo()
-        graphs.check_open_data(self.application)
-        ui.reload_item_menu(self.application)
+        if abs(self.clipboard_pos) < len(self.clipboard):
+            self.clipboard_pos -= 1
+            self.application.datadict = \
+                copy.deepcopy(self.clipboard[self.clipboard_pos]["datadict"])
+
+            if abs(self.clipboard_pos) >= len(self.clipboard):
+                self.application.main_window.undo_button.set_sensitive(False)
+            if self.clipboard_pos < -1:
+                self.application.main_window.redo_button.set_sensitive(True)
+            graphs.check_open_data(self.application)
+            ui.reload_item_menu(self.application)
+        if self.application.ViewClipboard.view_changed:
+            self.application.canvas.limits = \
+                self.clipboard[self.clipboard_pos]["view"]
         self.application.ViewClipboard.add()
 
     def redo(self):
@@ -89,22 +74,34 @@ class DataClipboard(BaseClipboard):
         Redo an action, moves the clipboard position forwards by one and
         changes the dataset to the state before the previous action was undone
         """
-        super().redo()
+        if self.clipboard_pos < -1:
+            self.clipboard_pos += 1
+            self.application.datadict = \
+                copy.deepcopy(self.clipboard[self.clipboard_pos]["datadict"])
+            self.application.canvas.limits = \
+                self.clipboard[self.clipboard_pos]["view"]
+            self.application.main_window.undo_button.set_sensitive(True)
+
+        if self.clipboard_pos >= -1:
+            self.application.main_window.redo_button.set_sensitive(False)
         graphs.check_open_data(self.application)
         ui.reload_item_menu(self.application)
-        self.application.ViewClipboard.add()
-
-    def set_clipboard_state(self):
-        self.application.datadict = \
-            copy.deepcopy(self.clipboard[self.clipboard_pos]["datadict"])
         if self.application.ViewClipboard.view_changed:
             self.application.canvas.limits = \
                 self.clipboard[self.clipboard_pos]["view"]
+        self.application.ViewClipboard.add()
+
+    def clear(self):
+        """Clear the clipboard to the initial state"""
+        self.clipboard = [{"datadict": {},
+                           "view": self.application.canvas.limits}]
+        self.clipboard_pos = -1
 
 
 class ViewClipboard(BaseClipboard):
 
     def __init__(self, application):
+
         super().__init__(application)
         self.clipboard = [self.application.canvas.limits]
         self.undo_button = self.application.main_window.view_back_button
@@ -121,10 +118,34 @@ class ViewClipboard(BaseClipboard):
             super().add(self.application.canvas.limits)
             self.view_changed = True
 
+    def undo(self):
+        """Go back to the previous view"""
+        if abs(self.clipboard_pos) < len(self.clipboard):
+            self.clipboard_pos -= 1
+            self.application.canvas.limits = self.clipboard[self.clipboard_pos]
+
+        if abs(self.clipboard_pos) >= len(self.clipboard):
+            self.application.main_window.view_back_button.set_sensitive(False)
+        if self.clipboard_pos < -1:
+            self.application.main_window.view_forward_button.set_sensitive(
+                True)
+
     def redo(self):
         """Go back to the next view"""
-        super().redo()
-        self.application.canvas.limits = self.clipboard[self.clipboard_pos]
+        if self.clipboard_pos < -1:
+            self.clipboard_pos += 1
+            self.application.canvas.limits = self.clipboard[self.clipboard_pos]
+            self.application.main_window.view_back_button.set_sensitive(True)
 
-    def set_clipboard_state(self):
+        if self.clipboard_pos >= -1:
+            self.application.main_window.view_forward_button.set_sensitive(
+                False)
         self.application.canvas.limits = self.clipboard[self.clipboard_pos]
+<<<<<<< HEAD
+=======
+
+    def clear(self):
+        """Clear the clipboard to the initial state"""
+        self.clipboard = [self.application.canvas.limits]
+        self.clipboard_pos = -1
+>>>>>>> parent of dbab31c (Fix clipboard buttons)

--- a/src/clipboard.py
+++ b/src/clipboard.py
@@ -39,8 +39,7 @@ class BaseClipboard:
             self.clipboard_pos += 1
             self.set_clipboard_state()
             self.undo_button.set_sensitive(True)
-
-        if self.clipboard_pos >= -1:
+        else:
             self.redo_button.set_sensitive(False)
 
     def __setitem__(self, key, value):

--- a/src/clipboard.py
+++ b/src/clipboard.py
@@ -21,9 +21,35 @@ class BaseClipboard:
         self.clipboard.append(new_state)
         self.redo_button.set_sensitive(False)
 
+    def undo(self):
+        if abs(self.clipboard_pos) < len(self.clipboard):
+            self.clipboard_pos -= 1
+            self.set_clipboard_state()
+
+        if abs(self.clipboard_pos) >= len(self.clipboard):
+            self.undo_button.set_sensitive(False)
+        if self.clipboard_pos < -1:
+            self.redo_button.set_sensitive(True)
+
+    def redo(self):
+        """
+        Redo an action, moves the clipboard position forwards by one and
+        changes the dataset to the state before the previous action was undone
+        """
+        if self.clipboard_pos < -1:
+            self.clipboard_pos += 1
+            self.set_clipboard_state()
+            self.undo_button.set_sensitive(True)
+
+        if self.clipboard_pos >= -1:
+            self.redo_button.set_sensitive(False)
+
     def __setitem__(self, key, value):
         """Allow to set the attributes in the Clipboard like a dictionary"""
         setattr(self, key, value)
+
+    def clear(self):
+        self.__init__(self.application)
 
 
 class DataClipboard(BaseClipboard):
@@ -53,20 +79,9 @@ class DataClipboard(BaseClipboard):
         changes the dataset to the state before the previous action was
         performed
         """
-        if abs(self.clipboard_pos) < len(self.clipboard):
-            self.clipboard_pos -= 1
-            self.application.datadict = \
-                copy.deepcopy(self.clipboard[self.clipboard_pos]["datadict"])
-
-            if abs(self.clipboard_pos) >= len(self.clipboard):
-                self.application.main_window.undo_button.set_sensitive(False)
-            if self.clipboard_pos < -1:
-                self.application.main_window.redo_button.set_sensitive(True)
-            graphs.check_open_data(self.application)
-            ui.reload_item_menu(self.application)
-        if self.application.ViewClipboard.view_changed:
-            self.application.canvas.limits = \
-                self.clipboard[self.clipboard_pos]["view"]
+        super().undo()
+        graphs.check_open_data(self.application)
+        ui.reload_item_menu(self.application)
         self.application.ViewClipboard.add()
 
     def redo(self):
@@ -74,34 +89,22 @@ class DataClipboard(BaseClipboard):
         Redo an action, moves the clipboard position forwards by one and
         changes the dataset to the state before the previous action was undone
         """
-        if self.clipboard_pos < -1:
-            self.clipboard_pos += 1
-            self.application.datadict = \
-                copy.deepcopy(self.clipboard[self.clipboard_pos]["datadict"])
-            self.application.canvas.limits = \
-                self.clipboard[self.clipboard_pos]["view"]
-            self.application.main_window.undo_button.set_sensitive(True)
-
-        if self.clipboard_pos >= -1:
-            self.application.main_window.redo_button.set_sensitive(False)
+        super().redo()
         graphs.check_open_data(self.application)
         ui.reload_item_menu(self.application)
+        self.application.ViewClipboard.add()
+
+    def set_clipboard_state(self):
+        self.application.datadict = \
+            copy.deepcopy(self.clipboard[self.clipboard_pos]["datadict"])
         if self.application.ViewClipboard.view_changed:
             self.application.canvas.limits = \
                 self.clipboard[self.clipboard_pos]["view"]
-        self.application.ViewClipboard.add()
-
-    def clear(self):
-        """Clear the clipboard to the initial state"""
-        self.clipboard = [{"datadict": {},
-                           "view": self.application.canvas.limits}]
-        self.clipboard_pos = -1
 
 
 class ViewClipboard(BaseClipboard):
 
     def __init__(self, application):
-
         super().__init__(application)
         self.clipboard = [self.application.canvas.limits]
         self.undo_button = self.application.main_window.view_back_button
@@ -118,34 +121,10 @@ class ViewClipboard(BaseClipboard):
             super().add(self.application.canvas.limits)
             self.view_changed = True
 
-    def undo(self):
-        """Go back to the previous view"""
-        if abs(self.clipboard_pos) < len(self.clipboard):
-            self.clipboard_pos -= 1
-            self.application.canvas.limits = self.clipboard[self.clipboard_pos]
-
-        if abs(self.clipboard_pos) >= len(self.clipboard):
-            self.application.main_window.view_back_button.set_sensitive(False)
-        if self.clipboard_pos < -1:
-            self.application.main_window.view_forward_button.set_sensitive(
-                True)
-
     def redo(self):
         """Go back to the next view"""
-        if self.clipboard_pos < -1:
-            self.clipboard_pos += 1
-            self.application.canvas.limits = self.clipboard[self.clipboard_pos]
-            self.application.main_window.view_back_button.set_sensitive(True)
-
-        if self.clipboard_pos >= -1:
-            self.application.main_window.view_forward_button.set_sensitive(
-                False)
+        super().redo()
         self.application.canvas.limits = self.clipboard[self.clipboard_pos]
-<<<<<<< HEAD
-=======
 
-    def clear(self):
-        """Clear the clipboard to the initial state"""
-        self.clipboard = [self.application.canvas.limits]
-        self.clipboard_pos = -1
->>>>>>> parent of dbab31c (Fix clipboard buttons)
+    def set_clipboard_state(self):
+        self.application.canvas.limits = self.clipboard[self.clipboard_pos]

--- a/src/clipboard.py
+++ b/src/clipboard.py
@@ -25,8 +25,7 @@ class BaseClipboard:
         if abs(self.clipboard_pos) < len(self.clipboard):
             self.clipboard_pos -= 1
             self.set_clipboard_state()
-
-        if abs(self.clipboard_pos) >= len(self.clipboard):
+        else:
             self.undo_button.set_sensitive(False)
         if self.clipboard_pos < -1:
             self.redo_button.set_sensitive(True)

--- a/src/ui.py
+++ b/src/ui.py
@@ -19,15 +19,14 @@ def set_clipboard_buttons(self):
     and forwards view.
     """
     self.main_window.view_forward_button.set_sensitive(
-        self.ViewClipboard.clipboard_pos >= -1)
+        self.ViewClipboard.clipboard_pos
+        < len(self.ViewClipboard.clipboard) - 1)
     self.main_window.view_back_button.set_sensitive(
-        abs(self.ViewClipboard.clipboard_pos)
-        >= len(self.ViewClipboard.clipboard))
+        self.ViewClipboard.clipboard_pos > -len(self.ViewClipboard.clipboard))
     self.main_window.undo_button.set_sensitive(
-        abs(self.Clipboard.clipboard_pos)
-        >= len(self.Clipboard.clipboard))
+        self.Clipboard.clipboard_pos > -len(self.Clipboard.clipboard))
     self.main_window.redo_button.set_sensitive(
-        self.Clipboard.clipboard_pos >= -1)
+        self.Clipboard.clipboard_pos < len(self.Clipboard.clipboard) - 1)
 
 
 def enable_data_dependent_buttons(self):


### PR DESCRIPTION
Refactors the new clipboard a bit, moves a bit more logic into the base class in a deduplication effort, and also fixes the `ui.set_clipboard_buttons` function which was not working properly (at least now when opening saved projects).