### PR TITLE
Fix optimize limits scaling in plot settings

### DIFF
--- a/src/plotting_tools.py
+++ b/src/plotting_tools.py
@@ -61,6 +61,7 @@ def optimize_limits(self):
         limits[f"min_{direction}"] = min_all
         limits[f"max_{direction}"] = max_all
     self.canvas.limits = limits
+    self.canvas.apply_limits()
     self.canvas.application.ViewClipboard.add()
 
 


### PR DESCRIPTION
In the current main, the limits are never pushed to the plot settings after an optimize limits call.

This means for instance that the old limits will be loaded into the entry fields after going into the figure settings afterwards. When closing that dialog, the old limits will be loaded into the canvas. Also the limits wouldn't be saved into a new project file.

This PR fixes this bug.