### PR TITLE
Refactor style logic

### DIFF
--- a/src/application.vala
+++ b/src/application.vala
@@ -6,6 +6,7 @@ namespace Graphs {
         public Window window { get; set; }
         public Settings settings { get; construct set; }
         public DataInterface data { get; construct set; }
+        public StyleManagerInterface figure_style_manager { get; set; }
         public int mode { get; set; default = 0; }
         public string version { get; construct set; default = ""; }
         public string name { get; construct set; default = ""; }
@@ -13,6 +14,5 @@ namespace Graphs {
         public string issues { get; construct set; default = ""; }
         public string author { get; construct set; default = ""; }
         public string pkgdatadir { get; construct set; default = ""; }
-        public string gtk_theme { get; construct set; default = "adwaita"; }
     }
 }

--- a/src/figure_settings.py
+++ b/src/figure_settings.py
@@ -4,7 +4,7 @@ from gettext import gettext as _
 
 from gi.repository import Adw, GObject, Graphs, Gtk
 
-from graphs import misc, styles, ui, utilities
+from graphs import misc, ui, utilities
 
 _DIRECTIONS = ["bottom", "left", "top", "right"]
 
@@ -53,7 +53,8 @@ class FigureSettingsWindow(Adw.PreferencesWindow):
         ui.bind_values_to_object(
             self.props.figure_settings, self, ignorelist=ignorelist,
         )
-        styles_ = styles.get_available_stylenames()
+        styles_ = \
+            application.get_figure_style_manager().get_available_stylenames()
         style_index = styles_.index(
             self.props.figure_settings.get_custom_style())
         self.custom_style.set_model(Gtk.StringList.new(styles_))

--- a/src/interfaces.vala
+++ b/src/interfaces.vala
@@ -33,4 +33,7 @@ namespace Graphs {
         public abstract bool highlight_enabled { get; set; default = false; }
         public abstract Application application { get; construct set; }
     }
+
+    public interface StyleManagerInterface : Object {
+    }
 }

--- a/src/migrate.py
+++ b/src/migrate.py
@@ -2,10 +2,11 @@
 import contextlib
 import pickle
 import sys
+from pathlib import Path
 
 from gi.repository import GLib, Gio
 
-from graphs import file_io, misc, styles, utilities
+from graphs import file_io, misc, utilities
 
 
 CONFIG_MIGRATION_TABLE = {
@@ -90,9 +91,19 @@ def _migrate_styles(old_styles_dir, new_config_dir):
     new_styles_dir = new_config_dir.get_child_for_display_name("styles")
     if not new_styles_dir.query_exists(None):
         new_styles_dir.make_directory_with_parents()
-    system_styles = styles.get_system_styles()
+    system_styles = []
+    directory = Gio.File.new_for_uri("resource:///se/sjoerd/Graphs/styles")
+    enumerator = directory.enumerate_children("default::*", 0, None)
+    while True:
+        file_info = enumerator.next_file(None)
+        if file_info is None:
+            break
+        system_styles.append(
+            Path(utilities.get_filename(enumerator.get_child(file_info)).stem),
+        )
+    enumerator.close(None)
     enumerator = old_styles_dir.enumerate_children("default::*", 0, None)
-    while 1:
+    while True:
         file_info = enumerator.next_file(None)
         if file_info is None:
             break

--- a/src/ui.py
+++ b/src/ui.py
@@ -6,30 +6,8 @@ from gettext import gettext as _
 
 from gi.repository import Adw, GLib, Gio, Gtk
 
-from graphs import file_import, file_io, migrate, styles, utilities
-from graphs.canvas import Canvas
+from graphs import file_import, file_io, migrate, utilities
 from graphs.item_box import ItemBox
-
-from matplotlib import pyplot
-
-
-def on_figure_style_change(_a, _b, self):
-    if not self.get_settings(
-            "general").get_boolean("override-item-properties"):
-        reload_canvas(self)
-        return
-    styles.update(self)
-    color_cycle = pyplot.rcParams["axes.prop_cycle"].by_key()["color"]
-    for item in self.get_data():
-        item.reset()
-    count = 0
-    for item in self.get_data():
-        if item.__gtype_name__ == "GraphsDataItem":
-            if count > len(color_cycle):
-                count = 0
-            item.props.color = color_cycle[count]
-            count += 1
-    reload_canvas(self)
 
 
 def on_items_change(data, _ignored, self):
@@ -272,20 +250,3 @@ def bind_values_to_object(source, window, ignorelist=None):
         except AttributeError:
             logging.warn(_("No way to apply “{}”").format(key))
     return bindings
-
-
-def reload_canvas(self):
-    """Reloads the canvas of the main window"""
-    styles.update(self)
-    canvas = Canvas(self)
-    data = self.get_data()
-    figure_settings = data.get_figure_settings()
-    for prop in dir(figure_settings.props):
-        if prop not in ["use_custom_style", "custom_style"]:
-            figure_settings.bind_property(prop, canvas, prop, 1 | 2)
-    data.bind_property("items", canvas, "items", 2)
-    win = self.get_window()
-    win.set_canvas(canvas)
-    win.get_cut_button().bind_property(
-        "sensitive", canvas, "highlight_enabled", 2,
-    )


### PR DESCRIPTION
Styles are now managed using a StyleManager helper class. This keeps track of any changes that might happen which would require styles to be updated and inherently the canvas to be reloaded. Also instead of iterating over the styles directory every time a list of styles is requested (which can happen quite often and sometimes get_system_styles gets called twice to check if the file is correctly named), a reference is kept, which automatically updates when something in said directory updates.

This is also a stepping stone for some ideas suggested in https://github.com/Sjoerd1993/Graphs/issues/529 as this would make implementing e. g. previews a lot more efficient.