### PR TITLE
Fix figure settings style change

### DIFF
--- a/data/ui/figure_settings.blp
+++ b/data/ui/figure_settings.blp
@@ -172,7 +172,6 @@ template $GraphsFigureSettingsWindow : Adw.PreferencesWindow {
         show-enable-switch: true;
         Adw.ComboRow custom_style {
           title: _("Style");
-          notify::selected => $on_custom_style_select();
         }
       }
     }

--- a/src/figure_settings.py
+++ b/src/figure_settings.py
@@ -58,7 +58,8 @@ class FigureSettingsWindow(Adw.PreferencesWindow):
             self.props.figure_settings.get_custom_style())
         self.custom_style.set_model(Gtk.StringList.new(styles_))
         self.custom_style.set_selected(style_index)
-
+        self.custom_style.connect(
+            "notify::selected", self.on_custom_style_select)
         self.set_axes_entries()
         self.no_data_message.set_visible(
             self.get_application().get_data().is_empty(),
@@ -95,7 +96,6 @@ class FigureSettingsWindow(Adw.PreferencesWindow):
         self.get_application().get_data().add_view_history_state()
         self.destroy()
 
-    @Gtk.Template.Callback()
     def on_custom_style_select(self, comborow, _ignored):
         selected_style = comborow.get_selected_item().get_string()
         if selected_style != self.props.figure_settings.get_custom_style():


### PR DESCRIPTION
In the current main branch there's the following bug: 

When a custom style is chosen, and the lines don't have the same color as default, and then figure settings is opened, then the colors are over-ridden by the default values of the chosen stylesheet. The reason for this, is that when the dropdown menu is created in the code, the selected index is by default 0 (adwaita). Then when the correct index of the current stylesheet is set in the next line, the code recognizes that as a changed style. So the line properties are taken from that new stylesheet. (So same bug will be there for non-default line widths etc..)

Of course the lines shouldn't all revert to default values when just opening the figure settings. This issue can be mitigated by simply connecting this signal *after* setting the correct index in the dropdown menu. Which is what this PR does.