### PR TITLE
Fix label in equation window and surpress square root error

### DIFF
--- a/data/ui/add_equation_window.blp
+++ b/data/ui/add_equation_window.blp
@@ -48,10 +48,16 @@ template $AddEquationWindow : Adw.Window {
               title: _("Y =");
               styles ["preferencesgroup"]
             }
+            Label {
+              margin-top: 6;
+              halign: start;
+              hexpand: true;
+              label: _("Enter a mathematical expression to generate data from");
+              styles ["dim-label"]
+            }
           }
 
           Adw.PreferencesGroup {
-            description: _("Enter a mathematical expression to generate data from");
             Adw.EntryRow name {
               max-width-chars: 25;
               title: _("Name (optional)");

--- a/src/scales.py
+++ b/src/scales.py
@@ -58,7 +58,9 @@ class SquareRootScale(scale.ScaleBase):
         is_separable = True  # Seperable in X and Y dimension
 
         def transform_non_affine(self, a):
-            return numpy.array(a)**0.5
+            # Don't spam about invalid divide by zero errors
+            with numpy.errstate(divide="ignore", invalid="ignore"):
+                return numpy.array(a)**0.5
 
         def inverted(self):
             return SquareRootScale.InvertedSquareRootTransform()


### PR DESCRIPTION
Two minor fixes, that maybe should have been their own PR.

 - The label in "add equation" is in the current main branch closer to the "Name" section, while it belongs to the "Add equation" section. This puts the label closer to where it belongs
 - Suppress errors with invalid values on the square root scaling. This prevents it from spitting out errors when for instance dealing with negative values. (Again this is the same behaviour as [ProPlot](https://proplot.readthedocs.io/en/latest/_modules/proplot/scale.html#InverseScale.limit_range_for_scale) uses on their custom axes. Stumbled upon that library when trying to read up on custom locators. They've got a bunch of nice ideas to take inspiration from)