### PR TITLE
Update shortcuts to follow GNOME Circle

### DIFF
--- a/data/ui/help_overlay.blp
+++ b/data/ui/help_overlay.blp
@@ -17,17 +17,17 @@ ShortcutsWindow help_overlay {
 
       ShortcutsShortcut {
         title: C_("shortcut window", "Open Preferences");
-        accelerator: "<primary>p";
+        accelerator: "<primary>comma";
       }
 
       ShortcutsShortcut {
         title: C_("shortcut window", "Open Figure Settings");
-        accelerator: "<primary><shift>P";
+        accelerator: "<primary><alt>comma";
       }
 
       ShortcutsShortcut {
         title: C_("shortcut window", "Open Styles");
-        accelerator: "<primary><alt>P";
+        accelerator: "<primary><alt>period";
       }
 
       ShortcutsShortcut {
@@ -110,7 +110,7 @@ ShortcutsWindow help_overlay {
 
       ShortcutsShortcut {
         title: C_("shortcut window", "Optimize Limits");
-        accelerator: "<primary>L";
+        accelerator: "<primary>0";
       }
 
 

--- a/data/ui/window.blp
+++ b/data/ui/window.blp
@@ -10,11 +10,11 @@ template $GraphsWindow : Adw.ApplicationWindow {
       action: "action(app.quit)";
     }
     Shortcut {
-      trigger: "<primary>p";
+      trigger: "<primary>comma";
       action: "action(app.preferences)";
     }
     Shortcut {
-      trigger: "<primary><shift>P";
+      trigger: "<primary><alt>comma";
       action: "action(app.figure_settings)";
     }
     Shortcut {
@@ -42,7 +42,7 @@ template $GraphsWindow : Adw.ApplicationWindow {
       action: "action(app.redo)";
     }
     Shortcut {
-      trigger: "<primary>L";
+      trigger: "<primary>0";
       action: "action(app.optimize_limits)";
     }
     Shortcut {
@@ -62,7 +62,7 @@ template $GraphsWindow : Adw.ApplicationWindow {
       action: "action(app.export_figure)";
     }
     Shortcut {
-      trigger: "<primary><alt>P";
+      trigger: "<primary>period";
       action: "action(app.styles)";
     }
     Shortcut {


### PR DESCRIPTION
I was looking into the [GNOME Circle criteria](https://gitlab.gnome.org/Teams/Releng/AppOrganization/-/blob/main/AppCriteria.md), where it states that [standard keyboard](https://developer.gnome.org/hig/reference/keyboard.html) shortcuts should be followed to ensure consistency with other applications. The default for preferences is Ctrl+comma, so we should probably use that.

Unfortunately ctrl+shift+comma does not work, as that triggers a `ctrl+;` in my case (ctrl+shift trigger a semicolon). A workaround would be to bind it to `ctrl+;`, but the secondary key behind the comma differs depending on the keyboard layout. (I am not sure about every single layout, but dvorak has a `<` behind the comma). So for now I bound styles to `ctrl+.`.

I bound optimize limits to `ctrl+0` as to mimic the "Reset view" behaviour. The idea is to in the future add a shortcut for `ctrl++` and `ctrl+-` to zoom in from the keyboard.
