### PR TITLE
Refactor preferences.

### DIFF
--- a/src/plot_styles.py
+++ b/src/plot_styles.py
@@ -254,8 +254,7 @@ class PlotStylesWindow(Adw.Window):
             self.color_boxes[box] = self.line_colors_box.get_last_child()
 
     def save_style(self):
-        new_values = {key: None for key in STYLE_DICT.keys()}
-        ui.save_values_to_dict(self, new_values)
+        new_values = ui.save_values_to_dict(self, STYLE_DICT.keys())
         for key, value in new_values.items():
             if value is not None:
                 for item in STYLE_DICT[key]:

--- a/src/ui.py
+++ b/src/ui.py
@@ -140,7 +140,7 @@ def show_about_window(self):
     ).present()
 
 
-def load_values_from_dict(window, values, ignorelist=None):
+def load_values_from_dict(window, values: dict, ignorelist=None):
     for key, value in values.items():
         if ignorelist is not None and key in ignorelist:
             continue
@@ -167,8 +167,9 @@ def load_values_from_dict(window, values, ignorelist=None):
             logging.warn(_("No way to apply “{}”").format(key))
 
 
-def save_values_to_dict(window, values, ignorelist=None):
-    for key in values.keys():
+def save_values_to_dict(window, keys: list, ignorelist=None):
+    values = {}
+    for key in keys:
         if ignorelist is not None and key in ignorelist:
             continue
         with contextlib.suppress(AttributeError):
@@ -187,3 +188,4 @@ def save_values_to_dict(window, values, ignorelist=None):
                 values[key] = widget.get_value()
             elif isinstance(widget, Gtk.Button):
                 values[key] = widget.color
+    return values


### PR DESCRIPTION
Preferences are automatically saved, when they are updated using `update()`.
Also tweak logic behind `save_values_to_dict` to accept a list of all keys and return a dict