### PR TITLE
Fix clipboard behaviour

### DIFF
--- a/src/clipboard.py
+++ b/src/clipboard.py
@@ -83,7 +83,7 @@ class DataClipboard(BaseClipboard):
             clipboard=[([], application.get_figure_settings().get_limits())],
         )
 
-    def add(self):
+    def add(self, old_limits=None):
         """
         Add data to the clipboard, is performed whenever an action is performed
         Appends the latest state to the clipboard.
@@ -94,6 +94,11 @@ class DataClipboard(BaseClipboard):
             self.props.current_batch,
             self.get_application().get_figure_settings().get_limits(),
         ))
+
+        if old_limits is not None:
+            for index in range(8):
+                self.get_clipboard()[self.get_clipboard_pos() - 1][1][index] \
+                    = old_limits[index]
         # Keep clipboard length limited to 100 spots
         if len(self.get_clipboard()) > 101:
             self.set_clipboard(self.get_clipboard()[1:])

--- a/src/operations.py
+++ b/src/operations.py
@@ -73,6 +73,7 @@ def sort_data(xdata, ydata):
 
 def perform_operation(self, callback, *args):
     data_selected = False
+    old_limits = self.get_figure_settings().get_limits()
     for item in self.get_data():
         if not item.selected or item.props.item_type != "Item":
             continue
@@ -99,7 +100,7 @@ def perform_operation(self, callback, *args):
             _("No data found within the highlighted area"))
         return
     utilities.optimize_limits(self)
-    self.get_clipboard().add()
+    self.get_clipboard().add(old_limits)
 
 
 def translate_x(_item, xdata, ydata, offset):


### PR DESCRIPTION
In the latest main branch, undo/redo actions no longer show the previous view when resetting an action. The fact that this worked actually seems to rely on a bug in the old optimize_limits function, where it didn't change the internal canvas limits properties. When this bug was fixed with one of the latest refactors, this functionality broke.

This PR reimplements this behaviour. A bit of a workaround, but it works as intended and exactly as it did before.