### PR TITLE
Use custom locator class

### DIFF
--- a/src/clipboard.py
+++ b/src/clipboard.py
@@ -36,7 +36,6 @@ class BaseClipboard(GObject.Object):
             self.props.clipboard_pos -= 1
             self.perform_undo()
             ui.set_clipboard_buttons(self.get_application())
-            self.get_application().get_window().get_canvas().update_locators()
 
     def redo(self):
         """
@@ -47,7 +46,6 @@ class BaseClipboard(GObject.Object):
             self.props.clipboard_pos += 1
             self.perform_redo()
             ui.set_clipboard_buttons(self.get_application())
-            self.get_application().get_window().get_canvas().update_locators()
 
     def clear(self):
         self.__init__(self.get_application())

--- a/src/scales.py
+++ b/src/scales.py
@@ -44,7 +44,9 @@ class SquareRootScale(scale.ScaleBase):
 
     def set_default_locators_and_formatters(self, axis):
         axis.set_major_locator(CustomScaleLocator())
-        axis.set_minor_locator(CustomScaleLocator(scale_type="minor"))
+        axis.set_minor_locator(CustomScaleLocator(is_minor=True))
+        axis.set_major_formatter(ticker.ScalarFormatter())
+        axis.set_minor_formatter(ticker.NullFormatter())
 
     def limit_range_for_scale(self, vmin, vmax, _minpos):
         return max(0, vmin), vmax
@@ -84,7 +86,9 @@ class InverseScale(scale.ScaleBase):
 
     def set_default_locators_and_formatters(self, axis):
         axis.set_major_locator(CustomScaleLocator())
-        axis.set_minor_locator(CustomScaleLocator(scale_type="minor"))
+        axis.set_minor_locator(CustomScaleLocator(is_minor=True))
+        axis.set_major_formatter(ticker.ScalarFormatter())
+        axis.set_minor_formatter(ticker.NullFormatter())
 
     def limit_range_for_scale(self, vmin, vmax, minpos):
         if not numpy.isfinite(minpos):
@@ -115,8 +119,8 @@ class InverseScale(scale.ScaleBase):
 
 class CustomScaleLocator(ticker.MaxNLocator):
     """Dynamically find tick positions on custom scales."""
-    def __init__(self, scale_type="major"):
-        self.scale_type = scale_type
+    def __init__(self, is_minor=False):
+        self.is_minor = is_minor
 
     @property
     def numticks(self):
@@ -126,21 +130,16 @@ class CustomScaleLocator(ticker.MaxNLocator):
             self._numticks = numpy.clip(numticks, 3, 9)
         else:
             self._numticks = 9
-        if self.scale_type == "minor":
+        if self.is_minor:
             # Amount of minor ticks is equal to amount of major ticks
             # times (N+1) minus N. Where N is the amount of minor ticks
             # in between the major ticks.
-            self.numticks = len(self.axis.get_majorticklocs()) * 4 - 3
+            self._numticks = len(self.axis.get_majorticklocs()) * 4 - 3
         return self._numticks
 
     @numticks.setter
     def numticks(self, numticks):
         self._numticks = numticks
-
-    def __call__(self):
-        """Return the locations of the ticks."""
-        vmin, vmax = self.axis.get_view_interval()
-        return self.tick_values(vmin, vmax)
 
     def tick_values(self, vmin, vmax):
         vmin, vmax = transforms.nonsingular(vmin, vmax, expander=0.05)

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -210,23 +210,21 @@ def optimize_limits(self):
         min_all = min(min_all)
         max_all = max(max_all)
         span = max_all - min_all
-        if scale != 1:
+        if scale != 1:  # For non-logarithmic scales
             # 0.05 padding on y-axis, 0.015 padding on x-axis
             padding_factor = 0.05 if count % 2 else 0.015
             max_all += padding_factor * span
 
-            # Don't add minimum padding for inverse scaling as that may lead
-            # to negative values
-            if scale != 4:
-                min_all -= padding_factor * span
-        elif scale == 1:
+            # For inverse scale, calculate padding using a factor
+            min_all = (min_all - padding_factor * span if scale != 4
+                       else min_all * 0.99)
+        elif scale == 1:  # Use different scaling type for logarithmic scale
             # Use padding factor of 2 for y-axis, 1.025 for x-axis
             padding_factor = 2 if count % 2 else 1.025
             min_all *= 1 / padding_factor
             max_all *= padding_factor
         self.get_figure_settings().set_property(f"min_{direction}", min_all)
         self.get_figure_settings().set_property(f"max_{direction}", max_all)
-    self.get_window().get_canvas().update_locators()
     self.get_view_clipboard().add()
 
 


### PR DESCRIPTION
Uses a custom locator class instead of calling a new fixed locator each time the axis is changed. Giving a much more stable and polished experience.

I was a bit unsure whether I should use a seperate class for the inverse and square root case, but it works well enough like this.