### PR TITLE
Limit item name length

### DIFF
--- a/data/ui/item_box.blp
+++ b/data/ui/item_box.blp
@@ -15,7 +15,6 @@ template $ItemBox : Box {
   }
 
   Label label {
-    notify => $on_label_change();
     margin-start: 6;
     margin-end: 6;
     halign: start;

--- a/data/ui/item_box.blp
+++ b/data/ui/item_box.blp
@@ -15,6 +15,7 @@ template $ItemBox : Box {
   }
 
   Label label {
+    notify => $on_label_change();
     margin-start: 6;
     margin-end: 6;
     halign: start;

--- a/src/item.py
+++ b/src/item.py
@@ -88,6 +88,14 @@ class Item(ItemBase):
         if self.props.ydata is None:
             self.props.ydata = []
 
+    @property
+    def name(self):
+        return self._name
+
+    @name.setter
+    def name(self, new_name):
+        self._name = f"{new_name[:18]}..."
+
     def reset(self):
         self.props.linestyle = \
             misc.LINESTYLES.index(pyplot.rcParams["lines.linestyle"])

--- a/src/item.py
+++ b/src/item.py
@@ -88,14 +88,6 @@ class Item(ItemBase):
         if self.props.ydata is None:
             self.props.ydata = []
 
-    @property
-    def name(self):
-        return self._name
-
-    @name.setter
-    def name(self, new_name):
-        self._name = f"{new_name[:18]}..."
-
     def reset(self):
         self.props.linestyle = \
             misc.LINESTYLES.index(pyplot.rcParams["lines.linestyle"])

--- a/src/item_box.py
+++ b/src/item_box.py
@@ -6,6 +6,7 @@ from gi.repository import Adw, GLib, GObject, Gdk, Gtk
 
 from graphs.edit_item import EditItemWindow
 from graphs.item import ItemBase
+from graphs import utilities
 
 
 @Gtk.Template(resource_path="/se/sjoerd/Graphs/ui/item_box.ui")
@@ -98,5 +99,9 @@ class ItemBox(Gtk.Box):
         )
 
     @Gtk.Template.Callback()
-    def edit(self, _):
+    def edit(self, _button):
         EditItemWindow(self.props.application, self.props.item)
+
+    @Gtk.Template.Callback()
+    def on_label_change(self, _itembox, _gobject):
+        self.label.set_text(utilities.shorten_label(self.item.name))

--- a/src/item_box.py
+++ b/src/item_box.py
@@ -8,6 +8,7 @@ from graphs import utilities
 from graphs.edit_item import EditItemWindow
 from graphs.item import ItemBase
 
+
 @Gtk.Template(resource_path="/se/sjoerd/Graphs/ui/item_box.ui")
 class ItemBox(Gtk.Box):
     __gtype_name__ = "ItemBox"

--- a/src/item_box.py
+++ b/src/item_box.py
@@ -7,8 +7,6 @@ from gi.repository import Adw, GLib, GObject, Gdk, Gtk
 from graphs import utilities
 from graphs.edit_item import EditItemWindow
 from graphs.item import ItemBase
-from graphs import utilities
-
 
 @Gtk.Template(resource_path="/se/sjoerd/Graphs/ui/item_box.ui")
 class ItemBox(Gtk.Box):

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -88,7 +88,7 @@ def get_fraction_at_value(value, start, end, scale):
         return (log_value - log_start) / log_range
 
 
-def shorten_label(label, max_length=20):
+def shorten_label(label, max_length=19):
     if len(label) > max_length:
         label = f"{label[:max_length]}…"
     return label


### PR DESCRIPTION
Somewhere along the way the item labels lost their limits. This makes the side-panel expand to unreasonable widths with very long filenames. This fixes the label length again