### PR TITLE
expand ExpanderRows automatically

### DIFF
--- a/src/ui.py
+++ b/src/ui.py
@@ -161,6 +161,7 @@ def load_values_from_dict(window, values, ignorelist=None):
                 widget.set_active(bool(value))
             elif isinstance(widget, Adw.ExpanderRow):
                 widget.set_enable_expansion(bool(value))
+                widget.set_expanded(bool(value))
             elif isinstance(widget, Gtk.Scale):
                 widget.set_value(value)
             elif isinstance(widget, Gtk.Button):


### PR DESCRIPTION
Default behavior when toggling an ExpanderRow expands it.
This way, when the initial state is enabled, it gets automatically expanded as well.

Signed-off-by: Christoph Matthias Kohnen <christoph.kohnen@disroot.org>
