### PR TITLE
Prevent view menu from stealing focus

### DIFF
--- a/data/ui/window.blp
+++ b/data/ui/window.blp
@@ -133,6 +133,7 @@ template $GraphsWindow : Adw.ApplicationWindow {
           tooltip-text: _("View Menu");
           always-show-arrow: true;
           menu-model: view_menu;
+          can-focus: false;
         }
         Separator {styles ["spacer"]}
       }

--- a/data/ui/window.blp
+++ b/data/ui/window.blp
@@ -618,6 +618,7 @@ template $GraphsWindow : Adw.ApplicationWindow {
 
       [content]
       Adw.ToastOverlay toast_overlay {
+        focusable: true;
         height-request: 200;
         width-request: 200;
       }

--- a/data/ui/window.blp
+++ b/data/ui/window.blp
@@ -133,7 +133,6 @@ template $GraphsWindow : Adw.ApplicationWindow {
           tooltip-text: _("View Menu");
           always-show-arrow: true;
           menu-model: view_menu;
-          can-focus: false;
         }
         Separator {styles ["spacer"]}
       }

--- a/src/actions.py
+++ b/src/actions.py
@@ -23,6 +23,7 @@ def change_scale(action, target, self, prop):
     self.get_figure_settings().set_property(prop, int(target.get_string()))
     utilities.optimize_limits(self)
     action.change_state(target)
+    self.get_window().toast_overlay.grab_focus()
 
 
 def quit_action(_action, _target, self):

--- a/src/actions.py
+++ b/src/actions.py
@@ -19,12 +19,6 @@ def set_mode(_action, _target, self, mode):
     self.set_mode(mode)
 
 
-def change_scale(action, target, self, prop):
-    self.get_figure_settings().set_property(prop, int(target.get_string()))
-    utilities.optimize_limits(self)
-    action.change_state(target)
-    self.get_window().toast_overlay.grab_focus()
-    
 def quit_action(_action, _target, self):
     self.quit()
 

--- a/src/main.py
+++ b/src/main.py
@@ -102,12 +102,10 @@ class GraphsApplication(Adw.Application):
                     str(settings.get_child("figure").get_enum(val)),
                 ),
             )
-            action.connect(
-                "activate",
-                lambda action_, target: figure_settings.set_property(
-                    action_.get_name()[7:], int(target.get_string()),
-                ),
-            )
+            action.connect("activate", lambda action_, target:
+                           (figure_settings.set_property(
+                            action_.get_name()[7:], int(target.get_string())),
+                            self.get_window().toast_overlay.grab_focus()))
             figure_settings.connect(
                 f"notify::{val}",
                 lambda _x, param, action_: action_.change_state(


### PR DESCRIPTION
See title. When scaling is changed through the view menu, the focus is changed to the view menu. Making it impossible to use shortcuts. This fixes this.