### PR TITLE
Set Yaru theme for snap package

### DIFF
--- a/data/se.sjoerd.Graphs.gschema.xml
+++ b/data/se.sjoerd.Graphs.gschema.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist gettext-domain="graphs">
-  <enum id="se.sjoerd.Graphs.system-styles">
-    <value nick="adwaita" value="0"/>
-    <value nick="seaborn" value="1"/>
-    <value nick="yaru" value="2"/>
-  </enum>
-
   <enum id="se.sjoerd.Graphs.general.center-values">
     <value nick="Center at maximum Y value" value="0"/>
     <value nick="Center at middle coordinate" value="1"/>
@@ -74,10 +68,6 @@
     <child name="export-figure" schema="se.sjoerd.Graphs.export-figure"/>
     <child name="figure" schema="se.sjoerd.Graphs.figure"/>
     <child name="import-params" schema="se.sjoerd.Graphs.import-params"/>
-
-    <key name="system-style" enum="se.sjoerd.Graphs.system-styles">
-      <default>"adwaita"</default>
-    </key>
   </schema>
 
   <schema id="se.sjoerd.Graphs.general">

--- a/src/application.py
+++ b/src/application.py
@@ -6,9 +6,11 @@ Classes:
     GraphsApplication
 """
 import logging
+import os
+
 from gettext import gettext as _
 
-from gi.repository import GLib, Gio, Graphs
+from gi.repository import GLib, Gio, Graphs, Gtk
 
 from graphs import actions, migrate, ui
 from graphs.data import Data
@@ -102,6 +104,13 @@ class PythonApplication(Graphs.Application):
         operation_action.connect("activate", actions.perform_operation, self)
         self.add_action(operation_action)
 
+        if "SNAP" in os.environ:
+            current_theme = \
+                Gtk.Settings.get_default().get_property("gtk-theme-name")
+            if current_theme.lower().startswith("yaru"):
+                self.get_settings().set_string("system-style", "yaru")
+            else:
+                self.get_settings().set_string("system-style", "adwaita")
         self.get_style_manager().connect(
             "notify", ui.on_figure_style_change, self,
         )

--- a/src/application.py
+++ b/src/application.py
@@ -6,11 +6,10 @@ Classes:
     GraphsApplication
 """
 import logging
-import os
 
 from gettext import gettext as _
 
-from gi.repository import GLib, Gio, Graphs, Gtk
+from gi.repository import GLib, Gio, Graphs
 
 from graphs import actions, migrate, ui
 from graphs.data import Data
@@ -104,13 +103,6 @@ class PythonApplication(Graphs.Application):
         operation_action.connect("activate", actions.perform_operation, self)
         self.add_action(operation_action)
 
-        if "SNAP" in os.environ:
-            current_theme = \
-                Gtk.Settings.get_default().get_property("gtk-theme-name")
-            if current_theme.lower().startswith("yaru"):
-                self.get_settings().set_string("system-style", "yaru")
-            else:
-                self.get_settings().set_string("system-style", "adwaita")
         self.get_style_manager().connect(
             "notify", ui.on_figure_style_change, self,
         )

--- a/src/styles.py
+++ b/src/styles.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 import contextlib
+import os
 from gettext import gettext as _
 from pathlib import Path
 
@@ -82,7 +83,14 @@ def get_style(file):
 
 
 def update(self):
-    system_stylename = self.get_settings().get_string("system-style")
+    if "SNAP" in os.environ:
+        current_theme = \
+            Gtk.Settings.get_default().get_property("gtk-theme-name")
+        if current_theme.lower().startswith("yaru"):
+            system_stylename = "yaru"
+    else:
+        system_stylename = "adwaita"
+
     if Adw.StyleManager.get_default().get_dark():
         system_stylename += "-dark"
     figure_settings = self.get_data().get_figure_settings()


### PR DESCRIPTION
Sets the Yaru system theme for the Snap package. Feel free with suggestions for other implementations. The logic here is that both the Snap and the Flatpak set some fingerprints in the environment variables (most noticable SNAP for the Snap package, the Flatpak can be identified  by the presence of FLATPAK_ID). 

Then for the Snap package, where the system theme is applied instead of libadwaita it checks what the current Gtk theme is. If this is set to anything that starts with Yaru (so also the Yaru variants), then Yaru is set as the preferred system theme. Otherwise it revers to adwaita, our preferred theme we target for. The reasoning for that second line where it reverts to adwaita, is that the settings are saved. So if the yaru theme is set in the Snap, and you then switch themes back to Adwaita, it would still keep the Yaru theming without that else statement.

Open to suggestions for different kind of implementations for this. 