### PR TITLE
Remove clipboard length option

### DIFF
--- a/data/config.json
+++ b/data/config.json
@@ -4,7 +4,7 @@
   "addequation_step_size": "0.01",
   "addequation_x_start": "0",
   "addequation_x_stop": "10",
-  "clipboard_length": 25,
+  "clipboard_length": 75,
   "export_figure_dpi": 100,
   "export_figure_filetype": "svg",
   "export_figure_transparent": true,

--- a/data/ui/preferences.blp
+++ b/data/ui/preferences.blp
@@ -60,22 +60,6 @@ template $PreferencesWindow : Adw.PreferencesWindow {
       title: _("Other");
       description: _("Other general settings");
 
-      Adw.ActionRow {
-        title: _("Clipboard Length");
-        subtitle: _("Number of states stored in the clipboard");
-
-        SpinButton clipboard_length {
-          valign: center;
-          numeric: true;
-          value: 15;
-          wrap: true;
-          adjustment: Adjustment {
-            step-increment: 1;
-            upper: 999;
-          };
-        }
-      }
-
       Adw.ComboRow other_handle_duplicates {
         title: _("Handle Duplicate Items");
         subtitle: _("Choose how to handle duplicate items when added");

--- a/src/clipboard.py
+++ b/src/clipboard.py
@@ -61,7 +61,8 @@ class DataClipboard(BaseClipboard):
                 "view": self.application.canvas.limits}
         super().add(copy.deepcopy(data))
         # Keep clipboard length limited to preference values
-        if len(self.clipboard) > 75:
+        if len(self.clipboard) > \
+                int(self.application.preferences["clipboard_length"]) + 1:
             self.clipboard = self.clipboard[1:]
 
     def undo(self):

--- a/src/clipboard.py
+++ b/src/clipboard.py
@@ -61,8 +61,7 @@ class DataClipboard(BaseClipboard):
                 "view": self.application.canvas.limits}
         super().add(copy.deepcopy(data))
         # Keep clipboard length limited to preference values
-        if len(self.clipboard) > \
-                int(self.application.preferences["clipboard_length"]) + 1:
+        if len(self.clipboard) > 75:
             self.clipboard = self.clipboard[1:]
 
     def undo(self):

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -87,7 +87,6 @@ CONFIG_IGNORELIST = [
 @Gtk.Template(resource_path="/se/sjoerd/Graphs/ui/preferences.ui")
 class PreferencesWindow(Adw.PreferencesWindow):
     __gtype_name__ = "PreferencesWindow"
-    clipboard_length = Gtk.Template.Child()
     import_delimiter = Gtk.Template.Child()
     import_separator = Gtk.Template.Child()
     import_column_x = Gtk.Template.Child()

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -80,7 +80,7 @@ class Preferences(dict):
 
 
 CONFIG_IGNORELIST = [
-    "import_params", "export_figure_filetype",
+    "import_params", "export_figure_filetype", "clipboard_length",
 ]
 
 


### PR DESCRIPTION
Removes the maximum clipboard length option, and defaults to a standard limit of 75 instead. It's extremely rare for a user to actually want to change the setting.

The limit of 75 was taken as a bit of a compromise of being long enough that it should never really be a big issue, but still limited so that the amount of data stored in memory is somewhat limited. I'm happy to discuss the exact value of this limit though.