### PR TITLE
Add square root scaling

### DIFF
--- a/data/ui/figure_settings.blp
+++ b/data/ui/figure_settings.blp
@@ -124,28 +124,28 @@ template $FigureSettingsWindow : Adw.PreferencesWindow {
       Adw.ComboRow bottom_scale {
         title: _("Bottom Axis Scale");
         model: StringList{
-          strings [_("linear"), _("logarithmic"), _("radians")]
+          strings [_("Linear"), _("Logarithmic"), _("Radians"), _("Square root")]
         };
       }
 
       Adw.ComboRow left_scale {
         title: _("Left Axis Scale");
         model: StringList{
-          strings [_("linear"), _("logarithmic"), _("radians")]
+          strings [_("Linear"), _("Logarithmic"), _("Radians"), _("Square root")]
         };
       }
 
       Adw.ComboRow top_scale {
         title: _("Top Axis Scale");
         model: StringList{
-          strings [_("linear"), _("logarithmic"), _("radians")]
+          strings [_("Linear"), _("Logarithmic"), _("Radians"), _("Square root")]
         };
       }
 
       Adw.ComboRow right_scale {
         title: _("Right Axis Scale");
         model: StringList{
-          strings [_("linear"), _("logarithmic"), _("radians")]
+          strings [_("Linear"), _("Logarithmic"), _("Radians"), _("Square root")]
         };
       }
     }

--- a/data/ui/window.blp
+++ b/data/ui/window.blp
@@ -681,6 +681,11 @@ menu view_menu {
         action: "app.change-top-scale";
         target: "2";
       }
+      item {
+        label: _("Square root");
+        action: "app.change-top-scale";
+        target: "3";
+      }
     }
     submenu {
       label: _("Bottom X Scale");
@@ -698,6 +703,11 @@ menu view_menu {
         label: _("Radians");
         action: "app.change-bottom-scale";
         target: "2";
+      }
+      item {
+        label: _("Square root");
+        action: "app.change-bottom-scale";
+        target: "3";
       }
     }
     submenu {
@@ -717,6 +727,11 @@ menu view_menu {
         action: "app.change-left-scale";
         target: "2";
       }
+      item {
+        label: _("Square root");
+        action: "app.change-left-scale";
+        target: "3";
+      }
     }
     submenu {
       label: _("Right Y Scale");
@@ -734,6 +749,11 @@ menu view_menu {
         label: _("Radians");
         action: "app.change-right-scale";
         target: "2";
+      }
+      item {
+        label: _("Square root");
+        action: "app.change-right-scale";
+        target: "3";
       }
     }
   }

--- a/src/main.py
+++ b/src/main.py
@@ -10,7 +10,7 @@ from gettext import gettext as _
 
 from gi.repository import Adw, GLib, GObject, Gio
 
-from graphs import actions, migrate, scales, ui
+from graphs import actions, migrate, ui
 from graphs.clipboard import DataClipboard, ViewClipboard
 from graphs.data import Data
 from graphs.figure_settings import FigureSettings

--- a/src/scales.py
+++ b/src/scales.py
@@ -43,9 +43,6 @@ class SquareRootScale(scale.ScaleBase):
     """Class for generating custom square root scale."""
     name = "squareroot"
 
-    def __init__(self, axis):
-        scale.ScaleBase.__init__(self, axis)
-
     def set_default_locators_and_formatters(self, axis):
         axis.set_major_locator(ticker.AutoLocator())
         axis.set_major_formatter(ticker.ScalarFormatter())
@@ -57,9 +54,9 @@ class SquareRootScale(scale.ScaleBase):
 
     class SquareRootTransform(transforms.Transform):
         """The transform to convert from linear to square root scale"""
-        input_dims = 1
-        output_dims = 1
-        is_separable = True
+        input_dims = 1 # Amount of input params in transform
+        output_dims = 1 # Amount of output params in transform
+        is_separable = True # Seperable in X and Y dimension
 
         def transform_non_affine(self, a):
             return numpy.array(a)**0.5

--- a/src/scales.py
+++ b/src/scales.py
@@ -54,9 +54,9 @@ class SquareRootScale(scale.ScaleBase):
 
     class SquareRootTransform(transforms.Transform):
         """The transform to convert from linear to square root scale"""
-        input_dims = 1 # Amount of input params in transform
-        output_dims = 1 # Amount of output params in transform
-        is_separable = True # Seperable in X and Y dimension
+        input_dims = 1  # Amount of input params in transform
+        output_dims = 1  # Amount of output params in transform
+        is_separable = True  # Seperable in X and Y dimension
 
         def transform_non_affine(self, a):
             return numpy.array(a)**0.5
@@ -66,9 +66,9 @@ class SquareRootScale(scale.ScaleBase):
 
     class InvertedSquareRootTransform(transforms.Transform):
         """The inverse transform to convert from square root to linear scale"""
-        input_dims = 1
-        output_dims = 1
-        is_separable = True
+        input_dims = 1  # Amount of input params in transform
+        output_dims = 1  # Amount of output params in transform
+        is_separable = True  # Seperable in X and Y dimension
 
         def transform(self, a):
             return numpy.array(a)**2

--- a/src/scales.py
+++ b/src/scales.py
@@ -9,11 +9,11 @@ custom Scale classes.
         to_string
         to_int
 """
-from matplotlib import scale, ticker
+from matplotlib import scale, ticker, transforms
 
 import numpy
 
-_SCALES = ["linear", "log", "radians"]
+_SCALES = ["linear", "log", "radians", "squareroot"]
 
 
 def to_string(scale: int) -> str:
@@ -39,4 +39,49 @@ class RadiansScale(scale.LinearScale):
         axis.set_major_locator(ticker.MultipleLocator(base=numpy.pi))
 
 
+class SquareRootScale(scale.ScaleBase):
+    """Class for generating custom square root scale."""
+    name = "squareroot"
+
+    def __init__(self, axis):
+        scale.ScaleBase.__init__(self, axis)
+
+    def set_default_locators_and_formatters(self, axis):
+        axis.set_major_locator(ticker.AutoLocator())
+        axis.set_major_formatter(ticker.ScalarFormatter())
+        axis.set_minor_locator(ticker.NullLocator())
+        axis.set_minor_formatter(ticker.NullFormatter())
+
+    def limit_range_for_scale(self, vmin, vmax, _minpos):
+        return max(0, vmin), vmax
+
+    class SquareRootTransform(transforms.Transform):
+        """The transform to convert from linear to square root scale"""
+        input_dims = 1
+        output_dims = 1
+        is_separable = True
+
+        def transform_non_affine(self, a):
+            return numpy.array(a)**0.5
+
+        def inverted(self):
+            return SquareRootScale.InvertedSquareRootTransform()
+
+    class InvertedSquareRootTransform(transforms.Transform):
+        """The inverse transform to convert from square root to linear scale"""
+        input_dims = 1
+        output_dims = 1
+        is_separable = True
+
+        def transform(self, a):
+            return numpy.array(a)**2
+
+        def inverted(self):
+            return SquareRootScale.SquareRootTransform()
+
+    def get_transform(self):
+        return self.SquareRootTransform()
+
+
 scale.register_scale(RadiansScale)
+scale.register_scale(SquareRootScale)

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -61,16 +61,22 @@ def get_value_at_fraction(fraction, start, end, scale):
     """
     Obtain the selected value of an axis given at which percentage (in terms of
     fraction) of the length this axis is selected given the start and end range
-    of this axis
+    of this axis.
     """
-    if scale == 0:
+    if scale == 0 or scale == 2:  # Linear  oscale
         return start + fraction * (end - start)
-    else:
+    elif scale == 1:  # Logarithmic scale
         log_start = numpy.log10(start)
         log_end = numpy.log10(end)
         log_range = log_end - log_start
         log_value = log_start + log_range * fraction
         return pow(10, log_value)
+    elif scale == 3:  # Square root scale
+        sqrt_start = numpy.sqrt(start)
+        sqrt_end = numpy.sqrt(end)
+        sqrt_range = sqrt_end - sqrt_start
+        sqrt_value = sqrt_start + sqrt_range * fraction
+        return sqrt_value * sqrt_value
 
 
 def get_fraction_at_value(value, start, end, scale):
@@ -78,14 +84,20 @@ def get_fraction_at_value(value, start, end, scale):
     Obtain the fraction of the total length of the selected axis a specific
     value corresponds to given the start and end range of the axis.
     """
-    if scale == 0:
+    if scale == 0 or scale == 2:  # Linear or radian scale
         return (value - start) / (end - start)
-    else:
+    elif scale == 1:  # Logarithmic scale
         log_start = numpy.log10(start)
         log_end = numpy.log10(end)
         log_value = numpy.log10(value)
         log_range = log_end - log_start
         return (log_value - log_start) / log_range
+    elif scale == 3:  # Square root scale
+        sqrt_start = numpy.sqrt(start)
+        sqrt_end = numpy.sqrt(end)
+        sqrt_value = numpy.sqrt(value)
+        sqrt_range = sqrt_end - sqrt_start
+        return (sqrt_value - sqrt_start) / sqrt_range
 
 
 def shorten_label(label, max_length=19):


### PR DESCRIPTION
Adds square root scaling as fourth option. I don't have any immediate plans of adding more options here (inverted (1/x) would be an option though). But as I mentioned, I am considering adding a context-depended option for .xrdml files so it will be possible to easily toggle between angular coordinates and reciprocal space. (Something which isn't even possible with the official DataViewer software from Panalytical, which frankly is pretty bad anyway)