### PR TITLE
Add inverse scaling

### DIFF
--- a/data/se.sjoerd.Graphs.gschema.xml
+++ b/data/se.sjoerd.Graphs.gschema.xml
@@ -43,6 +43,7 @@
     <value nick="Logarithmic" value="1"/>
     <value nick="Radians" value="2"/>
     <value nick="Square Root" value="3"/>
+    <value nick="Inverse" value="4"/>
   </enum>
 
   <enum id="se.sjoerd.Graphs.x-positions">

--- a/data/ui/figure_settings.blp
+++ b/data/ui/figure_settings.blp
@@ -124,28 +124,28 @@ template $FigureSettingsWindow : Adw.PreferencesWindow {
       Adw.ComboRow bottom_scale {
         title: _("Bottom Axis Scale");
         model: StringList{
-          strings [_("Linear"), _("Logarithmic"), _("Radians"), _("Square Root")]
+          strings [_("Linear"), _("Logarithmic"), _("Radians"), _("Square Root"), _("Inverse")]
         };
       }
 
       Adw.ComboRow left_scale {
         title: _("Left Axis Scale");
         model: StringList{
-          strings [_("Linear"), _("Logarithmic"), _("Radians"), _("Square Root")]
+          strings [_("Linear"), _("Logarithmic"), _("Radians"), _("Square Root"), _("Inverse")]
         };
       }
 
       Adw.ComboRow top_scale {
         title: _("Top Axis Scale");
         model: StringList{
-          strings [_("Linear"), _("Logarithmic"), _("Radians"), _("Square Root")]
+          strings [_("Linear"), _("Logarithmic"), _("Radians"), _("Square Root"), _("Inverse")]
         };
       }
 
       Adw.ComboRow right_scale {
         title: _("Right Axis Scale");
         model: StringList{
-          strings [_("Linear"), _("Logarithmic"), _("Radians"), _("Square Root")]
+          strings [_("Linear"), _("Logarithmic"), _("Radians"), _("Square Root"), _("Inverse")]
         };
       }
     }
@@ -178,3 +178,4 @@ template $FigureSettingsWindow : Adw.PreferencesWindow {
     }
   }
 }
+)

--- a/data/ui/figure_settings.blp
+++ b/data/ui/figure_settings.blp
@@ -178,4 +178,3 @@ template $FigureSettingsWindow : Adw.PreferencesWindow {
     }
   }
 }
-)

--- a/data/ui/preferences.blp
+++ b/data/ui/preferences.blp
@@ -142,4 +142,4 @@ template $PreferencesWindow : Adw.PreferencesWindow {
       }
     }
   }
-})
+}

--- a/data/ui/preferences.blp
+++ b/data/ui/preferences.blp
@@ -64,28 +64,28 @@ template $PreferencesWindow : Adw.PreferencesWindow {
       Adw.ComboRow figure_bottom_scale {
         title: _("Default Bottom Axis Scale");
         model: StringList{
-          strings [_("Linear"), _("Logarithmic"), _("Radians"), _("Square Root")]
+          strings [_("Linear"), _("Logarithmic"), _("Radians"), _("Square Root"), _("Inverse")]
         };
       }
 
       Adw.ComboRow figure_left_scale {
         title: _("Default Left Axis Scale");
         model: StringList{
-          strings [_("Linear"), _("Logarithmic"), _("Radians"), _("Square Root")]
+          strings [_("Linear"), _("Logarithmic"), _("Radians"), _("Square Root"), _("Inverse")]
         };
       }
 
       Adw.ComboRow figure_top_scale {
         title: _("Default Top Axis Scale");
         model: StringList{
-          strings [_("Linear"), _("Logarithmic"), _("Radians"), _("Square Root")]
+          strings [_("Linear"), _("Logarithmic"), _("Radians"), _("Square Root"), _("Inverse")]
         };
       }
 
       Adw.ComboRow figure_right_scale {
         title: _("Default Right Axis Scale");
         model: StringList{
-          strings [_("Linear"), _("Logarithmic"), _("Radians"), _("Square Root")]
+          strings [_("Linear"), _("Logarithmic"), _("Radians"), _("Square Root"), _("Inverse")]
         };
       }
 
@@ -142,4 +142,4 @@ template $PreferencesWindow : Adw.PreferencesWindow {
       }
     }
   }
-}
+})

--- a/data/ui/preferences.blp
+++ b/data/ui/preferences.blp
@@ -23,6 +23,10 @@ template $PreferencesWindow : Adw.PreferencesWindow {
           strings [_("Auto-rename duplicates"), _("Ignore duplicates"), _("Add duplicates"), _("Override existing items")]
         };
       }
+    }
+
+    Adw.PreferencesGroup {
+      title: _("Figure");
 
       Adw.ActionRow {
         title: _("Hide Unselected Items");
@@ -32,110 +36,26 @@ template $PreferencesWindow : Adw.PreferencesWindow {
           valign: center;
         }
       }
-    }
 
-    Adw.PreferencesGroup {
-      title: _("Labels");
-
-      Adw.EntryRow figure_title {
-        title: _("Default Title");
-      }
-
-      Adw.EntryRow figure_left_label {
-        title: _("Default Bottom Axis label");
-      }
-
-      Adw.EntryRow figure_bottom_label {
-        title: _("Default Left Axis Label");
-      }
-
-      Adw.EntryRow figure_top_label {
-        title: _("Default Top Axis Label");
-      }
-
-      Adw.EntryRow figure_right_label {
-        title: _("Default Right Axis Label");
-      }
-    }
-
-    Adw.PreferencesGroup {
-      title: _("Axes");
-
-      Adw.ComboRow figure_bottom_scale {
-        title: _("Default Bottom Axis Scale");
-        model: StringList{
-          strings [_("Linear"), _("Logarithmic"), _("Radians"), _("Square Root"), _("Inverse")]
-        };
-      }
-
-      Adw.ComboRow figure_left_scale {
-        title: _("Default Left Axis Scale");
-        model: StringList{
-          strings [_("Linear"), _("Logarithmic"), _("Radians"), _("Square Root"), _("Inverse")]
-        };
-      }
-
-      Adw.ComboRow figure_top_scale {
-        title: _("Default Top Axis Scale");
-        model: StringList{
-          strings [_("Linear"), _("Logarithmic"), _("Radians"), _("Square Root"), _("Inverse")]
-        };
-      }
-
-      Adw.ComboRow figure_right_scale {
-        title: _("Default Right Axis Scale");
-        model: StringList{
-          strings [_("Linear"), _("Logarithmic"), _("Radians"), _("Square Root"), _("Inverse")]
-        };
-      }
-
-      Adw.ComboRow figure_x_position {
+      Adw.ComboRow general_x_position {
         title: _("Default X-Axis Position");
         subtitle: _("Which axis should a new item be displayed on");
         model: StringList{
-          strings [_("bottom"), _("top")]
+          strings [_("Bottom"), _("Top")]
         };
       }
 
-      Adw.ComboRow figure_y_position {
+      Adw.ComboRow general_y_position {
         title: _("Default Y-Axis Position");
         subtitle: _("Which axis should a new item be displayed on");
         model: StringList{
-          strings [_("left"), _("right")]
+          strings [_("Left"), _("Right")]
         };
-      }
-    }
-
-    Adw.PreferencesGroup {
-      title: _("Styling");
-
-      Adw.ExpanderRow figure_legend {
-        title: _("Legend");
-        subtitle: _("Use a legend by default");
-        show-enable-switch: true;
-        Adw.ComboRow figure_legend_position {
-          title: _("Legend Position");
-          model: StringList{
-            strings [
-              _("Best"), _("Upper right"), _("Upper left"), _("Lower left"),
-              _("Lower right"), _("Center left"), _("Center right"),
-              _("Lower center"), _("Upper center"), _("Center"),
-            ]
-          };
-        }
-      }
-
-      Adw.ExpanderRow figure_use_custom_style {
-        title: _("Custom Style by Default");
-        show-enable-switch: true;
-        Adw.ComboRow figure_custom_style {
-          title: _("Style");
-          notify::selected => $on_custom_style_select();
-        }
       }
 
       Adw.ActionRow {
-        title: _("Override item properties on style change");
+        title: _("Override Item Properties on Style Change");
+        activatable-widget: general_override_item_properties;
         Switch general_override_item_properties {
           valign: center;
         }

--- a/data/ui/window.blp
+++ b/data/ui/window.blp
@@ -686,6 +686,11 @@ menu view_menu {
         action: "app.change-top-scale";
         target: "3";
       }
+      item {
+        label: _("Inverse");
+        action: "app.change-top-scale";
+        target: "4";
+      }
     }
     submenu {
       label: _("Bottom X Scale");
@@ -708,6 +713,11 @@ menu view_menu {
         label: _("Square Root");
         action: "app.change-bottom-scale";
         target: "3";
+      }
+      item {
+        label: _("Inverse");
+        action: "app.change-bottom-scale";
+        target: "4";
       }
     }
     submenu {
@@ -732,6 +742,11 @@ menu view_menu {
         action: "app.change-left-scale";
         target: "3";
       }
+      item {
+        label: _("Inverse");
+        action: "app.change-left-scale";
+        target: "4";
+      }
     }
     submenu {
       label: _("Right Y Scale");
@@ -754,6 +769,11 @@ menu view_menu {
         label: _("Square Root");
         action: "app.change-right-scale";
         target: "3";
+      }
+      item {
+        label: _("Inverse");
+        action: "app.change-right-scale";
+        target: "4";
       }
     }
   }

--- a/src/actions.py
+++ b/src/actions.py
@@ -21,6 +21,7 @@ def set_mode(_action, _target, self, mode):
 
 def change_scale(action, target, self, prop):
     self.get_figure_settings().set_property(prop, int(target.get_string()))
+    utilities.optimize_limits(self)
     action.change_state(target)
 
 

--- a/src/operations.py
+++ b/src/operations.py
@@ -21,6 +21,7 @@ def get_data(self, item):
     ydata = item.ydata
     new_xdata = xdata.copy()
     new_ydata = ydata.copy()
+    start_stop = []
     start_index = 0
     stop_index = len(xdata)
     if self.get_mode() == 2:
@@ -49,11 +50,12 @@ def get_data(self, item):
             found_stop = False
             for index, value in enumerate(xdata):
                 if value > startx and not found_start:
-                    start_index = index
+                    start_stop.append(index)
                     found_start = True
                 if value > stopx and not found_stop:
-                    stop_index = index
+                    start_stop.append(index)
                     found_stop = True
+            start_index, stop_index = min(start_stop), max(start_stop)
             new_xdata = new_x[start_index:stop_index]
             new_ydata = new_y[start_index:stop_index]
         else:
@@ -188,15 +190,15 @@ def shift_vertically(item, xdata, ydata, left_scale, right_scale, items):
         ymin = min(x for x in previous_ydata if x != 0)
         ymax = max(x for x in previous_ydata if x != 0)
         scale = right_scale if item.yposition else left_scale
-        if scale == 0:
-            shift_value_linear += 1.2 * (ymax - ymin)
-        else:
+        if scale == 1:  # Use log values for log scaling
             shift_value_log += numpy.log10(ymax / ymin)
+        else:
+            shift_value_linear += 1.2 * (ymax - ymin)
         if item.key == item_.key:
-            if scale == 0:
-                new_ydata = [value + shift_value_linear for value in ydata]
-            else:
+            if scale == 1:  # Log scaling
                 new_ydata = [value * 10 ** shift_value_log for value in ydata]
+            else:
+                new_ydata = [value + shift_value_linear for value in ydata]
             return xdata, new_ydata, False, False
     return xdata, ydata, False, False
 

--- a/src/operations.py
+++ b/src/operations.py
@@ -54,7 +54,8 @@ def get_data(self, item):
                 if value > stopx and not found_stop:
                     stop_index = index
                     found_stop = True
-            start_index, stop_index = [start_index, stop_index]
+            start_index, stop_index = min([start_index, stop_index]), \
+                max([start_index, stop_index])
             new_xdata = new_x[start_index:stop_index]
             new_ydata = new_y[start_index:stop_index]
         else:

--- a/src/operations.py
+++ b/src/operations.py
@@ -21,7 +21,6 @@ def get_data(self, item):
     ydata = item.ydata
     new_xdata = xdata.copy()
     new_ydata = ydata.copy()
-    start_stop = []
     start_index = 0
     stop_index = len(xdata)
     if self.get_mode() == 2:
@@ -50,12 +49,12 @@ def get_data(self, item):
             found_stop = False
             for index, value in enumerate(xdata):
                 if value > startx and not found_start:
-                    start_stop.append(index)
+                    start_index = index
                     found_start = True
                 if value > stopx and not found_stop:
-                    start_stop.append(index)
+                    stop_index = index
                     found_stop = True
-            start_index, stop_index = min(start_stop), max(start_stop)
+            start_index, stop_index = [start_index, stop_index]
             new_xdata = new_x[start_index:stop_index]
             new_ydata = new_y[start_index:stop_index]
         else:

--- a/src/scales.py
+++ b/src/scales.py
@@ -13,7 +13,7 @@ from matplotlib import scale, ticker, transforms
 
 import numpy
 
-_SCALES = ["linear", "log", "radians", "squareroot"]
+_SCALES = ["linear", "log", "radians", "squareroot", "inverse"]
 
 
 def to_string(scale: int) -> str:
@@ -43,6 +43,14 @@ class SquareRootScale(scale.ScaleBase):
     """Class for generating custom square root scale."""
     name = "squareroot"
 
+    def __init__(self, axis, **kwargs):
+        # note in older versions of matplotlib (<3.1), this worked fine.
+        # mscale.ScaleBase.__init__(self)
+
+        # In newer versions (>=3.1), you also need to pass in `axis` as an arg
+        scale.ScaleBase.__init__(self, axis)
+
+
     def set_default_locators_and_formatters(self, axis):
         axis.set_major_locator(ticker.AutoLocator())
         axis.set_major_formatter(ticker.ScalarFormatter())
@@ -59,7 +67,7 @@ class SquareRootScale(scale.ScaleBase):
         is_separable = True  # Seperable in X and Y dimension
 
         def transform_non_affine(self, a):
-            return numpy.array(a)**0.5
+            return numpy.sqrt(numpy.array(a))
 
         def inverted(self):
             return SquareRootScale.InvertedSquareRootTransform()
@@ -79,6 +87,75 @@ class SquareRootScale(scale.ScaleBase):
     def get_transform(self):
         return self.SquareRootTransform()
 
+    def axisinfo(self, axis, *args, **kwargs):
+        majloc = axis.get_major_locator()
+        majfmt = axis.get_major_formatter()
+        majfmt.set_useOffset(False)  # Prevent offset from being applied
+        majfmt.set_scientific(False)  # Prevent scientific notation
+        majfmt.set_useMathText(False)  # Prevent math text rendering
+        return scale.AxisInfo(majloc=majloc, majfmt=majfmt)
+
+    def transfer_transform(self, transform):
+        return self.InvertedSquareRootTransform()
+
+    def inverted(self):
+        return self.InvertedSquareRootTransform()
+
+class InverseScale(scale.ScaleBase):
+    """Class for generating custom inverse scale."""
+    name = "inverse"
+
+    def set_default_locators_and_formatters(self, axis):
+        class InverseLocator(ticker.Locator):
+            def __call__(self):
+                vmin, vmax = axis.get_view_interval()
+                num_ticks = 19  # Adjust as needed
+                ticklocs = numpy.linspace(vmin, vmax, num=num_ticks)
+                ticklocs_transformed = 1 / numpy.array(ticklocs)
+                return self.raise_if_exceeds(ticklocs_transformed)
+
+        axis.set_major_locator(InverseLocator())
+        axis.set_major_formatter(ticker.ScalarFormatter())
+        axis.set_minor_locator(ticker.NullLocator())
+        axis.set_minor_formatter(ticker.NullFormatter())
+        def limit_range_for_scale(self, vmin, vmax, _minpos):
+            return max(0, vmin), vmax
+
+    class InverseTransform(transforms.Transform):
+        """The transform to convert from linear to inverse scale"""
+        input_dims = 1  # Amount of input params in transform
+        output_dims = 1  # Amount of output params in transform
+        is_separable = True  # Separable in X and Y dimension
+
+        def transform_non_affine(self, a):
+            return 1/numpy.array(a)
+
+        def inverted(self):
+            return InverseScale.InvertedInverseTransform()
+
+    class InvertedInverseTransform(transforms.Transform):
+        """The inverse transform to convert from square root to linear scale"""
+        input_dims = 1  # Amount of input params in transform
+        output_dims = 1  # Amount of output params in transform
+        is_separable = True  # Separable in X and Y dimension
+
+        def transform(self, a):
+            return 1/numpy.array(a)
+
+        def inverted(self):
+            return InverseScale.InverseTransform()
+
+    def get_transform(self):
+        return self.InverseTransform()
+
+    def axisinfo(self, axis, *args, **kwargs):
+        majloc = axis.get_major_locator()
+        majfmt = axis.get_major_formatter()
+        majfmt.set_useOffset(False)  # Prevent offset from being applied
+        majfmt.set_scientific(False)  # Prevent scientific notation
+        majfmt.set_useMathText(False)  # Prevent math text rendering
+        return scale.AxisInfo(majloc=majloc, majfmt=majfmt)
 
 scale.register_scale(RadiansScale)
 scale.register_scale(SquareRootScale)
+scale.register_scale(InverseScale)

--- a/src/scales.py
+++ b/src/scales.py
@@ -13,7 +13,7 @@ from matplotlib import scale, ticker, transforms
 
 import numpy
 
-_SCALES = ["linear", "log", "radians", "squareroot", "inverse"]
+_SCALES = ["linear", "log", "radians", "squareroot", "inverted"]
 
 
 def to_string(scale: int) -> str:
@@ -43,14 +43,6 @@ class SquareRootScale(scale.ScaleBase):
     """Class for generating custom square root scale."""
     name = "squareroot"
 
-    def __init__(self, axis, **kwargs):
-        # note in older versions of matplotlib (<3.1), this worked fine.
-        # mscale.ScaleBase.__init__(self)
-
-        # In newer versions (>=3.1), you also need to pass in `axis` as an arg
-        scale.ScaleBase.__init__(self, axis)
-
-
     def set_default_locators_and_formatters(self, axis):
         axis.set_major_locator(ticker.AutoLocator())
         axis.set_major_formatter(ticker.ScalarFormatter())
@@ -67,7 +59,7 @@ class SquareRootScale(scale.ScaleBase):
         is_separable = True  # Seperable in X and Y dimension
 
         def transform_non_affine(self, a):
-            return numpy.sqrt(numpy.array(a))
+            return numpy.array(a)**0.5
 
         def inverted(self):
             return SquareRootScale.InvertedSquareRootTransform()
@@ -78,7 +70,7 @@ class SquareRootScale(scale.ScaleBase):
         output_dims = 1  # Amount of output params in transform
         is_separable = True  # Seperable in X and Y dimension
 
-        def transform(self, a):
+        def transform_non_affine(self, a):
             return numpy.array(a)**2
 
         def inverted(self):
@@ -87,75 +79,52 @@ class SquareRootScale(scale.ScaleBase):
     def get_transform(self):
         return self.SquareRootTransform()
 
-    def axisinfo(self, axis, *args, **kwargs):
-        majloc = axis.get_major_locator()
-        majfmt = axis.get_major_formatter()
-        majfmt.set_useOffset(False)  # Prevent offset from being applied
-        majfmt.set_scientific(False)  # Prevent scientific notation
-        majfmt.set_useMathText(False)  # Prevent math text rendering
-        return scale.AxisInfo(majloc=majloc, majfmt=majfmt)
 
-    def transfer_transform(self, transform):
-        return self.InvertedSquareRootTransform()
-
-    def inverted(self):
-        return self.InvertedSquareRootTransform()
-
-class InverseScale(scale.ScaleBase):
-    """Class for generating custom inverse scale."""
-    name = "inverse"
+class InvertedScale(scale.ScaleBase):
+    """Class for generating a custom reciprocal scale."""
+    name = "inverted"
 
     def set_default_locators_and_formatters(self, axis):
-        class InverseLocator(ticker.Locator):
-            def __call__(self):
-                vmin, vmax = axis.get_view_interval()
-                num_ticks = 19  # Adjust as needed
-                ticklocs = numpy.linspace(vmin, vmax, num=num_ticks)
-                ticklocs_transformed = 1 / numpy.array(ticklocs)
-                return self.raise_if_exceeds(ticklocs_transformed)
-
-        axis.set_major_locator(InverseLocator())
+        axis.set_major_locator(ticker.AutoLocator())
         axis.set_major_formatter(ticker.ScalarFormatter())
         axis.set_minor_locator(ticker.NullLocator())
         axis.set_minor_formatter(ticker.NullFormatter())
-        def limit_range_for_scale(self, vmin, vmax, _minpos):
-            return max(0, vmin), vmax
 
-    class InverseTransform(transforms.Transform):
-        """The transform to convert from linear to inverse scale"""
-        input_dims = 1  # Amount of input params in transform
-        output_dims = 1  # Amount of output params in transform
-        is_separable = True  # Separable in X and Y dimension
+    def limit_range_for_scale(self, vmin, vmax, _minpos):
+        if vmax > 0:
+            return max(vmax / 10, vmin), vmax
+        else:
+            return vmin, vmax
+
+    class InvertedTransform(transforms.Transform):
+        """The transform to convert between linear and reciprocal scale"""
+        input_dims = 1
+        output_dims = 1
 
         def transform_non_affine(self, a):
-            return 1/numpy.array(a)
+            return 1 / numpy.array(a)
 
         def inverted(self):
-            return InverseScale.InvertedInverseTransform()
+            return InvertedScale.InvertedInvertedTransform()
 
-    class InvertedInverseTransform(transforms.Transform):
-        """The inverse transform to convert from square root to linear scale"""
-        input_dims = 1  # Amount of input params in transform
-        output_dims = 1  # Amount of output params in transform
-        is_separable = True  # Separable in X and Y dimension
+    class InvertedInvertedTransform(transforms.Transform):
+        """
+        The inverse transform to convert the axis between reciprocal and
+        linear scale
+        """
+        input_dims = 1
+        output_dims = 1
 
-        def transform(self, a):
-            return 1/numpy.array(a)
+        def transform_non_affine(self, a):
+            return 1 / numpy.array(a)
 
         def inverted(self):
-            return InverseScale.InverseTransform()
+            return InvertedScale.InvertedTransform()
 
     def get_transform(self):
-        return self.InverseTransform()
+        return self.InvertedTransform()
 
-    def axisinfo(self, axis, *args, **kwargs):
-        majloc = axis.get_major_locator()
-        majfmt = axis.get_major_formatter()
-        majfmt.set_useOffset(False)  # Prevent offset from being applied
-        majfmt.set_scientific(False)  # Prevent scientific notation
-        majfmt.set_useMathText(False)  # Prevent math text rendering
-        return scale.AxisInfo(majloc=majloc, majfmt=majfmt)
 
 scale.register_scale(RadiansScale)
 scale.register_scale(SquareRootScale)
-scale.register_scale(InverseScale)
+scale.register_scale(InvertedScale)

--- a/src/scales.py
+++ b/src/scales.py
@@ -92,9 +92,9 @@ class InvertedScale(scale.ScaleBase):
 
     def limit_range_for_scale(self, vmin, vmax, _minpos):
         if vmax > 0:
-            return max(vmax / 10, vmin), vmax
-        else:
-            return vmin, vmax
+            if vmin <= 0:
+                return max(vmax / 10, vmin), vmax
+        return vmin, vmax
 
     class InvertedTransform(transforms.Transform):
         """The transform to convert between linear and reciprocal scale"""

--- a/src/scales.py
+++ b/src/scales.py
@@ -46,7 +46,7 @@ class SquareRootScale(scale.ScaleBase):
     def set_default_locators_and_formatters(self, axis):
         axis.set_major_locator(ticker.AutoLocator())
         axis.set_major_formatter(ticker.ScalarFormatter())
-        axis.set_minor_locator(ticker.NullLocator())
+        axis.set_minor_locator(ticker.AutoLocator())
         axis.set_minor_formatter(ticker.NullFormatter())
 
     def limit_range_for_scale(self, vmin, vmax, _minpos):
@@ -87,7 +87,7 @@ class InvertedScale(scale.ScaleBase):
     def set_default_locators_and_formatters(self, axis):
         axis.set_major_locator(ticker.AutoLocator())
         axis.set_major_formatter(ticker.ScalarFormatter())
-        axis.set_minor_locator(ticker.NullLocator())
+        axis.set_minor_locator(ticker.AutoLocator())
         axis.set_minor_formatter(ticker.NullFormatter())
 
     def limit_range_for_scale(self, vmin, vmax, _minpos):

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -63,7 +63,7 @@ def get_value_at_fraction(fraction, start, end, scale):
     fraction) of the length this axis is selected given the start and end range
     of this axis.
     """
-    if scale == 0 or scale == 2:  # Linear  or radian scale
+    if scale == 0 or scale == 2:  # Linear or radian scale
         return start + fraction * (end - start)
     elif scale == 1:  # Logarithmic scale
         log_start = numpy.log10(start)
@@ -77,6 +77,14 @@ def get_value_at_fraction(fraction, start, end, scale):
         sqrt_range = sqrt_end - sqrt_start
         sqrt_value = sqrt_start + sqrt_range * fraction
         return sqrt_value * sqrt_value
+    elif scale == 4:  # Inverted scale (1/X)
+        scaled_range = 1 / start - 1 / end
+
+        # Calculate the inverse-scaled value at the given percentage
+        scaled_value = 1 / (1 / end + fraction * scaled_range)
+        print("Value is")
+        print(scaled_value)
+        return scaled_value
 
 
 def get_fraction_at_value(value, start, end, scale):
@@ -98,6 +106,13 @@ def get_fraction_at_value(value, start, end, scale):
         sqrt_value = numpy.sqrt(value)
         sqrt_range = sqrt_end - sqrt_start
         return (sqrt_value - sqrt_start) / sqrt_range
+    elif scale == 4:  # Inverted scale (1/X)
+        scaled_range = 1 / start - 1 / end
+
+        # Calculate the scaled percentage corresponding to the data point
+        scaled_data_point = 1 / value
+        scaled_percentage = (scaled_data_point - 1 / end) / scaled_range
+        return scaled_percentage
 
 
 def shorten_label(label, max_length=19):
@@ -189,13 +204,17 @@ def optimize_limits(self):
         min_all = min(min_all)
         max_all = max(max_all)
         span = max_all - min_all
-        if scale == 0:
+        if scale != 1:  # If scale is not log, add padding to all axes
+            # 0.05 padding on y-axis, 0.015 padding on x-axis
             padding_factor = 0.05 if count % 2 else 0.015
             min_all -= padding_factor * span
             max_all += padding_factor * span
-        elif count % 2:
-            min_all *= 0.5
-            max_all *= 2
+            print(max_all)
+        else:
+            # Use padding factor of 2 for y-axis, 1.025 for x-axis
+            padding_factor = 2 if count % 2 else 1.025
+            min_all *= 1 / padding_factor
+            max_all *= padding_factor
         self.get_figure_settings().set_property(f"min_{direction}", min_all)
         self.get_figure_settings().set_property(f"max_{direction}", max_all)
     self.get_view_clipboard().add()

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -72,12 +72,16 @@ def get_value_at_fraction(fraction, start, end, scale):
         log_value = log_start + log_range * fraction
         return pow(10, log_value)
     elif scale == 3:  # Square root scale
+        # Use min limit as defined by scales.py
+        start = max(0, start)
         sqrt_start = numpy.sqrt(start)
         sqrt_end = numpy.sqrt(end)
         sqrt_range = sqrt_end - sqrt_start
         sqrt_value = sqrt_start + sqrt_range * fraction
         return sqrt_value * sqrt_value
-    elif scale == 4:  # Inverted scale (1/X)
+    elif scale == 4:  # Inverted scale (1/X)'
+        # Use min limit as defined by scales.py if min equals zero
+        start = end / 10 if end > 0 and start <= 0 else start
         scaled_range = 1 / start - 1 / end
 
         # Calculate the inverse-scaled value at the given percentage
@@ -99,12 +103,16 @@ def get_fraction_at_value(value, start, end, scale):
         log_range = log_end - log_start
         return (log_value - log_start) / log_range
     elif scale == 3:  # Square root scale
+        # Use min limit as defined by scales.py
+        start = max(0, start)
         sqrt_start = numpy.sqrt(start)
         sqrt_end = numpy.sqrt(end)
         sqrt_value = numpy.sqrt(value)
         sqrt_range = sqrt_end - sqrt_start
         return (sqrt_value - sqrt_start) / sqrt_range
     elif scale == 4:  # Inverted scale (1/X)
+        # Use min limit as defined by scales.py if min equals zero
+        start = end / 10 if end > 0 and start <= 0 else start
         scaled_range = 1 / start - 1 / end
 
         # Calculate the scaled percentage corresponding to the data point
@@ -202,12 +210,16 @@ def optimize_limits(self):
         min_all = min(min_all)
         max_all = max(max_all)
         span = max_all - min_all
-        if scale != 1:  # If scale is not log, add padding to all axes
+        if scale != 1:
             # 0.05 padding on y-axis, 0.015 padding on x-axis
             padding_factor = 0.05 if count % 2 else 0.015
-            min_all -= padding_factor * span
             max_all += padding_factor * span
-        else:
+
+            # Don't add minimum padding for inverse scaling as that may lead
+            # to negative values
+            if scale != 4:
+                min_all -= padding_factor * span
+        elif scale == 1:
             # Use padding factor of 2 for y-axis, 1.025 for x-axis
             padding_factor = 2 if count % 2 else 1.025
             min_all *= 1 / padding_factor

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -82,8 +82,6 @@ def get_value_at_fraction(fraction, start, end, scale):
 
         # Calculate the inverse-scaled value at the given percentage
         scaled_value = 1 / (1 / end + fraction * scaled_range)
-        print("Value is")
-        print(scaled_value)
         return scaled_value
 
 
@@ -209,7 +207,6 @@ def optimize_limits(self):
             padding_factor = 0.05 if count % 2 else 0.015
             min_all -= padding_factor * span
             max_all += padding_factor * span
-            print(max_all)
         else:
             # Use padding factor of 2 for y-axis, 1.025 for x-axis
             padding_factor = 2 if count % 2 else 1.025


### PR DESCRIPTION
Add inverse scaling to the amount of options. Needed some tweaks to get this to work correctly with panning/zooming, `select_data`, as well as with axis-dependent operations like `shift_vertically` and `optimize_limits`.

Finally, this also adds an `optimize_limits` call to scaling changes, as the scaling is often not good at all directly after changing scale, so running `optimize_limits` is often the first thing you want to do anyway.