### PR TITLE
Use cards for operations

### DIFF
--- a/data/ui/window.blp
+++ b/data/ui/window.blp
@@ -211,14 +211,22 @@ template $GraphsWindow : Adw.ApplicationWindow {
               spacing: 12;
               margin-start: 12;
               margin-end: 12;
-              margin-top: 6;
-              margin-bottom: 18;
-
+              margin-top: 12;
+              margin-bottom: 12;
+            Label {
+              halign: start;
+              hexpand: true;
+              label: "Adjust Data";
+              styles ["heading"]
+              }
               Adw.PreferencesGroup {
-                title: _("Adjust Data");
                 Grid {
                   column-spacing: 10;
                   row-spacing: 10;
+                  margin-start: 12;
+                  margin-end: 12;
+                  margin-top: 12;
+                  margin-bottom:12;
                   Button shift_vertically_button {
                     hexpand: true;
                     layout {
@@ -314,13 +322,23 @@ template $GraphsWindow : Adw.ApplicationWindow {
                     clicked => $cut();
                   }
                 }
+                styles ["card"]
               }
-
+            Label {
+              margin-top: 6;
+              halign: start;
+              hexpand: true;
+              label: "Mathematical Operations";
+              styles ["heading"]
+              }
               Adw.PreferencesGroup {
-                title: _("Mathematical Operations");
                 Grid {
                   column-spacing: 10;
                   row-spacing: 10;
+                  margin-start: 12;
+                  margin-end: 12;
+                  margin-top: 12;
+                  margin-bottom:12;
                   Button {
                     hexpand: true;
                     sensitive: bind shift_vertically_button.sensitive;
@@ -402,14 +420,23 @@ template $GraphsWindow : Adw.ApplicationWindow {
                     clicked => $transform();
                   }
                 }
+                styles ["card"]
               }
-
+            Label {
+              halign: start;
+              margin-top: 6;
+              hexpand: true;
+              label: "Translate and Multiply";
+              styles ["heading"]
+              }
               Adw.PreferencesGroup {
-                title: _("Translate and Multiply");
-
                 Grid {
                   column-spacing: 10;
                   row-spacing: 10;
+                  margin-start: 12;
+                  margin-end: 12;
+                  margin-top: 12;
+                  margin-bottom:12;
                   Entry translate_x_entry {
                     max-width-chars: 6;
                     hexpand: true;
@@ -502,6 +529,7 @@ template $GraphsWindow : Adw.ApplicationWindow {
                     }
                   }
                 }
+                                styles ["card"]
               }
             }
           }

--- a/data/ui/window.blp
+++ b/data/ui/window.blp
@@ -213,11 +213,11 @@ template $GraphsWindow : Adw.ApplicationWindow {
               margin-end: 12;
               margin-top: 12;
               margin-bottom: 12;
-            Label {
-              halign: start;
-              hexpand: true;
-              label: "Adjust Data";
-              styles ["heading"]
+              Label {
+                halign: start;
+                hexpand: true;
+                label: "Adjust Data";
+                styles ["heading"]
               }
               Adw.PreferencesGroup {
                 Grid {

--- a/data/ui/window.blp
+++ b/data/ui/window.blp
@@ -324,12 +324,12 @@ template $GraphsWindow : Adw.ApplicationWindow {
                 }
                 styles ["card"]
               }
-            Label {
-              margin-top: 6;
-              halign: start;
-              hexpand: true;
-              label: "Mathematical Operations";
-              styles ["heading"]
+              Label {
+                margin-top: 6;
+                halign: start;
+                hexpand: true;
+                label: "Mathematical Operations";
+                styles ["heading"]
               }
               Adw.PreferencesGroup {
                 Grid {

--- a/data/ui/window.blp
+++ b/data/ui/window.blp
@@ -422,12 +422,12 @@ template $GraphsWindow : Adw.ApplicationWindow {
                 }
                 styles ["card"]
               }
-            Label {
-              halign: start;
-              margin-top: 6;
-              hexpand: true;
-              label: "Translate and Multiply";
-              styles ["heading"]
+              Label {
+                halign: start;
+                margin-top: 6;
+                hexpand: true;
+                label: "Translate and Multiply";
+                styles ["heading"]
               }
               Adw.PreferencesGroup {
                 Grid {

--- a/data/ui/window.blp
+++ b/data/ui/window.blp
@@ -529,7 +529,7 @@ template $GraphsWindow : Adw.ApplicationWindow {
                     }
                   }
                 }
-                                styles ["card"]
+                styles ["card"]
               }
             }
           }


### PR DESCRIPTION
Puts the operations into cards, to create some more visual distinction between the categories in the side-panel. Slightly inspired by the way different things are categorised in e.g. GNOME Settings. Open to further suggestions.

![image](https://github.com/Sjoerd1993/Graphs/assets/68477016/28194cf5-788a-47da-b407-982a6cbf45ac)
