### PR TITLE
Fix decimal seperator formatting

### DIFF
--- a/data/ui/import.blp
+++ b/data/ui/import.blp
@@ -59,7 +59,7 @@ template $GraphsImportWindow : Adw.Window {
           Adw.ComboRow columns_separator {
             title: _("Decimal Separator");
             model: StringList{
-              strings [",", "."]
+              strings [_("Decimal comma (,)"), _("Decimal point (.)")]
             };
           }
 


### PR DESCRIPTION
This was quicker than I anticipated, as they were already converted to enums during migration to gschema settings. 

![image](https://github.com/Sjoerd1993/Graphs/assets/68477016/f44f1a45-f8f9-4ad5-ba3c-14e28cdc1cf7)


Fixes #487 