### PR TITLE
Minor bug fixes

### DIFF
--- a/src/clipboard.py
+++ b/src/clipboard.py
@@ -77,7 +77,6 @@ class DataClipboard(BaseClipboard):
         performed
         """
         super().undo()
-        graphs.check_open_data(self.props.application)
         ui.reload_item_menu(self.props.application)
         self.props.application.props.view_clipboard.add()
 
@@ -87,7 +86,6 @@ class DataClipboard(BaseClipboard):
         changes the dataset to the state before the previous action was undone
         """
         super().redo()
-        graphs.check_open_data(self.props.application)
         ui.reload_item_menu(self.props.application)
         self.props.application.props.view_clipboard.add()
 

--- a/src/graphs.py
+++ b/src/graphs.py
@@ -79,7 +79,6 @@ def delete_item(self, key, give_toast=False):
     if give_toast:
         self.main_window.add_toast(_("Deleted {name}").format(name=name))
     self.props.clipboard.add()
-    check_open_data(self)
 
 
 def check_open_data(self):

--- a/src/operations.py
+++ b/src/operations.py
@@ -157,7 +157,7 @@ def center(_item, xdata, ydata, center_maximum):
     return new_xdata, ydata, True, False
 
 
-def shift_vertically(item, xdata, ydata, yscale, right_scale, datadict):
+def shift_vertically(item, xdata, ydata, left_scale, right_scale, datadict):
     """
     Shifts data vertically with respect to each other
     By default it scales linear data by 1.2 times the total span of the
@@ -173,7 +173,7 @@ def shift_vertically(item, xdata, ydata, yscale, right_scale, datadict):
         ymin = min(x for x in previous_ydata if x != 0)
         ymax = max(x for x in previous_ydata if x != 0)
         if item.yposition == "left":
-            linear = (yscale == "linear")
+            linear = (left_scale == "linear")
         if item.yposition == "right":
             linear = (right_scale == "linear")
         if linear:

--- a/src/ui.py
+++ b/src/ui.py
@@ -47,6 +47,7 @@ def reload_item_menu(self):
 
     for item in self.datadict.values():
         self.main_window.item_list.append(ItemBox(self, item))
+    graphs.check_open_data(self)
 
 
 def add_data_dialog(self):

--- a/src/window.py
+++ b/src/window.py
@@ -39,7 +39,7 @@ class GraphsWindow(Adw.ApplicationWindow):
         app = self.props.application
         operations.perform_operation(
             app, operations.shift_vertically,
-            app.plot_settings.yscale, app.plot_settings.right_scale,
+            app.plot_settings.left_scale, app.plot_settings.right_scale,
             app.datadict)
 
     @Gtk.Template.Callback()


### PR DESCRIPTION
In the last PR, I found some bugs which I solved along the way, and thought it was easiest to just push those in a seperate PR. 

- Shift vertically was no longer working. This is because the term `yscale` was replaced to the much more sensible left_scale. (Using `yscale` for left the `left scale`, but `right_scale` for the right scale is a terrible idea so this was a good change. The reason for this inconsistency was simply due to historic reasons, in the very first version when this `shift_vertically` function was implemented, there was only support for a single y-scale, so back then the `y_scale` name made sense. Then I added a second y-scale, hence the `right_scale` name, but  didn't rename the left-hand scale.
Anyway, this is fixed now

- Open loading a project, the items were not loaded into the menu if the menu was previously empty. This was because it's hidden (so the placeholder can be shown), and the `check_for_open_data` function was never run so it remained hidden. I changed it now to check for open data automatically when refreshing the item menu. This way, we don't have to manually run this function each time.