### PR TITLE
Remove redundant imports

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -8,7 +8,7 @@ Classes:
 import logging
 from gettext import gettext as _
 
-from gi.repository import Adw, GLib, GObject, Gio, Graphs
+from gi.repository import GLib, Gio, Graphs
 
 from graphs import actions, migrate, ui
 from graphs.clipboard import DataClipboard, ViewClipboard


### PR DESCRIPTION
Very minor PR, but since migrating the last application class to Vala, the import of Adw and GObject has become redundant. Flake8 picked this up locally, didn't see anything failing here for some reason though. 