### PR TITLE
Fix yaru theme

### DIFF
--- a/src/application.py
+++ b/src/application.py
@@ -9,7 +9,7 @@ import logging
 
 from gettext import gettext as _
 
-from gi.repository import GLib, Gio, Graphs
+from gi.repository import GLib, Gio, Graphs, Gtk
 
 from graphs import actions, migrate, ui
 from graphs.data import Data
@@ -38,11 +38,13 @@ class PythonApplication(Graphs.Application):
     def __init__(self, application_id, **kwargs):
         """Init the application."""
         settings = Gio.Settings(application_id)
+        gtk_theme = Gtk.Settings.get_default().get_property("gtk-theme-name")
         migrate.migrate_config(settings)
         super().__init__(
             application_id=application_id, settings=settings,
             flags=Gio.ApplicationFlags.DEFAULT_FLAGS,
             data=Data(self, settings),
+            gtk_theme=gtk_theme,
             **kwargs,
         )
         font_list = font_manager.findSystemFonts(fontpaths=None, fontext="ttf")
@@ -58,7 +60,6 @@ class PythonApplication(Graphs.Application):
                 "activate", getattr(actions, f"{name}_action"), self,
             )
             self.add_action(action)
-
         figure_settings = self.get_data().get_figure_settings()
         for val in ["left-scale", "right-scale", "top-scale", "bottom-scale"]:
             action = Gio.SimpleAction.new_stateful(

--- a/src/application.vala
+++ b/src/application.vala
@@ -13,5 +13,6 @@ namespace Graphs {
         public string issues { get; construct set; default = ""; }
         public string author { get; construct set; default = ""; }
         public string pkgdatadir { get; construct set; default = ""; }
+        public string gtk_theme { get; construct set; default = "adwaita"; }
     }
 }

--- a/src/styles.py
+++ b/src/styles.py
@@ -83,13 +83,10 @@ def get_style(file):
 
 
 def update(self):
-    if "SNAP" in os.environ:
-        current_theme = \
-            Gtk.Settings.get_default().get_property("gtk-theme-name")
-        if current_theme.lower().startswith("yaru"):
+    system_stylename = "adwaita"
+    if "SNAP" not in os.environ:
+        if self.get_gtk_theme().lower().startswith("yaru"):
             system_stylename = "yaru"
-    else:
-        system_stylename = "adwaita"
 
     if Adw.StyleManager.get_default().get_dark():
         system_stylename += "-dark"


### PR DESCRIPTION
After trying out the Snap package, I found two errors:
- When the Snap package is ran (which I found is detected correctly, so that's good), and Yaru is not set as theme, `system_stylename` was never declared. This PR fixes this by setting adwaita first as default, and then overriding this for the Snap package in case Yaru is set as the theme
- For some reason, when getting the system theme from the update method in `styles.py`, it always returns `Adwaita-empty`. Not the actual theme. This is fixed by setting the theme upon init as property of the application. Ideally, I'd like it to run a `Gtk.Settings.get_default().get_property("gtk-theme-name")` when getting this attribute. But I haven't succeeded in getting this to work from the Vala class. Either way when I try to import Gtk there, it complains about Settings being ambigious between Glib.settings and Gtk.Settings for some reason. I could just set such function in the main application, but that felt less clean than using the Vala class here, and it would probably return Adwaita-empty anyway. 

Either way, the solution in this PR works. It's just that when having Graphs open, and then setting another theme in GNOME tweaks, that it doesn't immediately adapt until restarting the application. Which is a relatively minor issue. But I'm open for suggestions to run a query for the Gtk theme in the Vala class directly.