### PR TITLE
Fix item change implementation

### DIFF
--- a/src/data.py
+++ b/src/data.py
@@ -151,7 +151,7 @@ class Data(GObject.Object):
         else:
             items[index2:index1 + 1] = \
                 [self._items[key2]] + items[index2:index1]
-        self.set_items(items)
+        self.items = items
 
     def add_items(self, items: list):
         """


### PR DESCRIPTION
The reason for reverting to an item menu reload after changing items, is that the current behaviour is extremely buggy. See screencast:

[Screencast from 2023-09-08 10-12-01.webm](https://github.com/Sjoerd1993/Graphs/assets/68477016/7a4d10c1-0e59-4988-8ccc-a44cfe8aa90e)
