### PR TITLE
use getters and setters

### DIFF
--- a/src/actions.py
+++ b/src/actions.py
@@ -11,12 +11,12 @@ from graphs.styles import StylesWindow
 
 
 def toggle_sidebar(_action, _shortcut, self):
-    flap = self.main_window.sidebar_flap
+    flap = self.get_window().sidebar_flap
     flap.set_reveal_flap(not flap.get_reveal_flap())
 
 
 def set_mode(_action, _target, self, mode):
-    self.props.mode = mode
+    self.set_mode(mode)
 
 
 def quit_action(_action, _target, self):
@@ -44,23 +44,23 @@ def add_equation_action(_action, _target, self):
 
 
 def select_all_action(_action, _target, self):
-    for item in self.props.data:
+    for item in self.get_data():
         item.selected = True
-    self.props.clipboard.add()
+    self.get_clipboard().add()
 
 
 def select_none_action(_action, _target, self):
-    for item in self.props.data:
+    for item in self.get_data():
         item.selected = False
-    self.props.clipboard.add()
+    self.get_clipboard().add()
 
 
 def undo_action(_action, _target, self):
-    self.props.clipboard.undo()
+    self.get_clipboard().undo()
 
 
 def redo_action(_action, _target, self):
-    self.props.clipboard.redo()
+    self.get_clipboard().redo()
 
 
 def optimize_limits_action(_action, _target, self):
@@ -68,13 +68,13 @@ def optimize_limits_action(_action, _target, self):
 
 
 def view_back_action(_action, _target, self):
-    if self.main_window.view_back_button.get_sensitive():
-        self.props.view_clipboard.undo()
+    if self.get_window().view_back_button.get_sensitive():
+        self.get_view_clipboard().undo()
 
 
 def view_forward_action(_action, _target, self):
-    if self.main_window.view_forward_button.get_sensitive():
-        self.props.view_clipboard.redo()
+    if self.get_window().view_forward_button.get_sensitive():
+        self.get_view_clipboard().redo()
 
 
 def export_data_action(_action, _target, self):
@@ -94,12 +94,12 @@ def save_project_action(_action, _target, self):
 
 
 def open_project_action(_action, _target, self):
-    if not self.props.data.is_empty():
+    if not self.get_data().is_empty():
         def on_response(_dialog, response):
             if response == "discard":
                 ui.open_project_dialog(self)
         dialog = ui.build_dialog("discard_data")
-        dialog.set_transient_for(self.main_window)
+        dialog.set_transient_for(self.get_window())
         dialog.connect("response", on_response)
         dialog.present()
         return
@@ -107,7 +107,7 @@ def open_project_action(_action, _target, self):
 
 
 def delete_selected_action(_action, _target, self):
-    items = [item for item in self.props.data if item.selected]
+    items = [item for item in self.get_data() if item.selected]
     names = ", ".join([item.name for item in items])
-    self.props.data.delete_items(items)
-    self.main_window.add_toast(_("Deleted {}").format(names))
+    self.get_data().delete_items(items)
+    self.get_window().add_toast(_("Deleted {}").format(names))

--- a/src/add_equation.py
+++ b/src/add_equation.py
@@ -24,9 +24,9 @@ class AddEquationWindow(Adw.Window):
 
     def __init__(self, application):
         super().__init__(application=application,
-                         transient_for=application.main_window)
+                         transient_for=application.get_window())
         ui.bind_values_to_settings(
-            self.props.application.get_settings("add-equation"), self)
+            self.get_application().get_settings("add-equation"), self)
         self.present()
 
     @Gtk.Template.Callback()
@@ -50,8 +50,8 @@ class AddEquationWindow(Adw.Window):
             name = str(self.name.get_text())
             if name == "":
                 name = f"Y = {values['equation']}"
-            self.props.application.props.data.add_items(
-                [Item.new(self.props.application, xdata, ydata, name=name)],
+            self.get_application().get_data().add_items(
+                [Item.new(self.get_application(), xdata, ydata, name=name)],
             )
             self.destroy()
         except ValueError as error:

--- a/src/edit_item.py
+++ b/src/edit_item.py
@@ -30,23 +30,23 @@ class EditItemWindow(Adw.PreferencesWindow):
 
     def __init__(self, application, item):
         super().__init__(
-            application=application, transient_for=application.main_window,
+            application=application, transient_for=application.get_window,
             item=item, bindings=[],
-            model=Gtk.StringList.new(application.props.data.get_names()),
+            model=Gtk.StringList.new(application.get_data().get_names()),
         )
         self.item_selector.set_model(self.props.model)
         self.item_selector.set_selected(
-            self.props.application.props.data.props.items.index(item),
+            self.get_application().get_data().get_items().index(item),
         )
         self.present()
 
     @Gtk.Template.Callback()
     def on_select(self, _action, _target):
-        item = self.props.application.props.data[
+        item = self.get_application().get_data()[
             self.item_selector.get_selected()]
         if item != self.item:
             self.props.model.splice(
-                self.props.application.props.data.props.items.index(self.item),
+                self.get_application().get_data().get_items().index(self.item),
                 1, [self.item.name],
             )
             self.props.item = item
@@ -63,5 +63,5 @@ class EditItemWindow(Adw.PreferencesWindow):
 
     @Gtk.Template.Callback()
     def on_close(self, _a):
-        self.props.application.props.clipboard.add()
+        self.get_application().get_clipboard().add()
         self.destroy()

--- a/src/export_figure.py
+++ b/src/export_figure.py
@@ -18,16 +18,16 @@ class ExportFigureWindow(Adw.Window):
     file_formats = GObject.Property(type=object)
 
     def __init__(self, application):
-        self.canvas = application.main_window.toast_overlay.get_child()
+        self._canvas = application.get_window().get_canvas()
         super().__init__(
-            application=application, transient_for=application.main_window,
-            file_formats=self.canvas.get_supported_filetypes_grouped(),
+            application=application, transient_for=application.get_window(),
+            file_formats=self._canvas.get_supported_filetypes_grouped(),
         )
 
         self.file_format.set_model(
             Gtk.StringList.new(list(self.file_formats.keys())))
         ui.bind_values_to_settings(
-            self.props.application.get_settings("export-figure"), self)
+            self.get_application().get_settings("export-figure"), self)
         self.present()
 
     @Gtk.Template.Callback()
@@ -35,19 +35,19 @@ class ExportFigureWindow(Adw.Window):
         file_format = self.file_format.get_selected_item().get_string()
         file_suffixes = self.props.file_formats[file_format]
         filename = \
-            Path(self.canvas.get_default_filename()).stem
+            Path(self._canvas.get_default_filename()).stem
 
         def on_response(dialog, response):
             with contextlib.suppress(GLib.GError):
                 destination = dialog.save_finish(response)
                 file, stream = Gio.File.new_tmp("graphs-XXXXXX")
                 stream.close()
-                self.canvas.figure.savefig(
+                self._canvas.figure.savefig(
                     file.peek_path(), format=file_suffixes[0],
                     dpi=int(self.dpi.get_value()),
                     transparent=self.transparent.get_active())
                 file.move(destination, Gio.FileCopyFlags(1), None)
-                self.props.application.main_window.add_toast(
+                self.get_application().get_window().add_toast(
                     _("Exported Figure"))
                 self.destroy()
 
@@ -56,4 +56,4 @@ class ExportFigureWindow(Adw.Window):
         dialog.set_accept_label(_("Export"))
         dialog.set_filters(utilities.create_file_filters(
             [(file_format, file_suffixes)]))
-        dialog.save(self.props.application.main_window, None, on_response)
+        dialog.save(self.get_application().get_window(), None, on_response)

--- a/src/figure_settings.py
+++ b/src/figure_settings.py
@@ -105,8 +105,8 @@ class FigureSettingsWindow(Adw.PreferencesWindow):
 
     def __init__(self, application, highlighted=None):
         super().__init__(
-            application=application, transient_for=application.main_window,
-            figure_settings=application.props.figure_settings,
+            application=application, transient_for=application.get_window(),
+            figure_settings=application.get_figure_settings(),
         )
 
         ignorelist = ["custom_style", "min_selected", "max_selected"]
@@ -125,7 +125,7 @@ class FigureSettingsWindow(Adw.PreferencesWindow):
 
         self.set_axes_entries()
         self.no_data_message.set_visible(
-            self.props.application.props.data.is_empty(),
+            self.get_application().get_data().is_empty(),
         )
         if highlighted is not None:
             getattr(self, highlighted).grab_focus()
@@ -133,7 +133,7 @@ class FigureSettingsWindow(Adw.PreferencesWindow):
 
     def set_axes_entries(self):
         used_axes = [[direction, False] for direction in _DIRECTIONS]
-        for item in self.props.application.props.data:
+        for item in self.get_application().get_data():
             for index in item.xposition * 2, 1 + item.yposition * 2:
                 used_axes[index][1] = True
         for (direction, visible) in used_axes:
@@ -156,7 +156,7 @@ class FigureSettingsWindow(Adw.PreferencesWindow):
 
     @Gtk.Template.Callback()
     def on_close(self, *_args):
-        self.props.application.props.view_clipboard.add()
+        self.get_application().get_view_clipboard().add()
         self.destroy()
 
     @Gtk.Template.Callback()

--- a/src/file_import.py
+++ b/src/file_import.py
@@ -49,9 +49,9 @@ def import_from_files(self, import_settings_list: list):
         try:
             items.extend(_import_from_file(self, import_settings))
         except ParseError as error:
-            self.main_window.add_toast(error.message)
+            self.gt_window().add_toast(error.message)
             continue
-    self.props.data.add_items(items)
+    self.get_data().add_items(items)
 
 
 def _import_from_file(self, import_settings: ImportSettings):
@@ -83,12 +83,12 @@ class ImportWindow(Adw.Window):
 
     def __init__(self, application, modes: list, import_dict: dict):
         super().__init__(
-            application=application, transient_for=application.main_window,
+            application=application, transient_for=application.get_window(),
             modes=modes, import_dict=import_dict,
         )
 
         import_params = \
-            self.props.application.get_settings("import-params")
+            self.get_application().get_settings("import-params")
         visible = False
         for mode in import_params.list_children():
             if mode in self.props.modes:
@@ -98,7 +98,7 @@ class ImportWindow(Adw.Window):
                 visible = True
 
         if not visible:
-            prepare_import_finish(self.props.application, self.import_dict)
+            prepare_import_finish(self.get_application(), self.import_dict)
             self.destroy()
             return
         self.present()
@@ -117,7 +117,7 @@ class ImportWindow(Adw.Window):
 
     def reset_import(self):
         import_params = \
-            self.props.application.get_settings("import-params")
+            self.get_application().get_settings("import-params")
         for mode in import_params.list_children():
             settings = import_params.get_child(mode)
             for key in settings.props.settings_schema.list_keys():
@@ -125,7 +125,7 @@ class ImportWindow(Adw.Window):
 
     @Gtk.Template.Callback()
     def on_accept(self, _widget):
-        import_from_files(self.props.application, [
+        import_from_files(self.get_application(), [
             ImportSettings(
                 file=file, mode=mode, name=utilities.get_filename(file))
             for mode in _IMPORT_MODES.keys() for file in self.import_dict[mode]

--- a/src/item_box.py
+++ b/src/item_box.py
@@ -46,15 +46,13 @@ class ItemBox(Gtk.Box):
 
     def on_dnd_drop(self, drop_target, value, _x, _y):
         # Handle the dropped data here
-        data = self.props.application.props.data
+        data = self.get_application().get_data()
         before_index = data.index(value)
         data.change_position(drop_target.key, value)
-        clipboard = self.props.application.props.clipboard
-        clipboard.props.current_batch.append((3, (
-            before_index, data.index(value),
-        )))
+        clipboard = self.get_application().get_clipboard()
+        clipboard.append((3, (before_index, data.index(value))))
         clipboard.add()
-        self.props.application.props.view_clipboard.add()
+        self.get_application().get_view_clipboard().add()
 
     def on_dnd_prepare(self, drag_source, x, y):
         snapshot = Gtk.Snapshot.new()
@@ -74,13 +72,13 @@ class ItemBox(Gtk.Box):
         new_value = self.check_button.get_active()
         if self.props.item.props.selected != new_value:
             self.props.item.props.selected = new_value
-            self.props.application.props.clipboard.add()
+            self.get_application().get_clipboard().add()
 
     @Gtk.Template.Callback()
     def choose_color(self, _):
         dialog = Gtk.ColorDialog()
         dialog.choose_rgba(
-            self.props.application.main_window, self.props.item.get_color(),
+            self.get_application().get_window(), self.props.item.get_color(),
             None, self.on_color_dialog_accept)
 
     def on_color_dialog_accept(self, dialog, result):
@@ -88,19 +86,19 @@ class ItemBox(Gtk.Box):
             color = dialog.choose_rgba_finish(result)
             if color is not None:
                 self.props.item.set_color(color)
-                self.props.application.props.clipboard.add()
+                self.get_application().get_clipboard().add()
 
     @Gtk.Template.Callback()
     def delete(self, _button):
         name = self.props.item.props.name
-        self.props.application.props.data.delete_items([self.props.item])
-        self.props.application.main_window.add_toast(
+        self.get_application().get_data().delete_items([self.props.item])
+        self.get_application().get_window().add_toast(
             _("Deleted {name}").format(name=name),
         )
 
     @Gtk.Template.Callback()
     def edit(self, _button):
-        EditItemWindow(self.props.application, self.props.item)
+        EditItemWindow(self.get_application(), self.props.item)
 
     @GObject.Property(type=str, default="")
     def name(self) -> str:
@@ -109,3 +107,7 @@ class ItemBox(Gtk.Box):
     @name.setter
     def name(self, name: str):
         self.label.set_label(utilities.shorten_label(name))
+
+    def get_application(self):
+        """Get application property."""
+        return self.props.application

--- a/src/main.py
+++ b/src/main.py
@@ -47,7 +47,14 @@ class GraphsApplication(Adw.Application):
         mode: int (pan, zoom, select)
 
     Functions:
+        get_data
+        get_mode
+        set_mode
+        get_figure_settings
+        set_figure_settings
         get_settings
+        get_clipboard
+        get_view_clipboard
     """
 
     settings = GObject.Property(type=Gio.Settings)
@@ -114,16 +121,16 @@ class GraphsApplication(Adw.Application):
 
         self.get_style_manager().connect(
             "notify", ui.on_style_change, None, self)
-        self.props.figure_settings.connect(
+        self.get_figure_settings().connect(
             "notify::use-custom-style", ui.on_figure_style_change, self,
         )
-        self.props.figure_settings.connect(
+        self.get_figure_settings().connect(
             "notify::custom-style", ui.on_figure_style_change, self,
         )
-        self.props.data.connect(
+        self.get_data().connect(
             "notify::items", ui.on_items_change, self,
         )
-        self.props.data.connect(
+        self.get_data().connect(
             "items-ignored", ui.on_items_ignored, self,
         )
 
@@ -134,16 +141,39 @@ class GraphsApplication(Adw.Application):
         We raise the application"s main window, creating it if
         necessary.
         """
-        self.main_window = self.props.active_window
-        if not self.main_window:
-            self.main_window = GraphsWindow(self)
-            self.main_window.set_title(self.props.name)
+        self._window = self.props.active_window
+        if not self._window:
+            self._window = GraphsWindow(self)
+            self._window.set_title(self.props.name)
             if "(Development)" in self.props.name:
-                self.main_window.add_css_class("devel")
+                self._window.add_css_class("devel")
             self.props.clipboard = DataClipboard(self)
             self.props.view_clipboard = ViewClipboard(self)
             ui.set_clipboard_buttons(self)
-            self.main_window.present()
+            self._window.present()
+
+    def get_window(self):
+        return self._window
+
+    def get_data(self):
+        """Get data property."""
+        return self.props.data
+
+    def get_mode(self):
+        """Get mode property."""
+        return self.props.mode
+
+    def set_mode(self, mode: int):
+        """Set mode property."""
+        self.props.mode = mode
+
+    def get_figure_settings(self) -> FigureSettings:
+        """Get figure settings property."""
+        return self.props.figure_settings
+
+    def set_figure_settings(self, figure_settings: FigureSettings):
+        """Set figure settings property."""
+        self.props.figure_settings = figure_settings
 
     def get_settings(self, child=None):
         """
@@ -153,3 +183,11 @@ class GraphsApplication(Adw.Application):
         """
         return self.props.settings if child is None \
             else self.props.settings.get_child(child)
+
+    def get_clipboard(self):
+        """Get clipboard property."""
+        return self.props.clipboard
+
+    def get_view_clipboard(self):
+        """Get view clipboard property."""
+        return self.props.view_clipboard

--- a/src/operations.py
+++ b/src/operations.py
@@ -23,8 +23,8 @@ def get_data(self, item):
     new_ydata = ydata.copy()
     start_index = 0
     stop_index = len(xdata)
-    if self.props.mode == 2:
-        figure_settings = self.props.figure_settings
+    if self.get_mode() == 2:
+        figure_settings = self.get_figure_settings()
         if item.xposition == 0:
             xmin = figure_settings.props.min_bottom
             xmax = figure_settings.props.max_bottom
@@ -73,7 +73,7 @@ def sort_data(xdata, ydata):
 
 def perform_operation(self, callback, *args):
     data_selected = False
-    for item in self.props.data:
+    for item in self.get_data():
         if not item.selected or item.props.item_type != "Item":
             continue
         xdata, ydata, start_index, stop_index = get_data(self, item)
@@ -95,11 +95,11 @@ def perform_operation(self, callback, *args):
         item.notify("xdata")
         item.notify("ydata")
     if not data_selected:
-        self.main_window.add_toast(
+        self.get_window().add_toast(
             _("No data found within the highlighted area"))
         return
     utilities.optimize_limits(self)
-    self.props.clipboard.add()
+    self.get_clipboard().add()
 
 
 def translate_x(_item, xdata, ydata, offset):
@@ -260,7 +260,7 @@ def transform(_item, xdata, ydata, input_x, input_y, discard=False):
 def combine(self):
     """Combine the selected data into a new data set"""
     new_xdata, new_ydata = [], []
-    for item in self.props.data:
+    for item in self.get_data():
         if not item.selected or item.props.item_type != "Item":
             continue
         xdata, ydata = get_data(self, item)[:2]
@@ -269,6 +269,6 @@ def combine(self):
 
     # Create the item itself
     new_xdata, new_ydata = sort_data(new_xdata, new_ydata)
-    self.props.data.add_items(
+    self.get_data().add_items(
         [Item.new(self, new_xdata, new_ydata, name=_("Combined Data"))],
     )

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -30,12 +30,12 @@ class PreferencesWindow(Adw.PreferencesWindow):
 
     def __init__(self, application):
         super().__init__(
-            application=application, transient_for=application.main_window,
+            application=application, transient_for=application.get_window(),
         )
 
         styles_ = sorted(styles.get_user_styles(application).keys())
         self.figure_custom_style.set_model(Gtk.StringList.new(styles_))
-        settings = self.props.application.props.settings
+        settings = self.get_application().get_settings()
         ui.bind_values_to_settings(
             settings.get_child("figure"), self, prefix="figure_",
             ignorelist=["custom-style"])
@@ -51,6 +51,6 @@ class PreferencesWindow(Adw.PreferencesWindow):
 
     @Gtk.Template.Callback()
     def on_custom_style_select(self, comborow, _ignored):
-        self.props.application.get_settings("figure").set_string(
+        self.get_application().get_settings("figure").set_string(
             "custom-style", comborow.get_selected_item().get_string(),
         )

--- a/src/project.py
+++ b/src/project.py
@@ -8,13 +8,13 @@ from graphs.figure_settings import FigureSettings
 def save_project(self, file: Gio.File):
     file_io.write_json(file, {
         "version": self.version,
-        "data": self.props.data.to_list(),
-        "figure-settings": self.props.figure_settings.to_dict(),
-        "data-clipboard": self.props.clipboard.props.clipboard,
-        "data-clipboard-position": self.props.clipboard.props.clipboard_pos,
-        "view-clipboard": self.props.view_clipboard.props.clipboard,
+        "data": self.get_data().to_list(),
+        "figure-settings": self.get_figure_settings().to_dict(),
+        "data-clipboard": self.get_clipboard().get_clipboard(),
+        "data-clipboard-position": self.get_clipboard().get_clipboard_pos(),
+        "view-clipboard": self.get_view_clipboard().get_clipboard(),
         "view-clipboard-position":
-            self.props.view_clipboard.props.clipboard_pos,
+            self.get_view_clipboard().get_clipboard_pos(),
     }, False)
 
 
@@ -24,18 +24,19 @@ def load_project(self, file: Gio.File):
     except UnicodeDecodeError:
         project = migrate.migrate_project(file)
 
-    self.props.clipboard.clear()
-    self.props.view_clipboard.clear()
-    self.props.figure_settings = \
-        FigureSettings.new_from_dict(project["figure-settings"])
-    self.props.data.set_from_list(project["data"])
+    self.get_clipboard().clear()
+    self.get_view_clipboard().clear()
+    self.set_figure_settings(
+        FigureSettings.new_from_dict(project["figure-settings"]),
+    )
+    self.get_data().set_from_list(project["data"])
 
-    self.props.clipboard.props.data_copy = self.props.data.to_dict()
-    self.props.clipboard.props.clipboard = project["data-clipboard"]
-    self.props.clipboard.props.clipboard_pos = \
-        project["data-clipboard-position"]
-    self.props.view_clipboard.props.clipboard = project["view-clipboard"]
-    self.props.view_clipboard.props.clipboard_pos = \
-        project["view-clipboard-position"]
+    self.get_clipboard().props.data_copy = self.get_data().to_dict()
+    self.get_clipboard().set_clipboard(project["data-clipboard"])
+    self.get_clipboard().set_clipboard_pos(project["data-clipboard-position"])
+    self.get_view_clipboard().set_clipboard(project["view-clipboard"])
+    self.get_view_clipboard().get_clipboard_pos(
+        project["view-clipboard-position"],
+    )
     ui.set_clipboard_buttons(self)
-    self.main_window.reload_canvas()
+    self.get_window().reload_canvas()

--- a/src/styles.py
+++ b/src/styles.py
@@ -72,16 +72,16 @@ def get_system_preferred_style(self):
 
 
 def get_preferred_style(self):
-    if not self.props.figure_settings.props.use_custom_style:
+    if not self.get_figure_settings().props.use_custom_style:
         return get_system_preferred_style(self)
-    stylename = self.props.figure_settings.props.custom_style
+    stylename = self.get_figure_settings().props.custom_style
     try:
         return get_user_styles(self)[stylename]
     except KeyError:
-        self.main_window.add_toast(
+        self.get_window().add_toast(
             _(f"Plot style {stylename} does not exist "
               "loading system preferred"))
-        self.props.figure_settings.props.use_custom_style = False
+        self.get_figure_settings().props.use_custom_style = False
         return get_system_preferred_style(self)
 
 
@@ -193,7 +193,7 @@ class StylesWindow(Adw.Window):
 
     def __init__(self, application):
         super().__init__(application=application,
-                         transient_for=application.main_window)
+                         transient_for=application.get_window())
         self.styles = []
         self.style = None
         self.reload_styles()
@@ -300,8 +300,8 @@ class StylesWindow(Adw.Window):
             directory.get_child_for_display_name(f"{self.style.name}.mplstyle")
         file_io.write_style(file, self.style)
 
-        if file.equal(get_preferred_style(self.props.application)):
-            self.props.application.main_window.reload_canvas()
+        if file.equal(get_preferred_style(self.get_application())):
+            self.get_application().get_window().reload_canvas()
 
     @Gtk.Template.Callback()
     def add_color(self, _button):
@@ -311,13 +311,13 @@ class StylesWindow(Adw.Window):
 
     @Gtk.Template.Callback()
     def add_style(self, _button):
-        AddStyleWindow(self.props.application, self)
+        AddStyleWindow(self.get_application(), self)
 
     @Gtk.Template.Callback()
     def reset_styles(self, _button):
         def on_accept(_dialog, response):
             if response == "reset":
-                reset_user_styles(self.props.application)
+                reset_user_styles(self.get_application())
                 self.reload_styles()
         body = _("Are you sure you want to reset to the default styles?")
         dialog = ui.build_dialog("reset_to_defaults")
@@ -331,9 +331,9 @@ class StylesWindow(Adw.Window):
             self.styles.remove(box)
             self.styles_box.remove(self.styles_box.get_row_at_index(0))
         for style, file in \
-                sorted(get_user_styles(self.props.application).items()):
+                sorted(get_user_styles(self.get_application()).items()):
             box = StyleBox(self, style)
-            if not file.equal(get_preferred_style(self.props.application)):
+            if not file.equal(get_preferred_style(self.get_application())):
                 box.check_mark.hide()
                 box.label.set_hexpand(True)
             self.styles.append(box)
@@ -350,7 +350,7 @@ class StylesWindow(Adw.Window):
         dialog = Gtk.ColorDialog()
         dialog.set_with_alpha(False)
         dialog.choose_rgba(
-            self.props.application.main_window, color, None,
+            self.get_application().get_window(), color, None,
             self.on_color_change_accept, button)
 
     def on_color_change_accept(self, dialog, result, button):
@@ -379,7 +379,7 @@ class StyleBox(Gtk.Box):
     @Gtk.Template.Callback()
     def on_edit(self, _button):
         self.parent.style = get_style(
-            self.parent.props.application, self.style)
+            self.parent.get_application(), self.style)
         self.parent.load_style()
         self.parent.leaflet.navigate(1)
         self.parent.set_title(self.style)
@@ -391,7 +391,7 @@ class StyleBox(Gtk.Box):
         def remove_style(_dialog, response):
             if response == "delete":
                 get_user_styles(
-                    self.parent.props.application)[style].trash(None)
+                    self.parent.get_application())[style].trash(None)
                 self.parent.reload_styles()
         body = _("Are you sure you want to delete the {} style?").format(style)
         dialog = ui.build_dialog("delete_style")

--- a/src/transform_data.py
+++ b/src/transform_data.py
@@ -19,10 +19,10 @@ class TransformWindow(Adw.Window):
 
     def __init__(self, application):
         super().__init__(application=application,
-                         transient_for=application.main_window)
+                         transient_for=application.get_window())
         self.transform_x_entry.set_text("X")
         self.transform_y_entry.set_text("Y")
-        self.discard_row.set_visible(self.props.application.props.mode == 2)
+        self.discard_row.set_visible(self.get_application().get_mode() == 2)
         self.present()
         self.help_button.connect(
             "clicked", lambda _x: self.help_popover.popup())
@@ -34,11 +34,11 @@ class TransformWindow(Adw.Window):
             input_y = str(self.transform_y_entry.get_text())
             discard = self.discard.get_active()
             operations.perform_operation(
-                self.props.application, operations.transform,
+                self.get_application(), operations.transform,
                 input_x, input_y, discard)
         except (RuntimeError, KeyError) as exception:
             toast = _("{name}: Unable to do transformation, \
 make sure the syntax is correct").format(name=exception.__class__.__name__)
-            self.props.application.main_window.add_toast(toast)
+            self.get_application().get_window().add_toast(toast)
             logging.exception(_("Unable to do transformation"))
         self.destroy()

--- a/src/ui.py
+++ b/src/ui.py
@@ -11,32 +11,32 @@ from graphs.item_box import ItemBox
 
 
 def on_style_change(_shortcut, _theme, _widget, self):
-    self.main_window.reload_canvas()
+    self.get_window().reload_canvas()
 
 
 def on_figure_style_change(_figure_settings, _ignored, self):
     if not self.get_settings(
             "general").get_boolean("override-item-properties"):
-        self.main_window.reload_canvas()
+        self.get_window().reload_canvas()
         return
     styles.update(self)
-    for item in self.props.data:
+    for item in self.get_data():
         item.reset()
-    for item in self.props.data:
+    for item in self.get_data():
         if item.props.item_type == "Item":
-            item.color = utilities.get_next_color(self.props.data.props.items)
-    self.main_window.reload_canvas()
+            item.color = utilities.get_next_color(self.get_data().get_items())
+    self.get_window().reload_canvas()
 
 
 def on_items_change(data, _ignored, self):
-    while self.main_window.item_list.get_last_child() is not None:
-        self.main_window.item_list.remove(
-            self.main_window.item_list.get_last_child())
+    while self.get_window().item_list.get_last_child() is not None:
+        self.get_window().item_list.remove(
+            self.get_window().item_list.get_last_child())
 
     for item in data:
-        self.main_window.item_list.append(ItemBox(self, item))
-    self.main_window.item_list.set_visible(not data.is_empty())
-    self.props.view_clipboard.add()
+        self.get_window().item_list.append(ItemBox(self, item))
+    self.get_window().item_list.set_visible(not data.is_empty())
+    self.get_view_clipboard().add()
 
 
 def on_items_ignored(_data, _ignored, ignored, self):
@@ -44,11 +44,11 @@ def on_items_ignored(_data, _ignored, ignored, self):
         toast = _("Items {} already exist").format(ignored)
     else:
         toast = _("Item {} already exists")
-    self.main_window.add_toast(toast)
+    self.get_window().add_toast(toast)
 
 
 def on_scale_action(action, target, self, prop):
-    self.props.figure_settings.set_property(
+    self.get_figure_settings().set_property(
         prop, 0 if target.get_string() == "linear" else 1,
     )
     action.change_state(target)
@@ -59,16 +59,16 @@ def set_clipboard_buttons(self):
     Enable and disable the buttons for the undo and redo buttons and backwards
     and forwards view.
     """
-    self.main_window.view_forward_button.set_sensitive(
-        self.props.view_clipboard.clipboard_pos < - 1)
-    self.main_window.view_back_button.set_sensitive(
-        abs(self.props.view_clipboard.clipboard_pos)
-        < len(self.props.view_clipboard.clipboard))
-    self.main_window.undo_button.set_sensitive(
-        abs(self.props.clipboard.clipboard_pos)
-        < len(self.props.clipboard.clipboard))
-    self.main_window.redo_button.set_sensitive(
-        self.props.clipboard.clipboard_pos < - 1)
+    self.get_window().view_forward_button.set_sensitive(
+        self.get_view_clipboard().clipboard_pos < - 1)
+    self.get_window().view_back_button.set_sensitive(
+        abs(self.get_view_clipboard().clipboard_pos)
+        < len(self.get_view_clipboard().clipboard))
+    self.get_window().undo_button.set_sensitive(
+        abs(self.get_clipboard().clipboard_pos)
+        < len(self.get_clipboard().clipboard))
+    self.get_window().redo_button.set_sensitive(
+        self.get_clipboard().clipboard_pos < - 1)
 
 
 def add_data_dialog(self):
@@ -84,7 +84,7 @@ def add_data_dialog(self):
             (_("Leybold xry"), ["xry"]),
         ]),
     )
-    dialog.open_multiple(self.main_window, None, on_response)
+    dialog.open_multiple(self.get_window(), None, on_response)
 
 
 def save_project_dialog(self):
@@ -97,7 +97,7 @@ def save_project_dialog(self):
         utilities.create_file_filters([(_("Graphs Project File"),
                                       ["graphs"])]))
     dialog.set_initial_name("project.graphs")
-    dialog.save(self.main_window, None, on_response)
+    dialog.save(self.get_window(), None, on_response)
 
 
 def open_project_dialog(self):
@@ -109,37 +109,37 @@ def open_project_dialog(self):
     dialog.set_filters(
         utilities.create_file_filters([(_("Graphs Project File"),
                                       ["graphs"])]))
-    dialog.open(self.main_window, None, on_response)
+    dialog.open(self.get_window(), None, on_response)
 
 
 def export_data_dialog(self):
-    if self.props.data.is_empty():
-        self.main_window.add_toast(_("No data to export"))
+    if self.get_data().is_empty():
+        self.get_window().add_toast(_("No data to export"))
         return
-    multiple = len(self.props.data) > 1
+    multiple = len(self.get_data()) > 1
 
     def on_response(dialog, response):
         with contextlib.suppress(GLib.GError):
             if multiple:
                 directory = dialog.select_folder_finish(response)
-                for item in self.props.data:
+                for item in self.get_data():
                     file = directory.get_child_for_display_name(
                         f"{item.name}.txt")
                     file_io.save_item(file, item)
             else:
                 file_io.save_item(
-                    dialog.save_finish(response), self.props.data[0],
+                    dialog.save_finish(response), self.get_data()[0],
                 )
-            self.main_window.add_toast(_("Exported Data"))
+            self.get_window().add_toast(_("Exported Data"))
     dialog = Gtk.FileDialog()
     if multiple:
-        dialog.select_folder(self.main_window, None, on_response)
+        dialog.select_folder(self.get_window(), None, on_response)
     else:
-        filename = f"{self.props.data[0].name}.txt"
+        filename = f"{self.get_data()[0].name}.txt"
         dialog.set_initial_name(filename)
         dialog.set_filters(
             utilities.create_file_filters([(_("Text Files"), ["txt"])]))
-        dialog.save(self.main_window, None, on_response)
+        dialog.save(self.get_window(), None, on_response)
 
 
 def build_dialog(name):
@@ -149,7 +149,7 @@ def build_dialog(name):
 
 def show_about_window(self):
     Adw.AboutWindow(
-        transient_for=self.main_window, application_name=self.name,
+        transient_for=self.get_window(), application_name=self.name,
         application_icon=self.props.application_id, website=self.website,
         developer_name=self.author, issue_url=self.issues,
         version=self.version, developers=[

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -155,7 +155,7 @@ def optimize_limits(self):
         [direction, False, []]
         for direction in ["bottom", "left", "top", "right"]
     ]
-    for item in self.props.data:
+    for item in self.get_data():
         for index in item.xposition * 2, 1 + item.yposition * 2:
             axes[index][1] = True
             axes[index][2].append(item)
@@ -163,7 +163,7 @@ def optimize_limits(self):
     for count, (direction, used, items) in enumerate(axes):
         if not used:
             continue
-        scale = self.props.figure_settings.get_property(f"{direction}_scale")
+        scale = self.get_figure_settings().get_property(f"{direction}_scale")
         datalist = [item.ydata if count % 2 else item.xdata for item in items
                     if item.props.item_type == "Item"]
         min_all, max_all = [], []
@@ -184,9 +184,9 @@ def optimize_limits(self):
         elif count % 2:
             min_all *= 0.5
             max_all *= 2
-        self.props.figure_settings.set_property(f"min_{direction}", min_all)
-        self.props.figure_settings.set_property(f"max_{direction}", max_all)
-    self.props.view_clipboard.add()
+        self.get_figure_settings().set_property(f"min_{direction}", min_all)
+        self.get_figure_settings().set_property(f"max_{direction}", max_all)
+    self.get_view_clipboard().add()
 
 
 def get_next_color(items):

--- a/src/window.py
+++ b/src/window.py
@@ -28,19 +28,22 @@ class GraphsWindow(Adw.ApplicationWindow):
 
     def __init__(self, application):
         super().__init__(application=application)
-        self.props.application.props.data.bind_property(
+        self.get_application().get_data().bind_property(
             "items_selected", self.shift_vertically_button, "sensitive", 2,
         )
-        self.props.application.bind_property("mode", self, "mode", 2)
+        self.get_application().bind_property("mode", self, "mode", 2)
         self.reload_canvas()
 
     def reload_canvas(self):
-        styles.update(self.props.application)
-        canvas = Canvas(self.props.application)
+        styles.update(self.get_application())
+        canvas = Canvas(self.get_application())
         self.toast_overlay.set_child(canvas)
         self.cut_button.bind_property(
             "sensitive", canvas, "highlight_enabled", 2,
         )
+
+    def get_canvas(self):
+        return self.toast_overlay.get_child()
 
     @GObject.Property(type=int, default=0, minimum=0, maximum=2, flags=2)
     def mode(self):
@@ -57,44 +60,44 @@ class GraphsWindow(Adw.ApplicationWindow):
 
     @Gtk.Template.Callback()
     def on_sidebar_toggle(self, *_args):
-        self.props.application.toggle_sidebar.change_state(
+        self.get_application().toggle_sidebar.change_state(
             GLib.Variant.new_boolean(self.sidebar_flap.get_reveal_flap()),
         )
 
     @Gtk.Template.Callback()
     def shift_vertically(self, *_args):
-        app = self.props.application
+        app = self.get_application()
         operations.perform_operation(
             app, operations.shift_vertically,
-            app.props.figure_settings.left_scale,
-            app.props.figure_settings.right_scale, app.props.data.props.items,
+            app.get_figure_settings().left_scale,
+            app.get_figure_settings().right_scale, app.get_data().get_items(),
         )
 
     @Gtk.Template.Callback()
     def normalize(self, *_args):
         operations.perform_operation(
-            self.props.application, operations.normalize)
+            self.get_application(), operations.normalize)
 
     @Gtk.Template.Callback()
     def smoothen(self, *_args):
         operations.perform_operation(
-            self.props.application, operations.smoothen)
+            self.get_application(), operations.smoothen)
 
     @Gtk.Template.Callback()
     def center(self, *_args):
         operations.perform_operation(
-            self.props.application, operations.center,
-            self.props.application.get_settings("general").get_enum("center"))
+            self.get_application(), operations.center,
+            self.get_application().get_settings("general").get_enum("center"))
 
     @Gtk.Template.Callback()
     def combine(self, *_args):
-        operations.combine(self.props.application)
+        operations.combine(self.get_application())
 
     @Gtk.Template.Callback()
     def cut(self, *_args):
-        if self.props.application.props.mode == 2:
+        if self.get_application().get_mode() == 2:
             operations.perform_operation(
-                self.props.application, operations.cut_selected)
+                self.get_application(), operations.cut_selected)
 
     @Gtk.Template.Callback()
     def translate_x(self, *_args):
@@ -102,7 +105,7 @@ class GraphsWindow(Adw.ApplicationWindow):
             offset = utilities.string_to_float(
                 self.translate_x_entry.get_text())
             operations.perform_operation(
-                self.props.application, operations.translate_x, offset)
+                self.get_application(), operations.translate_x, offset)
         except ValueError as error:
             self.add_toast(error)
 
@@ -112,7 +115,7 @@ class GraphsWindow(Adw.ApplicationWindow):
             offset = utilities.string_to_float(
                 self.translate_y_entry.get_text())
             operations.perform_operation(
-                self.props.application, operations.translate_y, offset)
+                self.get_application(), operations.translate_y, offset)
         except ValueError as error:
             self.add_toast(error)
 
@@ -122,7 +125,7 @@ class GraphsWindow(Adw.ApplicationWindow):
             multiplier = utilities.string_to_float(
                 self.multiply_x_entry.get_text())
             operations.perform_operation(
-                self.props.application, operations.multiply_x, multiplier)
+                self.get_application(), operations.multiply_x, multiplier)
         except ValueError as error:
             self.add_toast(error)
 
@@ -132,30 +135,30 @@ class GraphsWindow(Adw.ApplicationWindow):
             multiplier = utilities.string_to_float(
                 self.multiply_y_entry.get_text())
             operations.perform_operation(
-                self.props.application, operations.multiply_y, multiplier)
+                self.get_application(), operations.multiply_y, multiplier)
         except ValueError as error:
             self.add_toast(error)
 
     @Gtk.Template.Callback()
     def derivative(self, *_args):
         operations.perform_operation(
-            self.props.application, operations.get_derivative)
+            self.get_application(), operations.get_derivative)
 
     @Gtk.Template.Callback()
     def integral(self, *_args):
         operations.perform_operation(
-            self.props.application, operations.get_integral)
+            self.get_application(), operations.get_integral)
 
     @Gtk.Template.Callback()
     def fourier(self, *_args):
         operations.perform_operation(
-            self.props.application, operations.get_fourier)
+            self.get_application(), operations.get_fourier)
 
     @Gtk.Template.Callback()
     def inverse_fourier(self, *_args):
         operations.perform_operation(
-            self.props.application, operations.get_inverse_fourier)
+            self.get_application(), operations.get_inverse_fourier)
 
     @Gtk.Template.Callback()
     def transform(self, *_args):
-        TransformWindow(self.props.application)
+        TransformWindow(self.get_application())


### PR DESCRIPTION
Use getters and setters for most commonly used properties.
This is more in line with GObject based libraries, which have explicit getter and setter methods.
This also allows to make the code a bit more readable and in case we need them inject safeguards into those methods.

In cases, where have function-defined properties, this can in some cases improve performance, as annotators have a slight overhead compared to regular functions.