### PR TITLE
Improve spacing in figure setting limits category

### DIFF
--- a/data/ui/figure_settings.blp
+++ b/data/ui/figure_settings.blp
@@ -41,86 +41,81 @@ template $GraphsFigureSettingsWindow : Adw.PreferencesWindow {
 
     Adw.PreferencesGroup {
       title: _("Axis Limits");
-      Adw.ActionRow no_data_message {
-        title: _("No Data");
-        subtitle: _("Add data to the figure to set axis limits");
+    	Adw.PreferencesGroup no_data_message {
+        Adw.ActionRow {
+          title: _("No Data");
+          subtitle: _("Add data to the figure to set axis limits");
+        }
       }
       Box {
-      	orientation: horizontal;
-      	margin-bottom: 12;
-      	Adw.PreferencesGroup {
-      	  margin-end: 3;
-      	  Adw.EntryRow min_left {
-	          title: _("Minimum Left-Hand Y-Axis");
-	          visible: false;
-	        }
+        orientation: vertical;
+        spacing: 12;
+        visible: bind no_data_message.visible inverted;
+        Box left_limits {
+        	orientation: horizontal;
+        	spacing: 6;
+          visible: false;
+        	Adw.PreferencesGroup {
+        	  Adw.EntryRow min_left {
+              title: _("Minimum Left-Hand Y-Axis");
+            }
+          }
+          Adw.PreferencesGroup {
+      	    Adw.EntryRow max_left {
+              title: _("Maximum Left-Hand Y-Axis");
+            }
+          }
         }
-	      Adw.PreferencesGroup {
-    	    margin-start: 3;
-    	    Adw.EntryRow max_left {
-	          title: _("Maximum Left-Hand Y-Axis");
-	          visible: false;
-	        }
-	      }
-	    }
-      Box {
-      	orientation: horizontal;
-      	margin-bottom: 12;
-      	Adw.PreferencesGroup {
-      	  margin-end: 3;
-      	  Adw.EntryRow min_bottom {
-	          title: _("Minimum Bottom X-Axis");
-	          visible: false;
-	        }
-	      }
-	      Adw.PreferencesGroup {
-      	  margin-start: 3;
-      	  Adw.EntryRow max_bottom {
-	          title: _("Maximum Bottom X-Axis");
-	          visible: false;
-	        }
-	      }
-	    }
-      Box {
-      	orientation: horizontal;
-      	margin-bottom: 12;
-    	  Adw.PreferencesGroup {
-      	  margin-end: 3;
-      	  Adw.EntryRow min_right {
-	          title: _("Minimum Right-Hand Y-Axis");
-	          visible: false;
-	        }
+        Box bottom_limits {
+        	orientation: horizontal;
+        	spacing: 6;
+          visible: false;
+        	Adw.PreferencesGroup {
+        	  Adw.EntryRow min_bottom {
+              title: _("Minimum Bottom X-Axis");
+            }
+          }
+          Adw.PreferencesGroup {
+        	  Adw.EntryRow max_bottom {
+              title: _("Maximum Bottom X-Axis");
+            }
+          }
         }
-	      Adw.PreferencesGroup {
-      	  margin-start: 3;
-      	  Adw.EntryRow max_right {
-	          title: _("Maximum Right-Hand Y-Axis");
-	          visible: false;
-	        }
-	      }
-	    }
-      Box {
-      	orientation: horizontal;
-    	  Adw.PreferencesGroup {
-      	  margin-end: 3;
-      	  Adw.EntryRow min_top {
-	          title: _("Minimum Top X-Axis");
-	          visible: false;
-	        }
-	      }
-	      Adw.PreferencesGroup {
-      	  margin-start: 3;
-      	  Adw.EntryRow max_top {
-	          title: _("Maximum Top Y-Axis");
-	          visible: false;
-	        }
-	      }
-	    }
+        Box right_limits {
+        	orientation: horizontal;
+        	spacing: 6;
+          visible: false;
+      	  Adw.PreferencesGroup {
+        	  Adw.EntryRow min_right {
+              title: _("Minimum Right-Hand Y-Axis");
+            }
+          }
+          Adw.PreferencesGroup {
+        	  Adw.EntryRow max_right {
+              title: _("Maximum Right-Hand Y-Axis");
+            }
+          }
+        }
+        Box top_limits {
+          spacing: 6;
+        	orientation: horizontal;
+          visible: false;
+      	  Adw.PreferencesGroup {
+        	  Adw.EntryRow min_top {
+              title: _("Minimum Top X-Axis");
+            }
+          }
+          Adw.PreferencesGroup {
+        	  Adw.EntryRow max_top {
+              title: _("Maximum Top Y-Axis");
+            }
+          }
+        }
+      }
     }
 
     Adw.PreferencesGroup {
       title: _("Scaling");
-
       Adw.ComboRow bottom_scale {
         title: _("Bottom Axis Scale");
         model: StringList{

--- a/data/ui/figure_settings.blp
+++ b/data/ui/figure_settings.blp
@@ -52,11 +52,11 @@ template $GraphsFigureSettingsWindow : Adw.PreferencesWindow {
         spacing: 12;
         visible: bind no_data_message.visible inverted;
         Box left_limits {
-        	orientation: horizontal;
-        	spacing: 6;
+          orientation: horizontal;
+          spacing: 6;
           visible: false;
-        	Adw.PreferencesGroup {
-        	  Adw.EntryRow min_left {
+          Adw.PreferencesGroup {
+            Adw.EntryRow min_left {
               title: _("Minimum Left-Hand Y-Axis");
             }
           }
@@ -67,46 +67,46 @@ template $GraphsFigureSettingsWindow : Adw.PreferencesWindow {
           }
         }
         Box bottom_limits {
-        	orientation: horizontal;
-        	spacing: 6;
+          orientation: horizontal;
+          spacing: 6;
           visible: false;
-        	Adw.PreferencesGroup {
-        	  Adw.EntryRow min_bottom {
+          Adw.PreferencesGroup {
+            Adw.EntryRow min_bottom {
               title: _("Minimum Bottom X-Axis");
             }
           }
           Adw.PreferencesGroup {
-        	  Adw.EntryRow max_bottom {
+            Adw.EntryRow max_bottom {
               title: _("Maximum Bottom X-Axis");
             }
           }
         }
         Box right_limits {
-        	orientation: horizontal;
-        	spacing: 6;
+          orientation: horizontal;
+          spacing: 6;
           visible: false;
-      	  Adw.PreferencesGroup {
-        	  Adw.EntryRow min_right {
+          Adw.PreferencesGroup {
+            Adw.EntryRow min_right {
               title: _("Minimum Right-Hand Y-Axis");
             }
           }
           Adw.PreferencesGroup {
-        	  Adw.EntryRow max_right {
+            Adw.EntryRow max_right {
               title: _("Maximum Right-Hand Y-Axis");
             }
           }
         }
         Box top_limits {
           spacing: 6;
-        	orientation: horizontal;
+          orientation: horizontal;
           visible: false;
-      	  Adw.PreferencesGroup {
-        	  Adw.EntryRow min_top {
+          Adw.PreferencesGroup {
+            Adw.EntryRow min_top {
               title: _("Minimum Top X-Axis");
             }
           }
           Adw.PreferencesGroup {
-        	  Adw.EntryRow max_top {
+            Adw.EntryRow max_top {
               title: _("Maximum Top Y-Axis");
             }
           }

--- a/src/figure_settings.py
+++ b/src/figure_settings.py
@@ -26,6 +26,10 @@ class FigureSettingsWindow(Adw.PreferencesWindow):
     legend_position = Gtk.Template.Child()
     use_custom_style = Gtk.Template.Child()
     custom_style = Gtk.Template.Child()
+    left_limits = Gtk.Template.Child()
+    right_limits = Gtk.Template.Child()
+    bottom_limits = Gtk.Template.Child()
+    top_limits = Gtk.Template.Child()
     min_left = Gtk.Template.Child()
     max_left = Gtk.Template.Child()
     min_bottom = Gtk.Template.Child()
@@ -78,13 +82,13 @@ class FigureSettingsWindow(Adw.PreferencesWindow):
             if visible:
                 for s in ["min_", "max_"]:
                     entry = getattr(self, s + direction)
-                    entry.set_visible(True)
                     entry.set_text(str(self.props.figure_settings.get_property(
                         s + direction,
                     )))
                     entry.connect(
                         "notify::text", self.on_entry_change, s + direction,
                     )
+                getattr(self, direction + "_limits").set_visible(True)
 
     def on_entry_change(self, entry, _param, prop):
         with contextlib.suppress(SyntaxError):


### PR DESCRIPTION
The current main branch has a weird spacing below the axes limits in Figure Settings. This is due to the entries themselves being hidden, but the box where they are in is not hidden. An empty box still takes some spacing, hence the spacing in the axes limits being wrong.

This PR fixes this, by hiding the boxes themselves instead of the entries. So the spacing is correct. 
Furhermore, the entire group with the limits is put into it's own box. This is so that a single `spacing` attribute can be set for all these widgets. This is necessary, as the current spacing set individually in each box means that there's a bottom-spacing on the lowest entry. (Unless that entry happens to be the limits for the top axis, but in 95% of the cases one works with left and bottom). Grouping these in a box, and setting a spacing attribute, means that there won't be any new artificial spacing between the Limits group and the Scaling group.