### PR TITLE
Fig migration

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -38,7 +38,7 @@ class GraphsApplication(Graphs.Application):
     def __init__(self, application_id, **kwargs):
         """Init the application."""
         settings = Gio.Settings(application_id)
-        migrate.migrate_config(self)
+        migrate.migrate_config(settings)
         figure_settings = \
             Graphs.FigureSettings.new(settings.get_child("figure"))
         super().__init__(

--- a/src/migrate.py
+++ b/src/migrate.py
@@ -48,11 +48,11 @@ def migrate_config(settings):
         _migrate_import_params(settings, import_file)
 
 
-def _migrate_config(settings, config_file):
+def _migrate_config(settings_, config_file):
     config = file_io.parse_json(config_file)
     for old_key, (category, key) in CONFIG_MIGRATION_TABLE.items():
         with contextlib.suppress(KeyError):
-            settings = settings.get_child(category)
+            settings = settings_.get_child(category)
             value = config[old_key]
             if "scale" in key:
                 value = value.capitalize()
@@ -65,9 +65,9 @@ def _migrate_config(settings, config_file):
     config_file.delete(None)
 
 
-def _migrate_import_params(settings, import_file):
+def _migrate_import_params(settings_, import_file):
     for mode, params in file_io.parse_json(import_file).items():
-        settings = settings.get_child("import-params").get_child(mode)
+        settings = settings_.get_child("import-params").get_child(mode)
         for key, value in params.items():
             if key == "separator":
                 settings.set_string(key, f"{value} ")


### PR DESCRIPTION
Fixes the migration. I was comparing some behaviours with the current stable branch, and when hopping back I got an error.

 There were two issues:
1 - The migration was given `self` as argument, instead of the settings
2 - When going through the categories, `settings` was getting overwritten, making it such that it cannot find the settings anymore after one loop.