### PR TITLE
Disable search in preferences

### DIFF
--- a/data/ui/preferences.blp
+++ b/data/ui/preferences.blp
@@ -4,6 +4,7 @@ using Adw 1;
 template $GraphsPreferencesWindow : Adw.PreferencesWindow {
   can-navigate-back: true;
   modal: true;
+  search-enabled: false;
 
   Adw.PreferencesPage {
     Adw.PreferencesGroup {


### PR DESCRIPTION
As suggested in the GNOME Circle feedback, disables the search in preferences.