### PR TITLE
Generate previews for user styles.

### DIFF
--- a/python-dependencies.json
+++ b/python-dependencies.json
@@ -2,7 +2,7 @@
     "name": "python-dependencies",
     "buildsystem": "simple",
     "build-commands": [
-        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"numpy\" \"scipy\" \"matplotlib\" \"numexpr\" \"sympy\""
+        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"numpy\" \"scipy\" \"matplotlib\" \"numexpr\" \"sympy\" \"svgutils\""
     ],
     "build-options": {
         "env": {
@@ -133,6 +133,11 @@
             "type": "file",
             "url": "https://files.pythonhosted.org/packages/d2/05/e6600db80270777c4a64238a98d442f0fd07cc8915be2a1c16da7f2b9e74/sympy-1.12-py3-none-any.whl",
             "sha256": "c3588cd4295d0c0f603d0f2ae780587e64e2efeedb3521e46b9bb1d08d184fa5"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/44/79/0367ebd8a2edfdc46332b90bce1fd183e25078ed1b0d446c6bf42ea7ba7a/svgutils-0.3.4-py3-none-any.whl",
+            "sha256": "4d08524a08126553c1a9bf2639616cf31290adea6fd235a3eb67d77c748abc00"
         }
     ],
     "cleanup": [

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -38,6 +38,7 @@ parts:
       - numexpr==2.8.6
       - mpmath==1.3.0
       - sympy==1.12
+      - svgutils==0.3.4
     prime:
       - -usr/bin/activate
       - -usr/bin/activate.csh

--- a/src/file_io.py
+++ b/src/file_io.py
@@ -18,7 +18,7 @@ import numpy
 def save_item(file, item_):
     delimiter = "\t"
     fmt = delimiter.join(["%.12e"] * 2)
-    stream = _get_write_stream(file)
+    stream = get_write_stream(file)
     if item_.xlabel != "" and item_.ylabel != "":
         _write_string(stream, item_.xlabel + delimiter + item_.ylabel + "\n")
     for row in numpy.stack([item_.xdata, item_.ydata], axis=1):
@@ -79,7 +79,7 @@ WRITE_IGNORELIST = [
 
 
 def write_style(file, style):
-    stream = _get_write_stream(file)
+    stream = get_write_stream(file)
     _write_string(stream, f"# {style.name}\n")
     _write_string(
         stream,
@@ -100,7 +100,7 @@ def parse_json(file):
 
 
 def write_json(file, json_object, pretty_print=True):
-    stream = _get_write_stream(file)
+    stream = get_write_stream(file)
     _write_string(stream, json.dumps(
         json_object, indent=4 if pretty_print else None, sort_keys=True,
     ))
@@ -111,7 +111,7 @@ def parse_xml(file):
     return minidom.parseString(read_file(file))
 
 
-def _get_write_stream(file):
+def get_write_stream(file):
     if file.query_exists(None):
         return file.replace(None, False, 0, None)
     return file.create(0, None)

--- a/src/migrate.py
+++ b/src/migrate.py
@@ -91,16 +91,15 @@ def _migrate_styles(old_styles_dir, new_config_dir):
     new_styles_dir = new_config_dir.get_child_for_display_name("styles")
     if not new_styles_dir.query_exists(None):
         new_styles_dir.make_directory_with_parents()
-    system_styles = []
+    system_styles = {}
     directory = Gio.File.new_for_uri("resource:///se/sjoerd/Graphs/styles")
     enumerator = directory.enumerate_children("default::*", 0, None)
     while True:
         file_info = enumerator.next_file(None)
         if file_info is None:
             break
-        system_styles.append(
-            Path(utilities.get_filename(enumerator.get_child(file_info)).stem),
-        )
+        file = enumerator.get_child(file_info)
+        system_styles[Path(utilities.get_filename(file)).stem] = file
     enumerator.close(None)
     enumerator = old_styles_dir.enumerate_children("default::*", 0, None)
     while True:

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -141,6 +141,11 @@ def get_config_directory():
     return main_directory.get_child_for_display_name("graphs")
 
 
+def get_cache_directory():
+    main_directory = Gio.File.new_for_path(GLib.get_user_cache_dir())
+    return main_directory.get_child_for_display_name("graphs")
+
+
 def create_file_filters(filters, add_all=True):
     list_store = Gio.ListStore()
     for name, suffix_list in filters:


### PR DESCRIPTION
Generates a preview image (svg) for user styles, whenever a style is added.

For example:
![adwaita (1)](https://github.com/Sjoerd1993/Graphs/assets/59118042/4e543b19-ef6a-4d2e-9597-dff638b7b2c8)

Very much subject to change, this is just for implementing the functionality.
Also this introduces a (small) new dependency for manipulating svg images. This one was chosen, because we can generate an image directly from a mpl figure and export (using etree) as binary sequence allowing to integrate perfectly with GFile.
In future we might want to discuss, if these should be stored as files or in memory (each preview is only a couple of kilobytes) to reduce fs overhead.