### PR TITLE
Fix clipboard

### DIFF
--- a/src/clipboard.py
+++ b/src/clipboard.py
@@ -2,6 +2,8 @@ from gi.repository import Adw, GObject
 
 from graphs import ui
 
+import copy
+
 import numpy
 
 
@@ -66,7 +68,7 @@ class DataClipboard(BaseClipboard):
         Appends the latest state to the clipboard.
         """
         super().add({
-            "data": self.props.application.props.data.to_list(),
+            "data": copy.deepcopy(self.props.application.props.data.to_list()),
             "view": self.props.application.props.figure_settings.get_limits(),
         })
         # Keep clipboard length limited to preference values


### PR DESCRIPTION
This took way too much time for such a simple fix, but in the current branch the clipboard is broken. The reason turned out to be that the data in the clipboard is saved as a list, where the items are all pointing to the same item in memory. So any changes to the data affect the entire clipboard.