### PR TITLE
Change locator behaviour on custom axes scales

### DIFF
--- a/src/canvas.py
+++ b/src/canvas.py
@@ -16,7 +16,7 @@ from gi.repository import Adw, GObject, Gtk
 from graphs import artist, misc, scales, utilities
 from graphs.figure_settings import FigureSettingsWindow
 
-from matplotlib import backend_tools as tools, ticker, pyplot
+from matplotlib import backend_tools as tools, pyplot, ticker
 from matplotlib.backend_bases import NavigationToolbar2
 from matplotlib.backends.backend_gtk4cairo import FigureCanvas
 from matplotlib.widgets import SpanSelector

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -16,10 +16,12 @@ from gi.repository import Adw, GObject, Gtk
 from graphs import artist, misc, scales, utilities
 from graphs.figure_settings import FigureSettingsWindow
 
-from matplotlib import backend_tools as tools, pyplot
+from matplotlib import backend_tools as tools, ticker, pyplot
 from matplotlib.backend_bases import NavigationToolbar2
 from matplotlib.backends.backend_gtk4cairo import FigureCanvas
 from matplotlib.widgets import SpanSelector
+
+import numpy
 
 
 class Canvas(FigureCanvas):
@@ -113,6 +115,7 @@ class Canvas(FigureCanvas):
         self.get_application().get_data().bind_property(
             "items", self, "items", 2,
         )
+        self.update_locators()
 
     def get_application(self):
         """Get application property."""
@@ -249,6 +252,28 @@ class Canvas(FigureCanvas):
         if self.top_right_axis.get_legend() is not None:
             self.top_right_axis.get_legend().remove()
         self.queue_draw()
+
+    def update_locators(self):
+        for axis in self.axes:
+            for single_axis in [axis.xaxis, axis.yaxis]:
+                scale = single_axis.get_scale()
+                if scale in ["squareroot", "inverse"]:
+                    min_limit, max_limit = single_axis.get_view_interval()
+                    axis_range = max_limit - min_limit
+                    original_values = numpy.linspace(min_limit, max_limit, 8)
+                    original_values = original_values[original_values != 0]
+                    if scale == "squareroot":
+                        sqrt_values = original_values ** 2
+                    elif scale == "inverse":
+                        sqrt_values = 1 / original_values
+                    tick_range = max(sqrt_values) - min(sqrt_values)
+                    sqrt_values = sqrt_values * (axis_range / tick_range)
+
+                    single_axis.set_major_locator(
+                        ticker.FixedLocator(sqrt_values))
+                    single_axis.set_major_formatter(ticker.ScalarFormatter())
+                    single_axis.set_minor_locator(ticker.AutoLocator())
+                    single_axis.set_minor_formatter(ticker.NullFormatter())
 
     @GObject.Property(type=bool, default=True)
     def legend(self) -> bool:
@@ -487,11 +512,13 @@ class _DummyToolbar(NavigationToolbar2):
                 self.press_pan(event)
             elif event.name == "button_release_event":
                 self.release_pan(event)
+                self.canvas.update_locators()
         elif mode == 1:
             if event.name == "button_press_event":
                 self.press_zoom(event)
             elif event.name == "button_release_event":
                 self.release_zoom(event)
+                self.canvas.update_locators()
 
     # Overwritten function - do not change name
     def _update_cursor(self, event):

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -202,7 +202,7 @@ def optimize_limits(self):
         min_all, max_all = [], []
         for data in datalist:
             nonzero_data = list(filter(lambda x: (x != 0), data))
-            if scale == 1 and len(nonzero_data) > 0:
+            if (scale == 1 or scale == 4) and len(nonzero_data) > 0:
                 min_all.append(min(nonzero_data))
             else:
                 min_all.append(min(data))
@@ -226,6 +226,7 @@ def optimize_limits(self):
             max_all *= padding_factor
         self.get_figure_settings().set_property(f"min_{direction}", min_all)
         self.get_figure_settings().set_property(f"max_{direction}", max_all)
+    self.get_window().get_canvas().update_locators()
     self.get_view_clipboard().add()
 
 


### PR DESCRIPTION
Changes the behaviour of locators on custom axes scaling, also offers some slight tweaks on the Inverse scaled limits.

The main point is that the locators (ticks) are now distributed evenly for the square root and inverted axis, leading to less awkward scaling in certain cases. For example with tons of ticks extremely close to each other. 

I am not 100% sure if an even distribution is always completely what we want. But in many cases it leads to a more readable graph. Here's the screenshot with and without the even ticks. One option is to have it as a toggle in the style sheet. 
![Screenshot from 2023-08-31 20-22-10](https://github.com/Sjoerd1993/Graphs/assets/68477016/cea319f5-e1f4-46ed-b80c-78767eae10f7)
 
![Screenshot from 2023-08-31 20-23-47](https://github.com/Sjoerd1993/Graphs/assets/68477016/4d944953-7217-4c2a-81b3-e10da2f349d4)
