### PR TITLE
move application properties to vala and update build system

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -72,14 +72,19 @@ blueprints = custom_target('blueprints',
   command: [find_program('blueprint-compiler'), 'batch-compile', '@OUTPUT@', '@CURRENT_SOURCE_DIR@', '@INPUT@'],
 )
 
-resources = gnome.compile_resources(
-  application_id,
-  application_id + '.gresource.xml',
+gresource_name = application_id + '.gresource.xml'
+gresource_file = join_paths(meson.current_build_dir(), gresource_name)
+
+run_command('cp', gresource_name, gresource_file, check: true)
+
+gresource = gnome.compile_resources(
+  application_id, gresource_file,
     dependencies: blueprints,
 gresource_bundle: true,
       source_dir: meson.current_build_dir(),
          install: true,
      install_dir: pkgdatadir,
+          c_name: project_name,
 )
 
 scalable_dir = join_paths('icons', 'hicolor', 'scalable', 'apps')

--- a/src/application.vala
+++ b/src/application.vala
@@ -1,0 +1,20 @@
+using Adw;
+
+namespace Graphs {
+    public class Application : Adw.Application {
+        public Adw.ApplicationWindow window { get; set; }
+        public Settings settings { get; construct set; }
+        public FigureSettings figure_settings { get; construct set; }
+        public Data data { get; construct set; }
+        public Clipboard clipboard { get; construct set; }
+        public Clipboard view_clipboard { get; construct set; }
+        public int mode { get; set; default = 0; }
+
+        public string version { get; construct set; default = ""; }
+        public string name { get; construct set; default = ""; }
+        public string website { get; construct set; default = ""; }
+        public string issues { get; construct set; default = ""; }
+        public string author { get; construct set; default = ""; }
+        public string pkgdatadir { get; construct set; default = ""; }
+    }
+}

--- a/src/clipboard.py
+++ b/src/clipboard.py
@@ -1,13 +1,13 @@
 import copy
 
-from gi.repository import Adw, GObject
+from gi.repository import Adw, GObject, Graphs
 
 from graphs import item, ui
 
 import numpy
 
 
-class BaseClipboard(GObject.Object):
+class BaseClipboard(GObject.Object, Graphs.Clipboard):
     __gtype_name__ = "BaseClipboard"
 
     application = GObject.Property(type=Adw.Application)

--- a/src/clipboard.vala
+++ b/src/clipboard.vala
@@ -1,0 +1,4 @@
+namespace Graphs {
+    public interface Clipboard : Object {
+    }
+}

--- a/src/data.py
+++ b/src/data.py
@@ -7,12 +7,12 @@ Classes:
 """
 import copy
 
-from gi.repository import GObject
+from gi.repository import GObject, Graphs
 
 from graphs import item, utilities
 
 
-class Data(GObject.Object):
+class Data(GObject.Object, Graphs.Data):
     """
     Class for managing data.
 

--- a/src/data.vala
+++ b/src/data.vala
@@ -1,0 +1,4 @@
+namespace Graphs {
+    public interface Data : Object {
+    }
+}

--- a/src/figure_settings.vala
+++ b/src/figure_settings.vala
@@ -58,7 +58,9 @@ namespace Graphs {
             return limits;
         }
 
-        public void set_limits (double[] limits) {
+        public void set_limits (double[] limits)
+                requires (limits.length == 8)
+        {
             for (int i = 0; i < limit_names.length; i++) {
                 set (limit_names[i], limits[i]);
             }

--- a/src/file_io.py
+++ b/src/file_io.py
@@ -104,7 +104,7 @@ def import_from_xry(self, import_settings):
 
 def import_from_columns(self, import_settings):
     item_ = Item.new(self, name=import_settings.name)
-    columns_params = self.settings.get_child(
+    columns_params = self.get_settings().get_child(
         "import-params").get_child("columns")
     column_x = columns_params.get_int("column-x")
     column_y = columns_params.get_int("column-y")

--- a/src/main.py
+++ b/src/main.py
@@ -27,47 +27,13 @@ _ACTIONS = [
 ]
 
 
-class GraphsApplication(Adw.Application):
+class GraphsApplication(Graphs.Application):
     """
     The main application singleton class.
 
-    Properties:
-        settings
-        version: str
-        name: str
-        website: str
-        issues: str
-        author: str
-        pkgdatadir: str
-        data
-        figure_settings
-        clipboard
-        view_clipboard
-        mode: int (pan, zoom, select)
-
     Functions:
-        get_data
-        get_mode
-        set_mode
-        get_figure_settings
         get_settings
-        get_clipboard
-        get_view_clipboard
     """
-
-    settings = GObject.Property(type=Gio.Settings)
-    version = GObject.Property(type=str, default="")
-    name = GObject.Property(type=str, default="")
-    website = GObject.Property(type=str, default="")
-    issues = GObject.Property(type=str, default="")
-    author = GObject.Property(type=str, default="")
-    pkgdatadir = GObject.Property(type=str, default="")
-
-    data = GObject.Property(type=Data)
-    figure_settings = GObject.Property(type=Graphs.FigureSettings)
-    clipboard = GObject.Property(type=DataClipboard)
-    view_clipboard = GObject.Property(type=ViewClipboard)
-    mode = GObject.Property(type=int, default=0, minimum=0, maximum=2)
 
     def __init__(self, application_id, **kwargs):
         """Init the application."""
@@ -153,35 +119,17 @@ class GraphsApplication(Adw.Application):
         We raise the application"s main window, creating it if
         necessary.
         """
-        self._window = self.props.active_window
-        if not self._window:
-            self._window = GraphsWindow(self)
-            self._window.set_title(self.props.name)
+        window = self.props.active_window
+        if not window:
+            window = GraphsWindow(self)
+            self.set_window(window)
+            window.set_title(self.props.name)
             if "(Development)" in self.props.name:
-                self._window.add_css_class("devel")
-            self.props.clipboard = DataClipboard(self)
-            self.props.view_clipboard = ViewClipboard(self)
+                window.add_css_class("devel")
+            self.set_clipboard(DataClipboard(self))
+            self.set_view_clipboard(ViewClipboard(self))
             ui.set_clipboard_buttons(self)
-            self._window.present()
-
-    def get_window(self):
-        return self._window
-
-    def get_data(self):
-        """Get data property."""
-        return self.props.data
-
-    def get_mode(self):
-        """Get mode property."""
-        return self.props.mode
-
-    def set_mode(self, mode: int):
-        """Set mode property."""
-        self.props.mode = mode
-
-    def get_figure_settings(self) -> Graphs.FigureSettings:
-        """Get figure settings property."""
-        return self.props.figure_settings
+            window.present()
 
     def get_settings(self, child=None):
         """
@@ -191,11 +139,3 @@ class GraphsApplication(Adw.Application):
         """
         return self.props.settings if child is None \
             else self.props.settings.get_child(child)
-
-    def get_clipboard(self):
-        """Get clipboard property."""
-        return self.props.clipboard
-
-    def get_view_clipboard(self):
-        """Get view clipboard property."""
-        return self.props.view_clipboard

--- a/src/meson.build
+++ b/src/meson.build
@@ -8,42 +8,45 @@ configuration: conf,
   install_dir: bindir
 )
 
-python_sources = [
-  'actions.py',
-  'add_equation.py',
-  'artist.py',
-  'canvas.py',
-  'clipboard.py',
-  'data.py',
-  'edit_item.py',
-  'export_figure.py',
-  'figure_settings.py',
-  'file_import.py',
-  'file_io.py',
-  'item.py',
-  'item_box.py',
-  'main.py',
-  'migrate.py',
-  'misc.py',
-  'operations.py',
-  'preferences.py',
-  'project.py',
-  'scales.py',
-  'styles.py',
-  'transform_data.py',
-  'ui.py',
-  'utilities.py',
-  'window.py',
-]
+python.install_sources(
+  files(
+	  'actions.py',
+	  'add_equation.py',
+	  'artist.py',
+	  'canvas.py',
+	  'clipboard.py',
+	  'data.py',
+	  'edit_item.py',
+	  'export_figure.py',
+	  'figure_settings.py',
+	  'file_import.py',
+	  'file_io.py',
+	  'item.py',
+	  'item_box.py',
+	  'main.py',
+	  'migrate.py',
+	  'misc.py',
+	  'operations.py',
+	  'preferences.py',
+	  'project.py',
+	  'scales.py',
+	  'styles.py',
+	  'transform_data.py',
+	  'ui.py',
+	  'utilities.py',
+	  'window.py',
+  ),
+  subdir: project_name
+)
 
-python.install_sources(python_sources, subdir: project_name)
-
-vala_sources = [
-  'figure_settings.vala',
-  'misc.vala',
-]
-
-graphs_lib = shared_library('graphs', vala_sources,
+graphs_lib = shared_library(
+  'graphs', files(
+		'application.vala',
+		'clipboard.vala',
+		'data.vala',
+		'figure_settings.vala',
+		'misc.vala',
+  ), gresource,
       vala_gir: 'Graphs-1.gir',
   dependencies: dependencies,
        install: true,

--- a/src/ui.py
+++ b/src/ui.py
@@ -138,14 +138,14 @@ def build_dialog(name):
 
 def show_about_window(self):
     Adw.AboutWindow(
-        transient_for=self.get_window(), application_name=self.name,
-        application_icon=self.props.application_id, website=self.website,
-        developer_name=self.author, issue_url=self.issues,
-        version=self.version, developers=[
+        transient_for=self.get_window(), application_name=self.get_name(),
+        application_icon=self.get_application_id(), website=self.get_website(),
+        developer_name=self.get_author(), issue_url=self.get_issues(),
+        version=self.get_version(), developers=[
             "Sjoerd Stendahl <contact@sjoerd.se>",
             "Christoph Kohnen <christoph.kohnen@disroot.org>",
         ],
-        copyright=f"© 2022 – {datetime.date.today().year} {self.author}",
+        copyright=f"© 2022 – {datetime.date.today().year} {self.get_author()}",
         license_type="GTK_LICENSE_GPL_3_0",
         translator_credits=_("translator-credits"),
         release_notes=file_io.read_file(


### PR DESCRIPTION
It took me literally days to figure out, why the vala compiler wouldn't work with composite templates. The solution was that he was looking for .ui files in data/ui where only .blp files (not yet compiled) exist. The solution was to copy the gresource xml into the build directory, so the vala compiler would have access to the compiled ui files.

This includes exactly that plus moving the applications properties to vala. This also includes the proof of concept on how to handle implementations written in python inside vala code. We simply define interfaces in vala, with functions we like to access, and add them as inheritance to the python class. This way we'd have to change nothing on the python side while still being able to access functions in vala code.
Another solution, like the one being employed here is to simply define the class and all properties and even some logic in vala and simply let the currently existing python class inherit from that.