### PR TITLE
Rework style logic

### DIFF
--- a/data/ui/style_window.blp
+++ b/data/ui/style_window.blp
@@ -26,12 +26,6 @@ template $GraphsStylesWindow : Adw.Window {
             tooltip-text: _("Add new style");
             clicked => $add_style();
           }
-          [end]
-          Button {
-            icon-name: "history-undo-symbolic";
-            tooltip-text: _("Reset to default styles");
-            clicked => $reset_styles();
-          }
           styles ["flat"]
         }
         ScrolledWindow {

--- a/src/data.py
+++ b/src/data.py
@@ -9,7 +9,7 @@ import copy
 
 from gi.repository import GObject, Graphs
 
-from graphs import item
+from graphs import item, utilities
 
 from matplotlib import pyplot
 
@@ -189,13 +189,9 @@ class Data(GObject.Object, Graphs.DataInterface):
             names = self.get_names()
             if new_item.get_name() in names:
                 if handle_duplicates == 0:  # Auto-add
-                    i = 1
-                    while True:
-                        new_name = f"{new_item.get_name()} ({i})"
-                        if new_name not in names:
-                            break
-                        i += 1
-                    new_item.set_name(new_name)
+                    new_item.set_name(utilities.get_duplicate_string(
+                        new_item.get_name(), names,
+                    ))
                 elif handle_duplicates == 1:  # Ignore
                     ignored.append(new_item.get_name())
                     continue

--- a/src/figure_settings.py
+++ b/src/figure_settings.py
@@ -53,7 +53,7 @@ class FigureSettingsWindow(Adw.PreferencesWindow):
         ui.bind_values_to_object(
             self.props.figure_settings, self, ignorelist=ignorelist,
         )
-        styles_ = sorted(styles.get_user_styles(application).keys())
+        styles_ = styles.get_available_stylenames()
         style_index = styles_.index(
             self.props.figure_settings.get_custom_style())
         self.custom_style.set_model(Gtk.StringList.new(styles_))

--- a/src/styles.py
+++ b/src/styles.py
@@ -78,8 +78,7 @@ def get_style(file):
 
 def update(self):
     # Check for Ubuntu
-    current_theme = \
-        Gtk.Settings.get_default().get_property("gtk-theme-name")
+    current_theme = Gtk.Settings.get_default().get_property("gtk-theme-name")
     system_style = "yaru" if "SNAP" in os.environ \
         and current_theme.lower().startswith("yaru") else "adwaita"
     if Adw.StyleManager.get_default().get_dark():

--- a/src/styles.py
+++ b/src/styles.py
@@ -12,11 +12,8 @@ from graphs import file_io, ui, utilities
 from matplotlib import pyplot
 
 
-def get_user_styles(self):
-    config_dir = utilities.get_config_directory()
-    directory = config_dir.get_child_for_display_name("styles")
-    if not directory.query_exists(None):
-        directory.make_directory_with_parents(None)
+def get_system_styles():
+    directory = Gio.File.new_for_uri("resource:///se/sjoerd/Graphs/styles")
     styles = {}
     enumerator = directory.enumerate_children("default::*", 0, None)
     while 1:
@@ -29,47 +26,77 @@ def get_user_styles(self):
     return styles
 
 
+def get_user_styles():
+    config_dir = utilities.get_config_directory()
+    directory = config_dir.get_child_for_display_name("styles")
+    if not directory.query_exists(None):
+        directory.make_directory_with_parents(None)
+    system_stylenames = get_system_styles().keys()
+    styles = {}
+    enumerator = directory.enumerate_children("default::*", 0, None)
+    while 1:
+        file_info = enumerator.next_file(None)
+        if file_info is None:
+            break
+        file = enumerator.get_child(file_info)
+        stylename = Path(utilities.get_filename(file)).stem
+        if stylename in system_stylenames:
+            stylename = utilities.get_duplicate_string(
+                stylename, system_stylenames,
+            )
+            filename = f"{stylename}.mplstyle"
+            file.set_display_name(filename, None)
+            file = directory.get_child_for_display_name(filename)
+        styles[stylename] = file
+    enumerator.close(None)
+    return styles
+
+
+def get_available_stylenames():
+    return sorted(
+        list(get_user_styles().keys()) + list(get_system_styles().keys()),
+    )
+
+
 def get_style(file):
     """
     Get the style based on the file.
 
     Returns a dictionary that has always valid keys. This is ensured through
-    checking against the styles base (if available) and copying missing params
-    as needed.
+    checking against adwaita and copying missing params as needed.
     """
     style = file_io.parse_style(file)
-    file = Gio.File.new_for_uri(
-        f"resource:///se/sjoerd/Graphs/styles/{style.name}.mplstyle",
+    adwaita = Gio.File.new_for_uri(
+        "resource:///se/sjoerd/Graphs/styles/adwaita.mplstyle",
     )
-    if not file.query_exists():
-        file = Gio.File.new_for_uri(
-            "resource:///se/sjoerd/Graphs/styles/adwaita.mplstyle",
-        )
-    for key, value in file_io.parse_style(file).items():
+    for key, value in file_io.parse_style(adwaita).items():
         if key not in style:
             style[key] = value
     return style
 
 
 def update(self):
-    system_stylename = self.get_settings().get_string("system-style")
+    system_style = self.get_settings().get_string("system-style")
     if Adw.StyleManager.get_default().get_dark():
-        system_stylename += "-dark"
+        system_style += "-dark"
     figure_settings = self.get_data().get_figure_settings()
+    user_styles = get_user_styles()
+    system_styles = get_system_styles()
+    file = system_styles[system_style]
     if figure_settings.get_use_custom_style():
         stylename = figure_settings.get_custom_style()
-        try:
-            pyplot.rcParams.update(get_style(get_user_styles(self)[stylename]))
+        if stylename in system_styles:
+            file = system_styles[stylename]
+        elif stylename in user_styles:
+            pyplot.rcParams.update(get_style(user_styles[stylename]))
             return
-        except KeyError:
+        else:
             self.get_window().add_toast_string(
                 _(f"Plot style {stylename} does not exist "
                   "loading system preferred"))
-            figure_settings.set_custom_style(system_stylename)
+            figure_settings.set_custom_style(system_style)
             figure_settings.set_use_custom_style(False)
-    pyplot.rcParams.update(file_io.parse_style(Gio.File.new_for_uri(
-        f"resource:///se/sjoerd/Graphs/styles/{system_stylename}.mplstyle",
-    )))
+    pyplot.rcParams.update(file_io.parse_style(file))
 
 
 STYLE_DICT = {
@@ -267,8 +294,7 @@ class StylesWindow(Adw.Window):
         for box in self.styles.copy():
             self.styles.remove(box)
             self.styles_box.remove(self.styles_box.get_row_at_index(0))
-        for style, file in \
-                sorted(get_user_styles(self.get_application()).items()):
+        for style, file in sorted(get_user_styles().items()):
             box = StyleBox(self, style, file)
             figure_settings = \
                 self.get_application().get_data().get_figure_settings()
@@ -375,35 +401,33 @@ class AddStyleWindow(Adw.Window):
     def __init__(self, application, parent):
         super().__init__(application=application,
                          transient_for=parent)
-        self.styles = get_user_styles(parent)
         self.style_templates.set_model(Gtk.StringList.new(
-            sorted(self.styles.keys()),
+            get_available_stylenames(),
         ))
         self.present()
 
     @Gtk.Template.Callback()
     def on_template_changed(self, _a, _b):
-        self.new_style_name.set_text(_("{name} (copy)").format(
-            name=self.style_templates.get_selected_item().get_string(),
+        self.new_style_name.set_text(utilities.get_duplicate_string(
+            self.style_templates.get_selected_item().get_string(),
+            get_available_stylenames(),
         ))
 
     @Gtk.Template.Callback()
     def on_accept(self, _button):
-        new_style = self.new_style_name.get_text()
-        i = 0
-        for style_1 in self.styles.keys():
-            if new_style == style_1:
-                while True:
-                    i += 1
-                    if f"{new_style} ({i})" not in self.styles.keys():
-                        new_style = f"{new_style} ({i})"
-                        break
+        user_styles = get_user_styles()
+        system_styles = get_system_styles()
+        new_stylename = utilities.get_duplicate_string(
+            self.new_style_name.get_text(),
+            list(user_styles.keys()) + list(system_styles.keys()),
+        )
         config_dir = utilities.get_config_directory()
         directory = config_dir.get_child_for_display_name("styles")
         destination = directory.get_child_for_display_name(
-            f"{new_style}.mplstyle")
-        self.styles[
-            self.style_templates.get_selected_item().get_string()
-        ].copy(destination, 0, None)
+            f"{new_stylename}.mplstyle")
+        template = self.style_templates.get_selected_item().get_string()
+        source = user_styles[template] if template in user_styles \
+            else system_styles[template]
+        source.copy(destination, 0, None)
         self.get_transient_for().reload_styles()
         self.close()

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -226,6 +226,9 @@ def string_to_function(equation_name):
 def get_duplicate_string(original_string: str, used_strings) -> str:
     if original_string not in used_strings:
         return original_string
+    m = re.compile(r"(?P<string>.+) \(\d+\)").match(original_string)
+    if m:
+        original_string = m.group("string")
     i = 1
     while True:
         new_string = f"{original_string} ({i})"

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -221,3 +221,12 @@ def string_to_function(equation_name):
             equation_name, locals=dict(zip(variables, sym_vars)),
         )
         return sympy.lambdify(sym_vars, symbolic)
+
+
+def get_duplicate_string(original_string: str, used_strings) -> str:
+    i = 1
+    while True:
+        new_string = f"{original_string} ({i})"
+        if new_string not in used_strings:
+            return new_string
+        i += 1

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -224,6 +224,8 @@ def string_to_function(equation_name):
 
 
 def get_duplicate_string(original_string: str, used_strings) -> str:
+    if original_string not in used_strings:
+        return original_string
     i = 1
     while True:
         new_string = f"{original_string} ({i})"


### PR DESCRIPTION
Styles are now in two groups: user styles and system styles. For the user this is mostly transparent. In Figure settings one can always choose any style to be used. In the styles window however just user styles can be added.

This also splits off duplicated logic for appending " (n)" at strings to be added as well as improving this functionality so that e. g. "adwaita (1)" becomes "adwaita (2)" instead of "adwaita (1) (1)"

Migration (deletion) for user styles, that are identical to the system ones will be another pr, but can be included here if required.