### PR TITLE
New project file format

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -76,11 +76,11 @@ blueprints = custom_target('blueprints',
 resources = gnome.compile_resources(
   application_id,
   application_id + '.gresource.xml',
-  dependencies: blueprints,
-  gresource_bundle: true,
-  source_dir: meson.current_build_dir(),
-  install: true,
-  install_dir: pkgdatadir,
+    dependencies: blueprints,
+gresource_bundle: true,
+      source_dir: meson.current_build_dir(),
+         install: true,
+     install_dir: pkgdatadir,
 )
 
 scalable_dir = join_paths('icons', 'hicolor', 'scalable', 'apps')
@@ -90,8 +90,8 @@ if debug
 endif
 install_data(
   join_paths(scalable_dir, icon_name),
-  rename: ('@0@.svg').format(application_id),
-  install_dir: join_paths(datadir, scalable_dir)
+     rename: ('@0@.svg').format(application_id),
+install_dir: join_paths(datadir, scalable_dir)
 )
 
 symbolic_dir = join_paths('icons', 'hicolor', 'symbolic', 'apps')

--- a/src/actions.py
+++ b/src/actions.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 """Main actions."""
-from graphs import graphs, plotting_tools, project, ui
+from graphs import graphs, plotting_tools, ui
 from graphs.add_equation import AddEquationWindow
 from graphs.export_figure import ExportFigureWindow
 from graphs.plot_settings import PlotSettingsWindow
@@ -98,8 +98,7 @@ def plot_styles_action(_action, _target, self):
 
 
 def save_project_action(_action, _target, self):
-    # ui.save_project_dialog(self)
-    project.create_project(self)
+    ui.save_project_dialog(self)
 
 
 def open_project_action(_action, _target, self):

--- a/src/actions.py
+++ b/src/actions.py
@@ -58,22 +58,21 @@ def select_none_action(_action, _target, self):
 
 
 def undo_action(_action, _target, self):
-    self.Clipboard.undo()
+    self.props.clipboard.undo()
 
 
 def redo_action(_action, _target, self):
-    self.Clipboard.redo()
+    self.props.clipboard.redo()
 
 
 def optimize_limits_action(_action, _target, self):
     plotting_tools.optimize_limits(self)
-    self.ViewClipboard.add()
     graphs.refresh(self)
 
 
 def view_back_action(_action, _target, self):
     if self.main_window.view_back_button.get_sensitive():
-        self.ViewClipboard.undo()
+        self.props.view_clipboard.undo()
         self.canvas.apply_limits()
         # Fix weird view on back
         graphs.refresh(self)
@@ -81,7 +80,7 @@ def view_back_action(_action, _target, self):
 
 def view_forward_action(_action, _target, self):
     if self.main_window.view_forward_button.get_sensitive():
-        self.ViewClipboard.redo()
+        self.props.view_clipboard.redo()
         self.canvas.apply_limits()
         graphs.refresh(self)
 

--- a/src/actions.py
+++ b/src/actions.py
@@ -67,6 +67,7 @@ def redo_action(_action, _target, self):
 
 def optimize_limits_action(_action, _target, self):
     plotting_tools.optimize_limits(self)
+    self.ViewClipboard.add()
     graphs.refresh(self)
 
 

--- a/src/actions.py
+++ b/src/actions.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 """Main actions."""
-from graphs import graphs, plotting_tools, ui
+from graphs import graphs, plotting_tools, project, ui
 from graphs.add_equation import AddEquationWindow
 from graphs.export_figure import ExportFigureWindow
 from graphs.plot_settings import PlotSettingsWindow
@@ -98,7 +98,8 @@ def plot_styles_action(_action, _target, self):
 
 
 def save_project_action(_action, _target, self):
-    ui.save_project_dialog(self)
+    # ui.save_project_dialog(self)
+    project.create_project(self)
 
 
 def open_project_action(_action, _target, self):

--- a/src/add_equation.py
+++ b/src/add_equation.py
@@ -43,7 +43,7 @@ class AddEquationWindow(Adw.Window):
                 name = f"Y = {values['equation']}"
             graphs.add_items(
                 self.props.application,
-                [Item(self.props.application, xdata, ydata, name)])
+                [Item.new(self.props.application, xdata, ydata, name=name)])
             self.destroy()
         except ValueError as error:
             self.toast_overlay.add_toast(Adw.Toast(title=error))

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -336,7 +336,7 @@ class DummyToolbar(NavigationToolbar2):
     # Overwritten function - do not change name
     def push_current(self):
         self.canvas.apply_limits()
-        self.canvas.application.ViewClipboard.add()
+        self.canvas.application.props.view_clipboard.add()
 
     # Overwritten function - do not change name
     def save_figure(self):

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -18,6 +18,8 @@ from matplotlib.widgets import SpanSelector
 
 
 class Canvas(FigureCanvas):
+    __gtype_name__ = "Canvas"
+
     application = GObject.Property(type=Adw.Application)
     one_click_trigger = GObject.Property(type=bool, default=False)
     time_first_click = GObject.Property(type=float, default=0)
@@ -34,19 +36,20 @@ class Canvas(FigureCanvas):
         self.top_right_axis = self.top_left_axis.twinx()
         self.set_axis_properties()
         self.set_ticks()
-        color_rgba = utilities.lookup_color(self.application, "accent_color")
+        color_rgba = \
+            utilities.lookup_color(self.props.application, "accent_color")
         self.rubberband_edge_color = utilities.rgba_to_tuple(color_rgba, True)
         color_rgba.alpha = 0.3
         self.rubberband_fill_color = utilities.rgba_to_tuple(color_rgba, True)
         self.limits = {
-            "min_bottom": self.application.plot_settings.min_bottom,
-            "max_bottom": self.application.plot_settings.max_bottom,
-            "min_top": self.application.plot_settings.min_top,
-            "max_top": self.application.plot_settings.max_top,
-            "min_left": self.application.plot_settings.min_left,
-            "max_left": self.application.plot_settings.max_left,
-            "min_right": self.application.plot_settings.min_right,
-            "max_right": self.application.plot_settings.max_right,
+            "min_bottom": self.props.application.plot_settings.min_bottom,
+            "max_bottom": self.props.application.plot_settings.max_bottom,
+            "min_top": self.props.application.plot_settings.min_top,
+            "max_top": self.props.application.plot_settings.max_top,
+            "min_left": self.props.application.plot_settings.min_left,
+            "max_left": self.props.application.plot_settings.max_left,
+            "min_right": self.props.application.plot_settings.min_right,
+            "max_right": self.props.application.plot_settings.max_right,
         }
         self.legends = []
         for axis in [self.right_axis, self.top_left_axis,
@@ -110,7 +113,7 @@ class Canvas(FigureCanvas):
                 clip_on=True, fontsize=item.size, rotation=item.rotation)
 
     def apply_limits(self):
-        plot_settings = self.application.plot_settings
+        plot_settings = self.props.application.plot_settings
         plot_settings.min_bottom = min(self.axis.get_xlim())
         plot_settings.max_bottom = max(self.axis.get_xlim())
         plot_settings.min_top = min(self.top_left_axis.get_xlim())
@@ -147,13 +150,13 @@ class Canvas(FigureCanvas):
         except ValueError:
             message = _("Error setting limits, one of the values was "
                         "probably infinite")
-            self.application.main_window.add_toast(message)
+            self.props.application.main_window.add_toast(message)
             logging.exception(message)
 
     def set_axis_properties(self):
         """Set the properties that are related to the axes."""
-        plot_settings = self.application.plot_settings
-        settings = self.application.settings.get_child("figure")
+        plot_settings = self.props.application.plot_settings
+        settings = self.props.application.settings.get_child("figure")
         title = settings["plot_title"] \
             if plot_settings.title is None else plot_settings.title
         bottom_label = settings.get_string("bottom-label") \
@@ -185,7 +188,7 @@ class Canvas(FigureCanvas):
         top = pyplot.rcParams["xtick.top"]
         right = pyplot.rcParams["ytick.right"]
         ticks = "both" if pyplot.rcParams["xtick.minor.visible"] else "major"
-        used_axes = utilities.get_used_axes(self.application)[0]
+        used_axes = utilities.get_used_axes(self.props.application)[0]
 
         # Define axes and their directions
         axes = {
@@ -231,7 +234,7 @@ class Canvas(FigureCanvas):
                  self.left_label, self.right_label}
         for item in items:
             if item.contains(event)[0]:
-                RenameWindow(self.application, item)
+                RenameWindow(self.props.application, item)
 
     # Overwritten function - do not change name
     def _post_draw(self, _widget, context):
@@ -264,7 +267,8 @@ class Canvas(FigureCanvas):
 
     def set_legend(self):
         """Set the legend of the graph"""
-        if self.application.plot_settings.legend:
+        plot_settings = self.props.application.plot_settings
+        if plot_settings.legend:
             self.legends = []
             lines1, labels1 = self.axis.get_legend_handles_labels()
             lines2, labels2 = self.right_axis.get_legend_handles_labels()
@@ -277,7 +281,7 @@ class Canvas(FigureCanvas):
             if labels:
                 self.top_right_axis.legend(
                     new_lines, labels,
-                    loc=self.application.plot_settings.legend_position.lower(),
+                    loc=plot_settings.legend_position.lower(),
                     frameon=True, reverse=True)
                 return
         if self.top_right_axis.get_legend() is not None:

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -76,8 +76,8 @@ class Canvas(FigureCanvas):
             self.figure.draw(self._renderer)
 
     def plot(self, item):
-        x_axis = item.plot_x_position
-        y_axis = item.plot_y_position
+        x_axis = item.xposition
+        y_axis = item.yposition
         if y_axis == "left":
             if x_axis == "bottom":
                 axis = self.axis
@@ -105,7 +105,7 @@ class Canvas(FigureCanvas):
                 linewidth=linewidth, markersize=markersize, label=item.name)
         elif isinstance(item, TextItem):
             axis.text(
-                item.x_anchor, item.y_anchor, item.text,
+                item.xanchor, item.yanchor, item.text,
                 **common_parameters,
                 clip_on=True, fontsize=item.size, rotation=item.rotation)
 

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -157,27 +157,27 @@ class Canvas(FigureCanvas):
         """Set the properties that are related to the axes."""
         plot_settings = self.props.application.plot_settings
         settings = self.props.application.settings.get_child("figure")
-        title = settings["plot_title"] \
-            if plot_settings.title is None else plot_settings.title
+        title = settings.get_string("title") \
+            if plot_settings.title == "" else plot_settings.title
         bottom_label = settings.get_string("bottom-label") \
-            if plot_settings.xlabel is None else plot_settings.xlabel
+            if plot_settings.bottom_label == "" else plot_settings.bottom_label
         right_label = settings.get_string("right-label") \
-            if plot_settings.right_label is None else plot_settings.right_label
+            if plot_settings.right_label == "" else plot_settings.right_label
         top_label = settings.get_string("top-label") \
-            if plot_settings.top_label is None else plot_settings.top_label
+            if plot_settings.top_label == "" else plot_settings.top_label
         left_label = settings.get_string("left-label") \
-            if plot_settings.ylabel is None else plot_settings.ylabel
+            if plot_settings.left_label == "" else plot_settings.left_label
         self.title = self.axis.set_title(title)
         self.bottom_label = self.axis.set_xlabel(bottom_label)
         self.right_label = self.right_axis.set_ylabel(right_label)
         self.top_label = self.top_left_axis.set_xlabel(top_label)
         self.left_label = self.axis.set_ylabel(left_label)
-        self.axis.set_xscale(plot_settings.xscale)
-        self.axis.set_yscale(plot_settings.yscale)
-        self.right_axis.set_xscale(plot_settings.xscale)
+        self.axis.set_xscale(plot_settings.bottom_scale)
+        self.axis.set_yscale(plot_settings.left_scale)
+        self.right_axis.set_xscale(plot_settings.bottom_scale)
         self.right_axis.set_yscale(plot_settings.right_scale)
         self.top_left_axis.set_xscale(plot_settings.top_scale)
-        self.top_left_axis.set_yscale(plot_settings.yscale)
+        self.top_left_axis.set_yscale(plot_settings.left_scale)
         self.top_right_axis.set_xscale(plot_settings.top_scale)
         self.top_right_axis.set_yscale(plot_settings.right_scale)
 

--- a/src/clipboard.py
+++ b/src/clipboard.py
@@ -1,14 +1,14 @@
-from gi.repository import Adw, GObject, Gtk
+from gi.repository import Adw, GObject
 
 from graphs import graphs, item, ui
 
 
 class BaseClipboard(GObject.Object):
+    __gtype_name__ = "BaseClipboard"
+
     application = GObject.Property(type=Adw.Application)
     clipboard = GObject.Property(type=object)
     clipboard_pos = GObject.Property(type=int, default=-1)
-    undo_button = GObject.Property(type=Gtk.Button)
-    redo_button = GObject.Property(type=Gtk.Button)
 
     def __init__(self, clipboard=None, **kwargs):
         if clipboard is None:
@@ -19,45 +19,45 @@ class BaseClipboard(GObject.Object):
         # If a couple of redo's were performed previously, it deletes the
         # clipboard data that is located after the current clipboard position
         # and disables the redo button
-        if self.clipboard_pos != -1:
-            self.clipboard = \
-                self.clipboard[:self.clipboard_pos + 1]
-        self.clipboard_pos = -1
-        self.clipboard.append(new_state)
-        ui.set_clipboard_buttons(self.application)
+        if self.props.clipboard_pos != -1:
+            self.props.clipboard = \
+                self.props.clipboard[:self.props.clipboard_pos + 1]
+        self.props.clipboard_pos = -1
+        self.props.clipboard.append(new_state)
+        ui.set_clipboard_buttons(self.props.application)
 
     def undo(self):
-        if abs(self.clipboard_pos) < len(self.clipboard):
-            self.clipboard_pos -= 1
+        if abs(self.props.clipboard_pos) < len(self.props.clipboard):
+            self.props.clipboard_pos -= 1
             self.set_clipboard_state()
-        ui.set_clipboard_buttons(self.application)
+        ui.set_clipboard_buttons(self.props.application)
 
     def redo(self):
         """
         Redo an action, moves the clipboard position forwards by one and
         changes the dataset to the state before the previous action was undone
         """
-        if self.clipboard_pos < -1:
-            self.clipboard_pos += 1
+        if self.props.clipboard_pos < -1:
+            self.props.clipboard_pos += 1
             self.set_clipboard_state()
-        ui.set_clipboard_buttons(self.application)
+        ui.set_clipboard_buttons(self.props.application)
 
     def __setitem__(self, key, value):
         """Allow to set the attributes in the Clipboard like a dictionary"""
         setattr(self, key, value)
 
     def clear(self):
-        self.__init__(self.application)
+        self.__init__(self.props.application)
 
 
 class DataClipboard(BaseClipboard):
+    __gtype_name__ = "DataClipboard"
+
     def __init__(self, application):
         super().__init__(
             application=application,
             clipboard=[{"data": [],
                         "view": application.canvas.limits}],
-            undo_button=application.main_window.undo_button,
-            redo_button=application.main_window.redo_button,
         )
 
     def add(self):
@@ -65,13 +65,14 @@ class DataClipboard(BaseClipboard):
         Add data to the clipboard, is performed whenever an action is performed
         Appends the latest state to the clipboard.
         """
-        items = [item.to_dict() for item in self.application.datadict.values()]
-        super().add({"data": items,
-                     "view": self.application.canvas.limits})
+        items = self.props.application.datadict.values()
+        super().add({"data": [item.to_dict() for item in items],
+                     "view": self.props.application.canvas.limits})
         # Keep clipboard length limited to preference values
-        if len(self.clipboard) > \
-                int(self.application.settings.get_int("clipboard-length")) + 1:
-            self.clipboard = self.clipboard[1:]
+        max_clipboard_length = \
+            self.props.application.props.settings.get_int("clipboard-length")
+        if len(self.props.clipboard) > max_clipboard_length + 1:
+            self.props.clipboard = self.props.clipboard[1:]
 
     def undo(self):
         """
@@ -80,9 +81,9 @@ class DataClipboard(BaseClipboard):
         performed
         """
         super().undo()
-        graphs.check_open_data(self.application)
-        ui.reload_item_menu(self.application)
-        self.application.ViewClipboard.add()
+        graphs.check_open_data(self.props.application)
+        ui.reload_item_menu(self.props.application)
+        self.props.application.ViewClipboard.add()
 
     def redo(self):
         """
@@ -90,27 +91,27 @@ class DataClipboard(BaseClipboard):
         changes the dataset to the state before the previous action was undone
         """
         super().redo()
-        graphs.check_open_data(self.application)
-        ui.reload_item_menu(self.application)
-        self.application.ViewClipboard.add()
+        graphs.check_open_data(self.props.application)
+        ui.reload_item_menu(self.props.application)
+        self.props.application.ViewClipboard.add()
 
     def set_clipboard_state(self):
-        state = self.clipboard[self.clipboard_pos]
+        state = self.props.clipboard[self.props.clipboard_pos]
         items = [item.new_from_dict(d) for d in state["data"]]
-        self.application.datadict = {item.key: item for item in items}
-        if self.application.ViewClipboard.view_changed:
-            self.application.canvas.limits = state["view"]
+        self.props.application.datadict = {item.key: item for item in items}
+        if self.props.application.ViewClipboard.view_changed:
+            self.props.application.canvas.limits = state["view"]
 
 
 class ViewClipboard(BaseClipboard):
+    __gtype_name__ = "ViewClipboard"
+
     view_changed = GObject.Property(type=bool, default=False)
 
     def __init__(self, application):
         super().__init__(
             application=application,
             clipboard=[application.canvas.limits],
-            undo_button=application.main_window.view_back_button,
-            redo_button=application.main_window.view_forward_button,
         )
 
     def add(self):
@@ -118,15 +119,17 @@ class ViewClipboard(BaseClipboard):
         Add the latest view to the clipboard, skip in case the new view is
         the same as previous one (e.g. if an action does not change the limits)
         """
-        self.view_changed = False
-        if self.application.canvas.limits != self.clipboard[-1]:
-            super().add(self.application.canvas.limits)
-            self.view_changed = True
+        self.props.view_changed = False
+        if self.props.application.canvas.limits != self.props.clipboard[-1]:
+            super().add(self.props.application.canvas.limits)
+            self.props.view_changed = True
 
     def redo(self):
         """Go back to the next view"""
         super().redo()
-        self.application.canvas.limits = self.clipboard[self.clipboard_pos]
+        self.props.application.canvas.limits = \
+            self.props.clipboard[self.props.clipboard_pos]
 
     def set_clipboard_state(self):
-        self.application.canvas.limits = self.clipboard[self.clipboard_pos]
+        self.props.application.canvas.limits = \
+            self.props.clipboard[self.props.clipboard_pos]

--- a/src/clipboard.py
+++ b/src/clipboard.py
@@ -42,10 +42,6 @@ class BaseClipboard(GObject.Object):
             self.set_clipboard_state()
         ui.set_clipboard_buttons(self.props.application)
 
-    def __setitem__(self, key, value):
-        """Allow to set the attributes in the Clipboard like a dictionary"""
-        setattr(self, key, value)
-
     def clear(self):
         self.__init__(self.props.application)
 

--- a/src/clipboard.py
+++ b/src/clipboard.py
@@ -79,7 +79,7 @@ class DataClipboard(BaseClipboard):
         super().undo()
         graphs.check_open_data(self.props.application)
         ui.reload_item_menu(self.props.application)
-        self.props.application.ViewClipboard.add()
+        self.props.application.props.view_clipboard.add()
 
     def redo(self):
         """
@@ -89,13 +89,13 @@ class DataClipboard(BaseClipboard):
         super().redo()
         graphs.check_open_data(self.props.application)
         ui.reload_item_menu(self.props.application)
-        self.props.application.ViewClipboard.add()
+        self.props.application.props.view_clipboard.add()
 
     def set_clipboard_state(self):
         state = self.props.clipboard[self.props.clipboard_pos]
         items = [item.new_from_dict(d) for d in state["data"]]
         self.props.application.datadict = {item.key: item for item in items}
-        if self.props.application.ViewClipboard.view_changed:
+        if self.props.application.props.view_clipboard.view_changed:
             self.props.application.canvas.limits = state["view"]
 
 

--- a/src/edit_item.py
+++ b/src/edit_item.py
@@ -57,9 +57,9 @@ class EditItemWindow(Adw.PreferencesWindow):
         self.set_title(self.item.name)
         self.name_entry.set_text(self.item.name)
         utilities.set_chooser(
-            self.plot_x_position, self.item.plot_x_position)
+            self.plot_x_position, self.item.xposition)
         utilities.set_chooser(
-            self.plot_y_position, self.item.plot_y_position)
+            self.plot_y_position, self.item.yposition)
         self.item_group.set_visible(False)
         if isinstance(self.item, Item):
             self.load_item_values()
@@ -78,14 +78,14 @@ class EditItemWindow(Adw.PreferencesWindow):
 
         # Only change limits when axes change, otherwise this is not needed
         set_limits = \
-            self.item.plot_x_position \
+            self.item.xposition \
             != utilities.get_selected_chooser_item(self.plot_x_position) \
-            or self.item.plot_y_position \
+            or self.item.yposition \
             != utilities.get_selected_chooser_item(self.plot_y_position)
 
-        self.item.plot_x_position = \
+        self.item.xposition = \
             utilities.get_selected_chooser_item(self.plot_x_position)
-        self.item.plot_y_position = \
+        self.item.yposition = \
             utilities.get_selected_chooser_item(self.plot_y_position)
         if isinstance(self.item, Item):
             self.apply_item_values()

--- a/src/edit_item.py
+++ b/src/edit_item.py
@@ -90,11 +90,10 @@ class EditItemWindow(Adw.PreferencesWindow):
         if isinstance(self.item, Item):
             self.apply_item_values()
         ui.reload_item_menu(self.props.application)
-        self.props.application.Clipboard.add()
+        self.props.application.props.clipboard.add()
         graphs.refresh(self.props.application)
         if set_limits:
             plotting_tools.optimize_limits(self.props.application)
-            self.props.application.ViewClipboard.add()
 
     def apply_item_values(self):
         self.item.linestyle = \

--- a/src/edit_item.py
+++ b/src/edit_item.py
@@ -94,6 +94,7 @@ class EditItemWindow(Adw.PreferencesWindow):
         graphs.refresh(self.props.application)
         if set_limits:
             plotting_tools.optimize_limits(self.props.application)
+            self.props.application.ViewClipboard.add()
 
     def apply_item_values(self):
         self.item.linestyle = \

--- a/src/file_import.py
+++ b/src/file_import.py
@@ -15,6 +15,8 @@ IMPORT_MODES = {
 
 
 class ImportSettings(GObject.Object):
+    __gtype_name__ = "ImportSettings"
+
     file = GObject.Property(type=Gio.File)
     mode = GObject.Property(type=str, default="columns")
     name = GObject.Property(type=str, default=_("Imported Data"))

--- a/src/file_io.py
+++ b/src/file_io.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 import json
 import logging
-import pickle
 import re
 from gettext import gettext as _
 from pathlib import Path
@@ -9,7 +8,7 @@ from xml.dom import minidom
 
 from gi.repository import GLib
 
-from graphs import utilities
+from graphs import item, utilities
 from graphs.item import Item, TextItem
 from graphs.misc import ParseError
 
@@ -17,46 +16,6 @@ from matplotlib import RcParams, cbook
 from matplotlib.style.core import STYLE_BLACKLIST
 
 import numpy
-
-
-def save_project(file, plot_settings, datadict, data_clipboard, view_clipboard,
-                 version):
-
-    # Clipboards are saved as dictionaries because our custom classes cannot
-    # be pickled
-    data_clipboard_dict = {
-        "clipboard": data_clipboard.clipboard,
-        "clipboard_pos": data_clipboard.clipboard_pos,
-    }
-
-    view_clipboard_dict = {"clipboard": view_clipboard.clipboard,
-                           "clipboard_pos": view_clipboard.clipboard_pos}
-
-    project_data = {
-        "plot_settings": plot_settings,
-        "data": datadict,
-        "data_clipboard": data_clipboard_dict,
-        "view_clipboard": view_clipboard_dict,
-        "version": version,
-    }
-    stream = _get_write_stream(file)
-    stream.write_bytes(GLib.Bytes(pickle.dumps(project_data)))
-    stream.close()
-
-
-def read_project(file):
-    project = pickle.loads(read_file(file, None))
-
-    # Load empty values if attribute does not exist in Project file, to
-    # ensure backwards compatibility with older project files
-    project_items = ["plot_settings", "data", "data_clipboard",
-                     "view_clipboard", "version"]
-
-    project.update({key: None for key in project_items if key not in project})
-    return \
-        project["plot_settings"], project["data"], \
-        project["data_clipboard"], project["view_clipboard"], \
-        project["version"]
 
 
 def save_item(file, item):
@@ -71,8 +30,8 @@ def save_item(file, item):
 
 
 def import_from_project(self, import_settings):
-    return [utilities.check_item(self, item)
-            for item in read_project(import_settings.file)[1].values()]
+    return [item.new_from_dict(dictionary)
+            for dictionary in parse_json(import_settings.file)["data"]]
 
 
 def import_from_xrdml(self, import_settings):

--- a/src/file_io.py
+++ b/src/file_io.py
@@ -101,8 +101,9 @@ def import_from_xrdml(self, import_settings):
             end_pos = float(end_pos[0].firstChild.data)
             xdata = numpy.linspace(start_pos, end_pos, len(ydata))
             xdata = numpy.ndarray.tolist(xdata)
-    return [Item(self, xdata, ydata, import_settings.name,
-                 xlabel=f"{scan_axis} ({unit})", ylabel=_("Intensity (cps)"))]
+    return [Item.new(
+        self, xdata, ydata, name=import_settings.name,
+        xlabel=f"{scan_axis} ({unit})", ylabel=_("Intensity (cps)"))]
 
 
 def import_from_xry(self, import_settings):
@@ -126,7 +127,7 @@ def import_from_xry(self, import_settings):
         else:
             name = import_settings.name
         items.append(
-            Item(self, name=name, xlabel=_("β (°)"), ylabel=_("R (1/s)")))
+            Item.new(self, name=name, xlabel=_("β (°)"), ylabel=_("R (1/s)")))
     for i in range(value_count):
         values = lines[18 + i].strip().split()
         for j in range(item_count):
@@ -137,13 +138,13 @@ def import_from_xry(self, import_settings):
     for row in lines[28 + value_count + item_count:]:
         values = row.strip().split()
         text = " ".join(values[7:])
-        items.append(
-            TextItem(self, float(values[5]), float(values[6]), text, text))
+        items.append(TextItem.new(
+            self, float(values[5]), float(values[6]), text, name=text))
     return items
 
 
 def import_from_columns(self, import_settings):
-    item = Item(self, name=import_settings.name)
+    item = Item.new(self, name=import_settings.name)
     columns_params = self.settings.get_child(
         "import-params").get_child("columns")
     column_x = columns_params.get_int("column-x")

--- a/src/graphs.py
+++ b/src/graphs.py
@@ -69,6 +69,7 @@ def add_items(self, items):
     ui.enable_data_dependent_buttons(self)
     refresh(self)
     plotting_tools.optimize_limits(self)
+    self.ViewClipboard.add()
     self.Clipboard.add()
 
 

--- a/src/graphs.py
+++ b/src/graphs.py
@@ -69,26 +69,26 @@ def add_items(self, items):
         if item.xlabel:
             original_position = item.xposition
             if item.xposition == "bottom":
-                if self.plot_settings.xlabel is None:
-                    self.plot_settings.xlabel = item.xlabel
-                elif item.xlabel != self.plot_settings.xlabel:
+                if self.plot_settings.bottom_label == "":
+                    self.plot_settings.bottom_label = item.xlabel
+                elif item.xlabel != self.plot_settings.bottom_label:
                     item.xposition = "top"
             if item.xposition == "top":
-                if self.plot_settings.top_label is None:
+                if self.plot_settings.top_label == "":
                     self.plot_settings.top_label = item.xlabel
-                elif item.xlabel != self.plot_settings.xlabel:
+                elif item.xlabel != self.plot_settings.bottom_label:
                     item.xposition = original_position
         if item.ylabel:
             original_position = item.yposition
             if item.yposition == "left":
-                if self.plot_settings.ylabel is None:
-                    self.plot_settings.ylabel = item.ylabel
-                elif item.ylabel != self.plot_settings.ylabel:
+                if self.plot_settings.left_label == "":
+                    self.plot_settings.left_label = item.ylabel
+                elif item.ylabel != self.plot_settings.left_label:
                     item.yposition = "right"
             if item.yposition == "right":
-                if self.plot_settings.right_label is None:
+                if self.plot_settings.right_label == "":
                     self.plot_settings.right_label = item.ylabel
-                elif item.ylabel != self.plot_settings.ylabel:
+                elif item.ylabel != self.plot_settings.left_label:
                     item.yposition = original_position
         if item.color == "":
             item.color = plotting_tools.get_next_color(self)

--- a/src/graphs.py
+++ b/src/graphs.py
@@ -6,7 +6,6 @@ from pickle import UnpicklingError
 from graphs import (file_io, plot_styles, plotting_tools, ui,
                     utilities)
 from graphs.canvas import Canvas
-from graphs.item import Item
 
 from matplotlib import pyplot
 
@@ -68,30 +67,30 @@ def add_items(self, items):
                 elif handle_duplicates == 3:  # Override
                     item.key = item_1.key
         if item.xlabel:
-            original_position = item.plot_x_position
-            if item.plot_x_position == "bottom":
+            original_position = item.xposition
+            if item.xposition == "bottom":
                 if self.plot_settings.xlabel is None:
                     self.plot_settings.xlabel = item.xlabel
                 elif item.xlabel != self.plot_settings.xlabel:
-                    item.plot_x_position = "top"
-            if item.plot_x_position == "top":
+                    item.xposition = "top"
+            if item.xposition == "top":
                 if self.plot_settings.top_label is None:
                     self.plot_settings.top_label = item.xlabel
                 elif item.xlabel != self.plot_settings.xlabel:
-                    item.plot_x_position = original_position
+                    item.xposition = original_position
         if item.ylabel:
-            original_position = item.plot_y_position
-            if item.plot_y_position == "left":
+            original_position = item.yposition
+            if item.yposition == "left":
                 if self.plot_settings.ylabel is None:
                     self.plot_settings.ylabel = item.ylabel
                 elif item.ylabel != self.plot_settings.ylabel:
-                    item.plot_y_position = "right"
-            if item.plot_y_position == "right":
+                    item.yposition = "right"
+            if item.yposition == "right":
                 if self.plot_settings.right_label is None:
                     self.plot_settings.right_label = item.ylabel
                 elif item.ylabel != self.plot_settings.ylabel:
-                    item.plot_y_position = original_position
-        if item.color is None and isinstance(item, Item):
+                    item.yposition = original_position
+        if item.color == "":
             item.color = plotting_tools.get_next_color(self)
         self.datadict[item.key] = item
 

--- a/src/graphs.py
+++ b/src/graphs.py
@@ -1,46 +1,10 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
-import logging
 from gettext import gettext as _
-from pickle import UnpicklingError
 
-from graphs import (file_io, plot_styles, plotting_tools, ui,
-                    utilities)
+from graphs import file_io, plot_styles, plotting_tools, ui, utilities
 from graphs.canvas import Canvas
 
 from matplotlib import pyplot
-
-
-def open_project(self, file):
-    for key in self.datadict.copy():
-        delete_item(self, key)
-    try:
-        new_plot_settings, new_datadict, data_clipboard, view_clipboard, \
-            version = file_io.read_project(file)
-        utilities.set_attributes(new_plot_settings, self.plot_settings)
-
-        self.Clipboard.clear()
-        self.ViewClipboard.clear()
-        self.plot_settings = new_plot_settings
-        self.datadict = {}
-        add_items(self,
-                  [utilities.check_item(self, item)
-                   for item in new_datadict.values()])
-
-        # Set clipboards
-        if data_clipboard is not None:
-            for key, value in data_clipboard.items():
-                self.Clipboard[key] = value
-        if view_clipboard is not None:
-            for key, value in view_clipboard.items():
-                self.ViewClipboard[key] = value
-
-        self.canvas.limits = self.ViewClipboard.clipboard[-1]
-        ui.set_clipboard_buttons(self)
-        refresh(self)
-    except (EOFError, UnpicklingError):
-        message = _("Could not open project")
-        self.main_window.add_toast(message)
-        logging.exception(message)
 
 
 def add_items(self, items):

--- a/src/graphs.py
+++ b/src/graphs.py
@@ -69,8 +69,7 @@ def add_items(self, items):
     ui.enable_data_dependent_buttons(self)
     refresh(self)
     plotting_tools.optimize_limits(self)
-    self.ViewClipboard.add()
-    self.Clipboard.add()
+    self.props.clipboard.add()
 
 
 def delete_item(self, key, give_toast=False):
@@ -79,7 +78,7 @@ def delete_item(self, key, give_toast=False):
     ui.reload_item_menu(self)
     if give_toast:
         self.main_window.add_toast(_("Deleted {name}").format(name=name))
-    self.Clipboard.add()
+    self.props.clipboard.add()
     check_open_data(self)
 
 

--- a/src/item.py
+++ b/src/item.py
@@ -1,43 +1,99 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 import uuid
 
+from gi.repository import GObject
+
 from matplotlib import pyplot
 
 
-class ItemBase:
-    def __init__(self, settings, name="", color=None, selected=True,
-                 xlabel="", ylabel=""):
-        self.key: str = str(uuid.uuid4())
-        self.name, self.color, self.selected = name, color, selected
-        self.xlabel, self.ylabel = xlabel, ylabel
-        self.plot_y_position = settings.get_string("y-position")
-        self.plot_x_position = settings.get_string("x-position")
-        self.alpha = 1
+def new_from_dict(dictionary: dict):
+    match dictionary["item_type"]:
+        case "Item":
+            cls = Item
+        case "TextItem":
+            cls = TextItem
+        case _:
+            pass
+    return cls(**dictionary)
+
+
+class ItemBase(GObject.Object):
+    __gtype_name__ = "ItemBase"
+
+    name = GObject.Property(type=str, default="")
+    color = GObject.Property(type=str, default="")
+    selected = GObject.Property(type=bool, default=True)
+    xlabel = GObject.Property(type=str, default="")
+    ylabel = GObject.Property(type=str, default="")
+    xposition = GObject.Property(type=str, default="bottom")
+    yposition = GObject.Property(type=str, default="left")
+    alpha = GObject.Property(type=float, default=1, minimum=0, maximum=1)
+
+    key = GObject.Property(type=str, default="")
+    item_type = GObject.Property(type=str, default="")
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        if self.props.key == "":
+            self.props.key = str(uuid.uuid4())
+        if self.props.item_type == "":
+            self.props.item_type = self.__gtype_name__
+
+    def to_dict(self):
+        return {key: self.get_property(key) for key in dir(self.props)}
 
 
 class Item(ItemBase):
-    def __init__(self, application, xdata=None, ydata=None, name="",
-                 xlabel="", ylabel=""):
-        super().__init__(
-            application.settings.get_child("figure"), name=name, xlabel=xlabel,
-            ylabel=ylabel)
-        if xdata is None:
-            xdata = []
-        if ydata is None:
-            ydata = []
-        self.xdata, self.ydata = xdata, ydata
-        self.linestyle = pyplot.rcParams["lines.linestyle"]
-        self.linewidth = float(pyplot.rcParams["lines.linewidth"])
-        self.markerstyle = pyplot.rcParams["lines.marker"]
-        self.markersize = float(pyplot.rcParams["lines.markersize"])
+    __gtype_name__ = "Item"
+
+    xdata = GObject.Property(type=object)
+    ydata = GObject.Property(type=object)
+    linestyle = GObject.Property(type=str, default="solid")
+    linewidth = GObject.Property(type=float, default=3)
+    markerstyle = GObject.Property(type=str, default="none")
+    markersize = GObject.Property(type=float, default=7)
+
+    @staticmethod
+    def new(application, xdata=None, ydata=None, **kwargs):
+        settings = application.settings.get_child("figure")
+        return Item(
+            yposition=settings.get_string("y-position"),
+            xposition=settings.get_string("x-position"),
+            linestyle=pyplot.rcParams["lines.linestyle"],
+            linewidth=pyplot.rcParams["lines.linewidth"],
+            markerstyle=pyplot.rcParams["lines.marker"],
+            markersize=pyplot.rcParams["lines.markersize"],
+            xdata=xdata, ydata=ydata, **kwargs,
+        )
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        if self.props.xdata is None:
+            self.props.xdata = []
+        if self.props.ydata is None:
+            self.props.ydata = []
 
 
 class TextItem(ItemBase):
-    def __init__(self, application, x_anchor=0, y_anchor=0, text="", name=""):
-        super().__init__(
-            application.settings.get_child("figure"), name=name,
-            color=pyplot.rcParams["text.color"])
-        self.x_anchor, self.y_anchor = float(x_anchor), float(y_anchor)
-        self.text = text
-        self.size = float(pyplot.rcParams["font.size"])
-        self.rotation = 0
+    __gtype_name__ = "TextItem"
+
+    xanchor = GObject.Property(type=float, default=0)
+    yanchor = GObject.Property(type=float, default=0)
+    text = GObject.Property(type=str, default="")
+    size = GObject.Property(type=float, default=12)
+    rotation = GObject.Property(type=int, default=0, minimum=0, maximum=360)
+
+    @staticmethod
+    def new(application, xanchor=0, yanchor=0, text="", **kwargs):
+        settings = application.settings.get_child("figure")
+        return TextItem(
+            yposition=settings.get_string("y-position"),
+            xposition=settings.get_string("x-position"),
+            size=pyplot.rcParams["font.size"],
+            xanchor=xanchor, yanchor=yanchor, text=text, **kwargs,
+        )
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        if self.props.color == "":
+            self.props.color = pyplot.rcParams["text.color"]

--- a/src/item_box.py
+++ b/src/item_box.py
@@ -46,8 +46,8 @@ class ItemBox(Gtk.Box):
         self.props.application.datadict = utilities.change_key_position(
             self.props.application.datadict, drop_target.key, value)
         ui.reload_item_menu(self.props.application)
-        self.props.application.Clipboard.add()
-        self.props.application.ViewClipboard.add()
+        self.props.application.props.clipboard.add()
+        self.props.application.props.view_clipboard.add()
         graphs.refresh(self.props.application)
 
     def on_dnd_prepare(self, drag_source, x, y):
@@ -83,8 +83,8 @@ class ItemBox(Gtk.Box):
                 self.props.item.color = utilities.rgba_to_hex(color).upper()
                 self.props.item.alpha = color.alpha
                 self.update_color()
-                self.props.application.Clipboard.add()
-                self.props.application.ViewClipboard.add()
+                self.props.application.props.clipboard.add()
+                self.props.application.props.view_clipboard.add()
                 graphs.refresh(self.props.application)
 
     @Gtk.Template.Callback()

--- a/src/item_box.py
+++ b/src/item_box.py
@@ -1,10 +1,11 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 import contextlib
 
-from gi.repository import GLib, Gdk, Gtk
+from gi.repository import Adw, GLib, GObject, Gdk, Gtk
 
 from graphs import graphs, ui, utilities
 from graphs.edit_item import EditItemWindow
+from graphs.item import ItemBase
 
 
 @Gtk.Template(resource_path="/se/sjoerd/Graphs/ui/item_box.ui")
@@ -14,12 +15,13 @@ class ItemBox(Gtk.Box):
     check_button = Gtk.Template.Child()
     color_button = Gtk.Template.Child()
 
+    application = GObject.Property(type=Adw.Application)
+    item = GObject.Property(type=ItemBase)
+
     def __init__(self, application, item):
-        super().__init__()
-        self.application = application
-        self.item = item
-        self.label.set_text(utilities.shorten_label(item.name))
-        self.check_button.set_active(item.selected)
+        super().__init__(application=application, item=item)
+        self.label.set_text(utilities.shorten_label(self.props.item.name))
+        self.check_button.set_active(self.props.item.selected)
 
         self.gesture = Gtk.GestureClick()
         self.gesture.set_button(0)
@@ -40,13 +42,13 @@ class ItemBox(Gtk.Box):
 
     def on_dnd_drop(self, drop_target, value, _x, _y):
         # Handle the dropped data here
-        self.application.datadict
-        self.application.datadict = utilities.change_key_position(
-            self.application.datadict, drop_target.key, value)
-        ui.reload_item_menu(self.application)
-        self.application.Clipboard.add()
-        self.application.ViewClipboard.add()
-        graphs.refresh(self.application)
+        self.props.application.datadict
+        self.props.application.datadict = utilities.change_key_position(
+            self.props.application.datadict, drop_target.key, value)
+        ui.reload_item_menu(self.props.application)
+        self.props.application.Clipboard.add()
+        self.props.application.ViewClipboard.add()
+        graphs.refresh(self.props.application)
 
     def on_dnd_prepare(self, drag_source, x, y):
         snapshot = Gtk.Snapshot.new()
@@ -54,47 +56,47 @@ class ItemBox(Gtk.Box):
         paintable = snapshot.to_paintable()
         drag_source.set_icon(paintable, int(x), int(y))
 
-        data = self.item.key
+        data = self.props.item.key
         return Gdk.ContentProvider.new_for_value(data)
 
     def update_color(self):
         self.provider.load_from_data(
             ("button {"
-             f" color: {self.item.color};"
-             f" opacity: {self.item.alpha};"
+             f" color: {self.props.item.color};"
+             f" opacity: {self.props.item.alpha};"
              "}"),
             -1)
 
     @Gtk.Template.Callback()
     def choose_color(self, _):
-        color = utilities.hex_to_rgba(self.item.color)
-        color.alpha = self.item.alpha
+        color = utilities.hex_to_rgba(self.props.item.color)
+        color.alpha = self.props.item.alpha
         dialog = Gtk.ColorDialog()
         dialog.choose_rgba(
-            self.application.main_window, color, None,
+            self.props.application.main_window, color, None,
             self.on_color_dialog_accept)
 
     def on_color_dialog_accept(self, dialog, result):
         with contextlib.suppress(GLib.GError):
             color = dialog.choose_rgba_finish(result)
             if color is not None:
-                self.item.color = utilities.rgba_to_hex(color).upper()
-                self.item.alpha = color.alpha
+                self.props.item.color = utilities.rgba_to_hex(color).upper()
+                self.props.item.alpha = color.alpha
                 self.update_color()
-                self.application.Clipboard.add()
-                self.application.ViewClipboard.add()
-                graphs.refresh(self.application)
+                self.props.application.Clipboard.add()
+                self.props.application.ViewClipboard.add()
+                graphs.refresh(self.props.application)
 
     @Gtk.Template.Callback()
     def delete(self, _):
-        graphs.delete_item(self.application, self.item.key, True)
+        graphs.delete_item(self.props.application, self.props.item.key, True)
 
     @Gtk.Template.Callback()
     def on_toggle(self, _):
-        self.item.selected = self.check_button.get_active()
-        graphs.refresh(self.application)
-        ui.enable_data_dependent_buttons(self.application)
+        self.props.item.selected = self.check_button.get_active()
+        graphs.refresh(self.props.application)
+        ui.enable_data_dependent_buttons(self.props.application)
 
     @Gtk.Template.Callback()
     def edit(self, _):
-        EditItemWindow(self.application, self.item)
+        EditItemWindow(self.props.application, self.props.item)

--- a/src/main.py
+++ b/src/main.py
@@ -29,6 +29,8 @@ class GraphsApplication(Adw.Application):
 
     datadict = GObject.Property(type=object)
     figure_settings = GObject.Property(type=FigureSettings)
+    clipboard = GObject.Property(type=DataClipboard)
+    view_clipboard = GObject.Property(type=ViewClipboard)
 
     def __init__(self, args):
         """Init the application."""
@@ -126,8 +128,8 @@ class GraphsApplication(Adw.Application):
         pyplot.rcParams.update(
             file_io.parse_style(plot_styles.get_preferred_style(self)))
         self.canvas = Canvas(self)
-        self.Clipboard = DataClipboard(self)
-        self.ViewClipboard = ViewClipboard(self)
+        self.props.clipboard = DataClipboard(self)
+        self.props.view_clipboard = ViewClipboard(self)
         self.main_window.toast_overlay.set_child(self.canvas)
         ui.set_clipboard_buttons(self)
         ui.enable_data_dependent_buttons(self)

--- a/src/main.py
+++ b/src/main.py
@@ -26,15 +26,18 @@ class GraphsApplication(Adw.Application):
     issues = GObject.Property(type=str, default="")
     author = GObject.Property(type=str, default="")
     pkgdatadir = GObject.Property(type=str, default="")
+
     datadict = GObject.Property(type=object)
+    figure_settings = GObject.Property(type=FigureSettings)
 
     def __init__(self, args):
         """Init the application."""
+        settings = Gio.Settings(args[1])
         super().__init__(
             application_id=args[1], flags=Gio.ApplicationFlags.DEFAULT_FLAGS,
             version=args[0], name=args[2], website=args[3], issues=args[4],
-            author=args[5], pkgdatadir=args[6],
-            datadict={}, settings=Gio.Settings(args[1]),
+            author=args[5], pkgdatadir=args[6], datadict={}, settings=settings,
+            figure_settings=FigureSettings.new(settings.get_child("figure")),
         )
         migrate.migrate_config(self)
         font_list = font_manager.findSystemFonts(fontpaths=None, fontext="ttf")
@@ -46,6 +49,8 @@ class GraphsApplication(Adw.Application):
         self.add_actions()
         self.get_style_manager().connect(
             "notify", ui.on_style_change, None, self)
+
+        self.plot_settings = self.props.figure_settings
 
     def add_actions(self):
         """Create actions, which are defined in actions.py."""
@@ -118,8 +123,6 @@ class GraphsApplication(Adw.Application):
         self.main_window.set_title(self.name)
         if "(Development)" in self.name:
             self.main_window.add_css_class("devel")
-        self.plot_settings = \
-            FigureSettings.new(self.settings.get_child("figure"))
         pyplot.rcParams.update(
             file_io.parse_style(plot_styles.get_preferred_style(self)))
         self.canvas = Canvas(self)

--- a/src/main.py
+++ b/src/main.py
@@ -10,7 +10,8 @@ from gi.repository import Adw, GLib, GObject, Gio
 from graphs import actions, file_io, migrate, plot_styles, plotting_tools, ui
 from graphs.canvas import Canvas
 from graphs.clipboard import DataClipboard, ViewClipboard
-from graphs.misc import InteractionMode, PlotSettings
+from graphs.misc import InteractionMode
+from graphs.plot_settings import FigureSettings
 from graphs.window import GraphsWindow
 
 from matplotlib import font_manager, pyplot
@@ -117,7 +118,8 @@ class GraphsApplication(Adw.Application):
         self.main_window.set_title(self.name)
         if "(Development)" in self.name:
             self.main_window.add_css_class("devel")
-        self.plot_settings = PlotSettings(self.settings.get_child("figure"))
+        self.plot_settings = \
+            FigureSettings.new(self.settings.get_child("figure"))
         pyplot.rcParams.update(
             file_io.parse_style(plot_styles.get_preferred_style(self)))
         self.canvas = Canvas(self)

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 configure_file(
-  input: 'graphs.in',
-  output: project_name,
-  configuration: conf,
-  install: true,
-  install_mode: 'rwxr-xr-x',
+        input: 'graphs.in',
+       output: project_name,
+configuration: conf,
+      install: true,
+ install_mode: 'rwxr-xr-x',
   install_dir: bindir
 )
 
@@ -29,6 +29,7 @@ graphs_sources = [
   'plot_styles.py',
   'plotting_tools.py',
   'preferences.py',
+  'project.py',
   'rename.py',
   'transform_data.py',
   'ui.py',

--- a/src/migrate.py
+++ b/src/migrate.py
@@ -79,6 +79,7 @@ def _migrate_import_params(self, import_file):
 class PlotSettings:
     pass
 
+
 class Item:
     pass
 
@@ -126,6 +127,7 @@ def _migrate_item(item: Item) -> dict:
     dictionary["item_type"] = "Item"
     return dictionary
 
+
 PLOT_SETTINGS_MIGRATION_TABLE = {
     "xlabel": "bottom_label",
     "ylabel": "left_label",
@@ -134,6 +136,7 @@ PLOT_SETTINGS_MIGRATION_TABLE = {
     "use_custom_plot_style": "use_custom_style",
     "custom_plot_style": "custom_style",
 }
+
 
 def _migrate_plot_settings(item: Item) -> dict:
     return {

--- a/src/migrate.py
+++ b/src/migrate.py
@@ -107,8 +107,8 @@ def migrate_project(file):
         "data-clipboard": [{"data": [],
                             "view": DEFAULT_VIEW.copy()}],
         "data-clipboard-position": project["clipboard_pos"],
-        "view-clipboard": [],
-        "view-clipboard-position": -1,
+        "view-clipboard": None,
+        "view-clipboard-position": None,
     }
 
 

--- a/src/migrate.py
+++ b/src/migrate.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 import contextlib
+import pickle
+import sys
 
 from graphs import file_io, utilities
 
@@ -72,3 +74,70 @@ def _migrate_import_params(self, import_file):
             elif isinstance(value, int):
                 settings.set_int(key, value)
     import_file.delete(None)
+
+
+class PlotSettings:
+    pass
+
+class Item:
+    pass
+
+
+DEFAULT_VIEW = {
+    "min_bottom": 0,
+    "max_bottom": 1,
+    "min_top": 0,
+    "max_top": 10,
+    "min_left": 0,
+    "max_left": 1,
+    "min_right": 0,
+    "max_right": 10,
+}
+
+
+def migrate_project(file):
+    sys.modules["graphs.misc"] = sys.modules[__name__]
+    sys.modules["graphs.item"] = sys.modules[__name__]
+    project = pickle.loads(file_io.read_file(file, None))
+
+    return {
+        "version": project["version"],
+        "data": [_migrate_item(item) for item in project["data"].values()],
+        "figure-settings": _migrate_plot_settings(project["plot_settings"]),
+        "data-clipboard": [{"data": [],
+                            "view": DEFAULT_VIEW.copy()}],
+        "data-clipboard-position": project["clipboard_pos"],
+        "view-clipboard": [],
+        "view-clipboard-position": -1,
+    }
+
+
+ITEM_MIGRATION_TABLE = {
+    "plot_x_position": "xposition",
+    "plot_y_position": "yposition",
+}
+
+
+def _migrate_item(item: Item) -> dict:
+    dictionary = {
+        ITEM_MIGRATION_TABLE[key] if key in ITEM_MIGRATION_TABLE
+        else key: value for key, value in item.__dict__.items()
+    }
+    dictionary["item_type"] = "Item"
+    return dictionary
+
+PLOT_SETTINGS_MIGRATION_TABLE = {
+    "xlabel": "bottom_label",
+    "ylabel": "left_label",
+    "xscale": "bottom_scale",
+    "yscale": "left_scale",
+    "use_custom_plot_style": "use_custom_style",
+    "custom_plot_style": "custom_style",
+}
+
+def _migrate_plot_settings(item: Item) -> dict:
+    return {
+        PLOT_SETTINGS_MIGRATION_TABLE[key]
+        if key in PLOT_SETTINGS_MIGRATION_TABLE
+        else key: value for key, value in item.__dict__.items()
+    }

--- a/src/misc.py
+++ b/src/misc.py
@@ -2,39 +2,6 @@
 from enum import Enum
 
 
-def _get_scale(settings, key):
-    return "linear" if settings.get_enum(key) == 0 else "log"
-
-
-class PlotSettings:
-    """
-    The plot-related settings for the current session. The default values are
-    retreived from the preferencess file.
-    """
-    def __init__(self, settings):
-        self.xlabel = None
-        self.right_label = None
-        self.top_label = None
-        self.ylabel = None
-        self.xscale = _get_scale(settings, "bottom-scale")
-        self.yscale = _get_scale(settings, "left-scale")
-        self.right_scale = _get_scale(settings, "right-scale")
-        self.top_scale = _get_scale(settings, "top-scale")
-        self.title = settings.get_string("title")
-        self.legend = settings.get_boolean("legend")
-        self.use_custom_plot_style = settings.get_boolean("use-custom-style")
-        self.legend_position = settings.get_string("legend-position")
-        self.custom_plot_style = settings.get_string("custom-style")
-        self.min_bottom = 0
-        self.max_bottom = 1
-        self.min_top = 0
-        self.max_top = 10
-        self.min_left = 0
-        self.max_left = 1
-        self.min_right = 0
-        self.max_right = 10
-
-
 class InteractionMode(str, Enum):
     PAN = "pan/zoom"
     ZOOM = "zoom rect"

--- a/src/operations.py
+++ b/src/operations.py
@@ -85,6 +85,7 @@ def perform_operation(self, callback, *args):
             _("No data found within the highlighted area"))
     graphs.refresh(self)
     plotting_tools.optimize_limits(self)
+    self.ViewClipboard.add()
     self.Clipboard.add()
 
 

--- a/src/operations.py
+++ b/src/operations.py
@@ -85,8 +85,7 @@ def perform_operation(self, callback, *args):
             _("No data found within the highlighted area"))
     graphs.refresh(self)
     plotting_tools.optimize_limits(self)
-    self.ViewClipboard.add()
-    self.Clipboard.add()
+    self.props.clipboard.add()
 
 
 def translate_x(_item, xdata, ydata, offset):

--- a/src/operations.py
+++ b/src/operations.py
@@ -24,7 +24,7 @@ def get_data(self, item):
     stop_index = len(xdata)
     if self.interaction_mode == InteractionMode.SELECT:
         startx, stopx = self.canvas.highlight.get_start_stop(
-            item.plot_x_position == "bottom")
+            item.xposition == "bottom")
 
         # If startx and stopx are not out of range, that is,
         # if the item data is within the highlight
@@ -172,9 +172,9 @@ def shift_vertically(item, xdata, ydata, yscale, right_scale, datadict):
         previous_ydata = data_list[index - 1].ydata
         ymin = min(x for x in previous_ydata if x != 0)
         ymax = max(x for x in previous_ydata if x != 0)
-        if item.plot_y_position == "left":
+        if item.yposition == "left":
             linear = (yscale == "linear")
-        if item.plot_y_position == "right":
+        if item.yposition == "right":
             linear = (right_scale == "linear")
         if linear:
             shift_value_linear += 1.2 * (ymax - ymin)
@@ -249,4 +249,4 @@ def combine(self):
     # Create the item itself
     new_xdata, new_ydata = sort_data(new_xdata, new_ydata)
     graphs.add_items(
-        self, [Item(self, new_xdata, new_ydata, name=_("Combined Data"))])
+        self, [Item.new(self, new_xdata, new_ydata, name=_("Combined Data"))])

--- a/src/plot_settings.py
+++ b/src/plot_settings.py
@@ -195,8 +195,8 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
         }
 
         graphs.refresh(self.props.application)
-        self.props.application.Clipboard.add()
-        self.props.application.ViewClipboard.add()
+        self.props.application.props.clipboard.add()
+        self.props.application.props.view_clipboard.add()
 
     @Gtk.Template.Callback()
     def on_custom_style_select(self, comborow, _ignored):

--- a/src/plot_settings.py
+++ b/src/plot_settings.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
-from gi.repository import Adw, Gtk, GObject
+from gi.repository import Adw, GObject, Gtk
 
 from graphs import graphs, misc, plot_styles, plotting_tools, ui, utilities
 from graphs.item import Item

--- a/src/plot_settings.py
+++ b/src/plot_settings.py
@@ -1,10 +1,63 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
-from gi.repository import Adw, Gtk
+from gi.repository import Adw, Gtk, GObject
 
 from graphs import graphs, misc, plot_styles, plotting_tools, ui, utilities
 from graphs.item import Item
 
 from matplotlib import pyplot
+
+
+class FigureSettings(GObject.Object):
+    __gtype_name__ = "FigureSettings"
+
+    title = GObject.Property(type=str, default="")
+    bottom_label = GObject.Property(type=str, default="")
+    left_label = GObject.Property(type=str, default="")
+    top_label = GObject.Property(type=str, default="")
+    right_label = GObject.Property(type=str, default="")
+
+    bottom_scale = GObject.Property(type=str, default="linear")
+    left_scale = GObject.Property(type=str, default="linear")
+    top_scale = GObject.Property(type=str, default="linear")
+    right_scale = GObject.Property(type=str, default="linear")
+
+    legend = GObject.Property(type=bool, default=True)
+    legend_position = GObject.Property(type=str, default="Best")
+    use_custom_style = GObject.Property(type=bool, default=False)
+    custom_style = GObject.Property(type=str, default="adwaita")
+
+    min_bottom = GObject.Property(type=int, default=0)
+    max_bottom = GObject.Property(type=int, default=1)
+    min_left = GObject.Property(type=int, default=0)
+    max_left = GObject.Property(type=int, default=10)
+    min_top = GObject.Property(type=int, default=0)
+    max_top = GObject.Property(type=int, default=1)
+    min_right = GObject.Property(type=int, default=0)
+    max_right = GObject.Property(type=int, default=10)
+
+    @staticmethod
+    def new(settings):
+        def _get_scale(scale):
+            return "linear" if settings.get_enum(scale) == 0 else "log"
+
+        return FigureSettings(
+            bottom_scale=_get_scale("bottom-scale"),
+            left_scale=_get_scale("left-scale"),
+            right_scale=_get_scale("right-scale"),
+            top_scale=_get_scale("top-scale"),
+            title=settings.get_string("title"),
+            legend=settings.get_boolean("legend"),
+            use_custom_style=settings.get_boolean("use-custom-style"),
+            legend_position=settings.get_string("legend-position"),
+            custom_style=settings.get_string("custom-style"),
+        )
+
+    @staticmethod
+    def new_from_dict(dictionary: dict):
+        return FigureSettings(**dictionary)
+
+    def to_dict(self):
+        return {key: self.get_property(key) for key in dir(self.props)}
 
 
 @Gtk.Template(resource_path="/se/sjoerd/Graphs/ui/plot_settings.ui")
@@ -49,18 +102,19 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
         self.min_top.set_text(str(self.plot_settings.min_top))
         self.max_top.set_text(str(self.plot_settings.max_top))
 
-        if self.plot_settings.xlabel is not None:
-            self.plot_x_label.set_text(self.plot_settings.xlabel)
-        if self.plot_settings.ylabel is not None:
-            self.plot_y_label.set_text(self.plot_settings.ylabel)
-        if self.plot_settings.top_label is not None:
+        if self.plot_settings.bottom_label != "":
+            self.plot_x_label.set_text(self.plot_settings.bottom_label)
+        if self.plot_settings.left_label != "":
+            self.plot_y_label.set_text(self.plot_settings.left_label)
+        if self.plot_settings.top_label != "":
             self.plot_top_label.set_text(self.plot_settings.top_label)
-        if self.plot_settings.right_label is not None:
+        if self.plot_settings.right_label != "":
             self.plot_right_label.set_text(self.plot_settings.right_label)
         utilities.populate_chooser(self.plot_x_scale, misc.SCALES)
-        utilities.set_chooser(self.plot_x_scale, self.plot_settings.xscale)
+        utilities.set_chooser(
+            self.plot_x_scale, self.plot_settings.bottom_scale)
         utilities.populate_chooser(self.plot_y_scale, misc.SCALES)
-        utilities.set_chooser(self.plot_y_scale, self.plot_settings.yscale)
+        utilities.set_chooser(self.plot_y_scale, self.plot_settings.left_scale)
         utilities.populate_chooser(self.plot_top_scale, misc.SCALES)
         utilities.set_chooser(
             self.plot_top_scale, self.plot_settings.top_scale)
@@ -68,13 +122,13 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
         utilities.set_chooser(
             self.plot_right_scale, self.plot_settings.right_scale)
         self.use_custom_plot_style.set_enable_expansion(
-            self.plot_settings.use_custom_plot_style)
+            self.plot_settings.use_custom_style)
         utilities.populate_chooser(
             self.custom_plot_style,
             sorted(plot_styles.get_user_styles(self.props.application).keys()),
             translate=False)
         utilities.set_chooser(
-            self.custom_plot_style, self.plot_settings.custom_plot_style)
+            self.custom_plot_style, self.plot_settings.custom_style)
         self.plot_legend.set_enable_expansion(self.plot_settings.legend)
         utilities.populate_chooser(
             self.plot_legend_position, misc.LEGEND_POSITIONS)
@@ -107,14 +161,14 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
         if self.plot_title.get_text() != "":
             self.plot_settings.title = self.plot_title.get_text()
         if self.plot_x_label.get_text() != "":
-            self.plot_settings.xlabel = self.plot_x_label.get_text()
+            self.plot_settings.bottom_label = self.plot_x_label.get_text()
         if self.plot_y_label.get_text() != "":
-            self.plot_settings.ylabel = self.plot_y_label.get_text()
+            self.plot_settings.left_label = self.plot_y_label.get_text()
         if self.plot_top_label.get_text() != "":
             self.plot_settings.top_label = self.plot_top_label.get_text()
         if self.plot_right_label.get_text() != "":
             self.plot_settings.right_label = self.plot_right_label.get_text()
-        self.plot_settings.xscale = \
+        self.plot_settings.bottom_scale = \
             utilities.get_selected_chooser_item(self.plot_x_scale)
         self.plot_settings.yscale = \
             utilities.get_selected_chooser_item(self.plot_y_scale)
@@ -147,17 +201,17 @@ class PlotSettingsWindow(Adw.PreferencesWindow):
     @Gtk.Template.Callback()
     def on_custom_style_select(self, comborow, _ignored):
         selected_style = utilities.get_selected_chooser_item(comborow)
-        if selected_style == self.plot_settings.custom_plot_style:
+        if selected_style == self.plot_settings.custom_style:
             return
-        self.plot_settings.custom_plot_style = selected_style
+        self.plot_settings.custom_style = selected_style
         self._handle_style_change()
 
     @Gtk.Template.Callback()
     def on_custom_style_enable(self, expanderrow, _ignored):
         use_custom_style = expanderrow.get_enable_expansion()
-        if use_custom_style == self.plot_settings.use_custom_plot_style:
+        if use_custom_style == self.plot_settings.use_custom_style:
             return
-        self.plot_settings.use_custom_plot_style = use_custom_style
+        self.plot_settings.use_custom_style = use_custom_style
         self._handle_style_change()
 
     def _handle_style_change(self):

--- a/src/plot_styles.py
+++ b/src/plot_styles.py
@@ -69,16 +69,16 @@ def get_system_preferred_style(self):
 
 
 def get_preferred_style(self):
-    if not self.plot_settings.use_custom_plot_style:
+    if not self.plot_settings.use_custom_style:
         return get_system_preferred_style(self)
-    stylename = self.plot_settings.custom_plot_style
+    stylename = self.plot_settings.custom_style
     try:
         return get_user_styles(self)[stylename]
     except KeyError:
         self.main_window.add_toast(
             _(f"Plot style {stylename} does not exist "
               "loading system preferred"))
-        self.plot_settings.use_custom_plot_style = False
+        self.plot_settings.use_custom_style = False
         return get_system_preferred_style(self)
 
 

--- a/src/plotting_tools.py
+++ b/src/plotting_tools.py
@@ -94,7 +94,7 @@ def _change_scale(self, action, target):
 def change_left_scale(action, target, self):
     self.canvas.axis.set_yscale(target.get_string())
     self.canvas.top_left_axis.set_yscale(target.get_string())
-    self.plot_settings.yscale = target.get_string()
+    self.plot_settings.left_scale = target.get_string()
     _change_scale(self, action, target)
 
 
@@ -115,7 +115,7 @@ def change_top_scale(action, target, self):
 def change_bottom_scale(action, target, self):
     self.canvas.axis.set_xscale(target.get_string())
     self.canvas.right_axis.set_xscale(target.get_string())
-    self.plot_settings.xscale = target.get_string()
+    self.plot_settings.bottom_scale = target.get_string()
     _change_scale(self, action, target)
 
 

--- a/src/plotting_tools.py
+++ b/src/plotting_tools.py
@@ -1,6 +1,4 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
-import contextlib
-
 from graphs import graphs, utilities
 from graphs.item import Item
 

--- a/src/plotting_tools.py
+++ b/src/plotting_tools.py
@@ -8,9 +8,8 @@ from matplotlib import pyplot
 
 
 def optimize_limits(self):
-    with contextlib.suppress(KeyError):
-        self.Clipboard.clipboard[self.Clipboard.clipboard_pos]["view"] = \
-            self.canvas.limits
+    self.props.clipboard.clipboard[self.props.clipboard.clipboard_pos][
+        "view"] = self.canvas.limits
     used_axes, items = utilities.get_used_axes(self)
     axis_map = {
         "left": self.canvas.axis,
@@ -65,6 +64,7 @@ def optimize_limits(self):
         limits[f"max_{direction}"] = max_all
     self.canvas.limits = limits
     self.canvas.apply_limits()
+    self.props.view_clipboard.add()
 
 
 def hide_unused_axes(self, canvas):
@@ -91,7 +91,6 @@ def _change_scale(self, action, target):
     action.change_state(target)
     graphs.refresh(self)
     optimize_limits(self)
-    self.ViewClipboard.add()
 
 
 def change_left_scale(action, target, self):

--- a/src/plotting_tools.py
+++ b/src/plotting_tools.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
+import contextlib
+
 from graphs import graphs, utilities
 from graphs.item import Item
 
@@ -6,8 +8,9 @@ from matplotlib import pyplot
 
 
 def optimize_limits(self):
-    self.Clipboard.clipboard[self.Clipboard.clipboard_pos]["view"] = \
-        self.canvas.limits
+    with contextlib.suppress(KeyError):
+        self.Clipboard.clipboard[self.Clipboard.clipboard_pos]["view"] = \
+            self.canvas.limits
     used_axes, items = utilities.get_used_axes(self)
     axis_map = {
         "left": self.canvas.axis,
@@ -62,7 +65,6 @@ def optimize_limits(self):
         limits[f"max_{direction}"] = max_all
     self.canvas.limits = limits
     self.canvas.apply_limits()
-    self.canvas.application.ViewClipboard.add()
 
 
 def hide_unused_axes(self, canvas):
@@ -89,6 +91,7 @@ def _change_scale(self, action, target):
     action.change_state(target)
     graphs.refresh(self)
     optimize_limits(self)
+    self.ViewClipboard.add()
 
 
 def change_left_scale(action, target, self):

--- a/src/project.py
+++ b/src/project.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+
+def create_project(self) -> dict:
+    project = {
+        "version": self.version,
+        "data": [item.to_dict() for item in self.datadict.values()],
+    }
+
+    print(project)
+
+
+def load_project(self, project: dict):
+    pass

--- a/src/project.py
+++ b/src/project.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 from gi.repository import Gio
 
-from graphs import file_io, graphs, item, ui, migrate, plotting_tools
+from graphs import file_io, graphs, item, migrate, plotting_tools, ui
 from graphs.plot_settings import FigureSettings
 
 
@@ -13,7 +13,7 @@ def save_project(self, file: Gio.File):
         "data-clipboard": self.props.clipboard.props.clipboard,
         "data-clipboard-position": self.props.clipboard.props.clipboard_pos,
         "view-clipboard": self.props.view_clipboard.props.clipboard,
-        "view-clipboard-position": \
+        "view-clipboard-position":
             self.props.view_clipboard.props.clipboard_pos,
     })
 
@@ -32,7 +32,8 @@ def load_project(self, file: Gio.File):
     self.props.datadict = {item.key: item for item in items}
 
     self.props.clipboard.props.clipboard = project["data-clipboard"]
-    self.props.clipboard.props.clipboard_pos = project["data-clipboard-position"]
+    self.props.clipboard.props.clipboard_pos = \
+        project["data-clipboard-position"]
 
     # migrated project
     if project["view-clipboard"] is None:

--- a/src/project.py
+++ b/src/project.py
@@ -1,14 +1,40 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
+from gi.repository import Gio
+
+from graphs import file_io, graphs, item, ui
+from graphs.plot_settings import FigureSettings
 
 
-def create_project(self) -> dict:
-    project = {
+def save_project(self, file: Gio.File):
+    file_io.write_json(file, {
         "version": self.version,
         "data": [item.to_dict() for item in self.datadict.values()],
-    }
+        "figure-settings": self.props.figure_settings.to_dict(),
+        "data-clipboard": self.Clipboard.props.clipboard,
+        "data-clipboard-position": self.Clipboard.props.clipboard_pos,
+        "view-clipboard": self.ViewClipboard.props.clipboard,
+        "view-clipboard-position": self.ViewClipboard.props.clipboard_pos,
+    })
 
-    print(project)
 
+def load_project(self, file: Gio.File):
+    project = file_io.parse_json(file)
 
-def load_project(self, project: dict):
-    pass
+    self.Clipboard.clear()
+    self.ViewClipboard.clear()
+    self.props.figure_settings = \
+        FigureSettings.new_from_dict(project["figure-settings"])
+    items = [item.new_from_dict(d) for d in project["data"]]
+    self.datadict = {item.key: item for item in items}
+
+    self.Clipboard.props.clipboard = project["data-clipboard"]
+    self.Clipboard.props.clipboard_pos = project["data-clipboard-position"]
+    self.ViewClipboard.props.clipboard = project["view-clipboard"]
+    self.ViewClipboard.props.clipboard_pos = project["view-clipboard-position"]
+
+    self.canvas.limits = self.ViewClipboard.props.clipboard[-1]
+    self.canvas.apply_limits()
+    ui.reload_item_menu(self)
+    ui.enable_data_dependent_buttons(self)
+    ui.set_clipboard_buttons(self)
+    graphs.reload(self)

--- a/src/rename.py
+++ b/src/rename.py
@@ -34,9 +34,9 @@ class RenameWindow(Adw.Window):
         if self.item == self.props.application.canvas.top_label:
             self.props.application.plot_settings.top_label = text
         if self.item == self.props.application.canvas.left_label:
-            self.props.application.plot_settings.ylabel = text
+            self.props.application.plot_settings.left_label = text
         if self.item == self.props.application.canvas.bottom_label:
-            self.props.application.plot_settings.xlabel = text
+            self.props.application.plot_settings.bottom_label = text
         if self.item == self.props.application.canvas.right_label:
             self.props.application.plot_settings.right_label = text
         if self.item == self.props.application.canvas.title:

--- a/src/ui.py
+++ b/src/ui.py
@@ -6,7 +6,7 @@ from gettext import gettext as _
 
 from gi.repository import Adw, GLib, Gio, Gtk
 
-from graphs import file_import, file_io, graphs, utilities
+from graphs import file_import, file_io, graphs, project, utilities
 from graphs.item import Item
 from graphs.item_box import ItemBox
 
@@ -68,9 +68,7 @@ def save_project_dialog(self):
     def on_response(dialog, response):
         with contextlib.suppress(GLib.GError):
             file = dialog.save_finish(response)
-            file_io.save_project(
-                file, self.plot_settings, self.datadict, self.Clipboard,
-                self.ViewClipboard, self.version)
+            project.save_project(self, file)
     dialog = Gtk.FileDialog()
     dialog.set_filters(
         utilities.create_file_filters([(_("Graphs Project File"),
@@ -83,7 +81,7 @@ def open_project_dialog(self):
     def on_response(dialog, response):
         with contextlib.suppress(GLib.GError):
             file = dialog.open_finish(response)
-            graphs.open_project(self, file)
+            project.load_project(self, file)
     dialog = Gtk.FileDialog()
     dialog.set_filters(
         utilities.create_file_filters([(_("Graphs Project File"),

--- a/src/ui.py
+++ b/src/ui.py
@@ -21,14 +21,15 @@ def set_clipboard_buttons(self):
     and forwards view.
     """
     self.main_window.view_forward_button.set_sensitive(
-        self.ViewClipboard.clipboard_pos < - 1)
+        self.props.view_clipboard.clipboard_pos < - 1)
     self.main_window.view_back_button.set_sensitive(
-        abs(self.ViewClipboard.clipboard_pos)
-        < len(self.ViewClipboard.clipboard))
+        abs(self.props.view_clipboard.clipboard_pos)
+        < len(self.props.view_clipboard.clipboard))
     self.main_window.undo_button.set_sensitive(
-        abs(self.Clipboard.clipboard_pos) < len(self.Clipboard.clipboard))
+        abs(self.props.clipboard.clipboard_pos)
+        < len(self.props.clipboard.clipboard))
     self.main_window.redo_button.set_sensitive(
-        self.Clipboard.clipboard_pos < - 1)
+        self.props.clipboard.clipboard_pos < - 1)
 
 
 def enable_data_dependent_buttons(self):

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -43,16 +43,16 @@ def get_used_axes(self):
         "bottom": [],
     }
     for item in self.datadict.values():
-        if item.plot_y_position == "left":
+        if item.yposition == "left":
             used_axes["left"] = True
             items["left"].append(item)
-        if item.plot_y_position == "right":
+        if item.yposition == "right":
             used_axes["right"] = True
             items["right"].append(item)
-        if item.plot_x_position == "top":
+        if item.xposition == "top":
             used_axes["top"] = True
             items["top"].append(item)
-        if item.plot_x_position == "bottom":
+        if item.xposition == "bottom":
             used_axes["bottom"] = True
             items["bottom"].append(item)
     return used_axes, items


### PR DESCRIPTION
Closes https://github.com/Sjoerd1993/Graphs/issues/394
Use new Format for storing project files.
Refactor huge portions of the codebase to adapt new format.
Rename some item and figure_settings properties.

Old project files can still be opened. (Ones created in 1.6.1 or earlier. Clipboards are lost however (like the current implementation))
