### PR TITLE
Complete transition from key to uuid

### DIFF
--- a/src/clipboard.py
+++ b/src/clipboard.py
@@ -148,7 +148,7 @@ class DataClipboard(BaseClipboard):
                 data.change_position(data.get_keys()[change[0]], item_.uuid)
                 items_changed = True
             elif change_type == 3:
-                data.change_position(data[change[0]].key, data[change[1]].key)
+                data.change_position(data[change[0]].uuid, data[change[1]].uuid)
                 items_changed = True
         if items_changed:
             data.notify("items")
@@ -171,7 +171,7 @@ class DataClipboard(BaseClipboard):
                 data.pop(change[1]["key"])
                 items_changed = True
             elif change_type == 3:
-                data.change_position(data[change[1]].key, data[change[0]].key)
+                data.change_position(data[change[1]].uuid, data[change[0]].uuid)
                 items_changed = True
         if items_changed:
             data.notify("items")

--- a/src/clipboard.py
+++ b/src/clipboard.py
@@ -148,7 +148,8 @@ class DataClipboard(BaseClipboard):
                 data.change_position(data.get_keys()[change[0]], item_.uuid)
                 items_changed = True
             elif change_type == 3:
-                data.change_position(data[change[0]].uuid, data[change[1]].uuid)
+                data.change_position(data[change[0]].uuid,
+                                     data[change[1]].uuid)
                 items_changed = True
         if items_changed:
             data.notify("items")
@@ -171,7 +172,8 @@ class DataClipboard(BaseClipboard):
                 data.pop(change[1]["key"])
                 items_changed = True
             elif change_type == 3:
-                data.change_position(data[change[1]].uuid, data[change[0]].uuid)
+                data.change_position(data[change[1]].uuid,
+                                     data[change[0]].uuid)
                 items_changed = True
         if items_changed:
             data.notify("items")

--- a/src/edit_item.py
+++ b/src/edit_item.py
@@ -5,7 +5,7 @@ from graphs import ui
 from graphs.item import ItemBase
 
 _IGNORELIST = [
-    "alpha", "color", "item_type", "key", "selected", "xdata", "xlabel",
+    "alpha", "color", "item_type", "uuid", "selected", "xdata", "xlabel",
     "ydata", "ylabel",
 ]
 

--- a/src/item_box.py
+++ b/src/item_box.py
@@ -35,7 +35,7 @@ class ItemBox(Gtk.Box):
         self.drag_source.set_actions(Gdk.DragAction.COPY)
         self.drag_source.connect("prepare", self.on_dnd_prepare)
         self.drop_source = Gtk.DropTarget.new(str, Gdk.DragAction.COPY)
-        self.drop_source.key = item.uuid
+        self.drop_source.uuid = item.uuid
         self.drop_source.connect("drop", self.on_dnd_drop)
 
         self.item.connect("notify::color", self.on_color_change)
@@ -67,7 +67,7 @@ class ItemBox(Gtk.Box):
         # Handle the dropped data here
         data = self.get_application().get_data()
         before_index = data.index(value)
-        data.change_position(drop_target.key, value)
+        data.change_position(drop_target.uuid, value)
         clipboard = self.get_application().get_clipboard()
         clipboard.append((3, (before_index, data.index(value))))
         clipboard.add()


### PR DESCRIPTION
I noticed a warning that the uuid cannot be set when going into the item edit window. So I went through the code to check where key was still used instead of the uuid attribute, and found a few instances.

The reason for the warning by the way was because the IGNORELIST when binding the values to the objects in the window, still contained key instead of the uuid. But this PR includes a few other places as well where key was still used.