### PR TITLE
Stop canvas from stealing focus

### DIFF
--- a/src/canvas.py
+++ b/src/canvas.py
@@ -92,6 +92,7 @@ class Canvas(FigureCanvas):
         """
         GObject.Object.__init__(self, application=application)
         super().__init__()
+        self.set_can_focus(False)
         self.figure.set_tight_layout(True)
         self.mpl_connect("pick_event", self._on_pick)
         self.axis = self.figure.add_subplot(111)

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -92,7 +92,6 @@ class Canvas(FigureCanvas):
         """
         GObject.Object.__init__(self, application=application, can_focus=False)
         super().__init__()
-        self.set_can_focus(False)
         self.figure.set_tight_layout(True)
         self.mpl_connect("pick_event", self._on_pick)
         self.axis = self.figure.add_subplot(111)

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -90,7 +90,7 @@ class Canvas(FigureCanvas):
         style context. Bind `items` to `data.items` and all figure settings
         attributes to their respective values.
         """
-        GObject.Object.__init__(self, application=application)
+        GObject.Object.__init__(self, application=application, can_focus=False)
         super().__init__()
         self.set_can_focus(False)
         self.figure.set_tight_layout(True)


### PR DESCRIPTION
Currently, when panning/zooming on the graph, the canvas itself steals focus. This means that shortcuts such as ctrl+z or ctrl+N and such no longer work.

There's no real reason to have a the focus on the canvas. This change makes it such that shortcuts keep working.