### PR TITLE
Suggestion: Redesign operations

### DIFF
--- a/data/ui/window.blp
+++ b/data/ui/window.blp
@@ -204,23 +204,21 @@ template $GraphsWindow : Adw.ApplicationWindow {
         ScrolledWindow {
           hscrollbar-policy: never;
           Viewport {
-            Adw.PreferencesGroup {
+            Box {
+              orientation: vertical;
               vexpand: true;
               hexpand: false;
+              spacing: 12;
               margin-start: 12;
               margin-end: 12;
-              margin-top: 12;
-              margin-bottom: 12;
+              margin-top: 6;
+              margin-bottom: 18;
 
-              Adw.ExpanderRow {
+              Adw.PreferencesGroup {
                 title: _("Adjust Data");
                 Grid {
                   column-spacing: 10;
                   row-spacing: 10;
-                  margin-start: 10;
-                  margin-end: 10;
-                  margin-top: 10;
-                  margin-bottom: 10;
                   Button shift_vertically_button {
                     hexpand: true;
                     layout {
@@ -318,15 +316,11 @@ template $GraphsWindow : Adw.ApplicationWindow {
                 }
               }
 
-              Adw.ExpanderRow {
+              Adw.PreferencesGroup {
                 title: _("Mathematical Operations");
                 Grid {
                   column-spacing: 10;
                   row-spacing: 10;
-                  margin-start: 10;
-                  margin-end: 10;
-                  margin-top: 10;
-                  margin-bottom: 10;
                   Button {
                     hexpand: true;
                     sensitive: bind shift_vertically_button.sensitive;
@@ -410,16 +404,12 @@ template $GraphsWindow : Adw.ApplicationWindow {
                 }
               }
 
-              Adw.ExpanderRow {
+              Adw.PreferencesGroup {
                 title: _("Translate and Multiply");
 
                 Grid {
                   column-spacing: 10;
                   row-spacing: 10;
-                  margin-start: 10;
-                  margin-end: 10;
-                  margin-top: 10;
-                  margin-bottom: 10;
                   Entry translate_x_entry {
                     max-width-chars: 6;
                     hexpand: true;


### PR DESCRIPTION
![Bildschirmfoto vom 2023-08-25 17-38-21](https://github.com/Sjoerd1993/Graphs/assets/59118042/979f6e41-2c02-48bf-8a6f-6be6535e1390)

Open for discussion if we wanna keep it the way it is or change it.
The benefits of this are in my opinion, that buttons always stay relative to each other.
On small resolutions you'd always have to scroll but given the default resolution all elements (except translation) are visible.
On a 100% scaled 1080p monitor all items are visible without the need for a scrollbar.