### PR TITLE
remove get_next_color()

### DIFF
--- a/src/ui.py
+++ b/src/ui.py
@@ -10,6 +10,8 @@ from graphs import file_import, file_io, project, styles, utilities
 from graphs.canvas import Canvas
 from graphs.item_box import ItemBox
 
+from matplotlib import pyplot
+
 
 def on_figure_style_change(_a, _b, self):
     if not self.get_settings(
@@ -17,11 +19,16 @@ def on_figure_style_change(_a, _b, self):
         reload_canvas(self)
         return
     styles.update(self)
+    color_cycle = pyplot.rcParams["axes.prop_cycle"].by_key()["color"]
     for item in self.get_data():
         item.reset()
+    count = 0
     for item in self.get_data():
         if item.props.item_type == "Item":
-            item.color = utilities.get_next_color(self.get_data().get_items())
+            if count > len(color_cycle):
+                count = 0
+            item.props.color = color_cycle[count]
+            count += 1
     reload_canvas(self)
 
 

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -6,8 +6,6 @@ from gettext import gettext as _
 
 from gi.repository import GLib, Gdk, Gio, Gtk
 
-from matplotlib import pyplot
-
 import numpy
 
 
@@ -243,21 +241,3 @@ def optimize_limits(self):
         figure_settings.set_property(f"min_{direction}", min_all)
         figure_settings.set_property(f"max_{direction}", max_all)
     self.get_view_clipboard().add()
-
-
-def get_next_color(items):
-    """Get the color that is to be used for the next data set"""
-    color_cycle = pyplot.rcParams["axes.prop_cycle"].by_key()["color"]
-    used_colors = []
-    for item in items:
-        used_colors.append(item.color)
-        # If we've got all colors once, remove those from used_colors so we
-        # can loop around
-        if set(used_colors) == set(color_cycle):
-            for color in color_cycle:
-                used_colors.remove(color)
-
-    for color in color_cycle:
-        if color not in used_colors:
-            return color
-    return "000000"


### PR DESCRIPTION
Remove get_next_color() from utilities. When adding a number of items, this used to loop quite often. Also during reset. This changes that to use the already existing loop structures