### PR TITLE
Fix custom style

### DIFF
--- a/src/figure_settings.py
+++ b/src/figure_settings.py
@@ -119,10 +119,10 @@ class FigureSettingsWindow(Adw.PreferencesWindow):
             self.props.figure_settings, self, ignorelist=ignorelist,
         )
         styles_ = sorted(styles.get_user_styles(application).keys())
+        style_index = styles_.index(
+            self.props.figure_settings.props.custom_style)
         self.custom_style.set_model(Gtk.StringList.new(styles_))
-        self.custom_style.set_selected(
-            styles_.index(self.props.figure_settings.props.custom_style),
-        )
+        self.custom_style.set_selected(style_index)
 
         self.set_axes_entries()
         self.no_data_message.set_visible(


### PR DESCRIPTION
There's a bug in the current Figure Settings, where it always loads "Adwaita", even if another style has been set previously. This also persists when setting a different default. The cause is that `self.custom_style.set_model(Gtk.StringList.new(styles_))` resets the current `custom_style` property as well, so the previously set custom style is overloaded by adwaita.

This PR fixes this issue.