### PR TITLE
Fix localised actions

### DIFF
--- a/data/ui/window.blp
+++ b/data/ui/window.blp
@@ -280,7 +280,7 @@ template $GraphsWindow: Adw.ApplicationWindow {
                         clicked => $perform_operation();
                       }
 
-                      Button {
+                      Button normalize_button {
                         hexpand: true;
                         sensitive: bind shift_button.sensitive;
                         layout {
@@ -296,7 +296,7 @@ template $GraphsWindow: Adw.ApplicationWindow {
                         clicked => $perform_operation();
                       }
 
-                      Button {
+                      Button smoothen_button {
                         hexpand: true;
                         sensitive: bind shift_button.sensitive;
                         layout {
@@ -312,7 +312,7 @@ template $GraphsWindow: Adw.ApplicationWindow {
                         clicked => $perform_operation();
                       }
 
-                      Button {
+                      Button center_button {
                         hexpand: true;
                         sensitive: bind shift_button.sensitive;
                         layout {
@@ -328,7 +328,7 @@ template $GraphsWindow: Adw.ApplicationWindow {
                         clicked => $perform_operation();
                       }
 
-                      Button {
+                      Button combine_button {
                         hexpand: true;
                         sensitive: bind shift_button.sensitive;
                         layout {
@@ -369,7 +369,7 @@ template $GraphsWindow: Adw.ApplicationWindow {
                       column-spacing: 12;
                       row-spacing: 12;
                       margin-bottom:12;
-                      Button {
+                      Button derivative_button {
                         hexpand: true;
                         sensitive: bind shift_button.sensitive;
                         layout {
@@ -385,7 +385,7 @@ template $GraphsWindow: Adw.ApplicationWindow {
                         clicked => $perform_operation();
                       }
 
-                      Button {
+                      Button integral_button {
                         hexpand: true;
                         sensitive: bind shift_button.sensitive;
                         layout {
@@ -401,7 +401,7 @@ template $GraphsWindow: Adw.ApplicationWindow {
                           clicked => $perform_operation();
                         }
 
-                      Button {
+                      Button fft_button {
                         hexpand: true;
                         sensitive: bind shift_button.sensitive;
                         layout {
@@ -417,7 +417,7 @@ template $GraphsWindow: Adw.ApplicationWindow {
                         clicked => $perform_operation();
                       }
 
-                      Button {
+                      Button inverse_fft_button {
                         hexpand: true;
                         sensitive: bind shift_button.sensitive;
                         layout {
@@ -433,7 +433,7 @@ template $GraphsWindow: Adw.ApplicationWindow {
                         clicked => $perform_operation();
                       }
 
-                      Button {
+                      Button custom_transformation_button {
                         hexpand: true;
                         sensitive: bind shift_button.sensitive;
                         layout {
@@ -467,7 +467,7 @@ template $GraphsWindow: Adw.ApplicationWindow {
                           row: 0;
                         }
                       }
-                      Button {
+                      Button translate_x_button {
                         valign: center;
                         sensitive: bind shift_button.sensitive;
                         clicked => $perform_operation();
@@ -490,7 +490,7 @@ template $GraphsWindow: Adw.ApplicationWindow {
                           row: 1;
                         }
                       }
-                      Button {
+                      Button translate_y_button {
                         valign: center;
                         sensitive: bind shift_button.sensitive;
                         clicked => $perform_operation();
@@ -513,7 +513,7 @@ template $GraphsWindow: Adw.ApplicationWindow {
                           row: 2;
                         }
                       }
-                      Button {
+                      Button multiply_x_button {
                         valign: center;
                         sensitive: bind shift_button.sensitive;
                         clicked => $perform_operation();
@@ -536,7 +536,7 @@ template $GraphsWindow: Adw.ApplicationWindow {
                           row: 3;
                         }
                       }
-                      Button {
+                      Button multiply_y_button {
                         valign: center;
                         sensitive: bind shift_button.sensitive;
                         clicked => $perform_operation();

--- a/src/actions.py
+++ b/src/actions.py
@@ -12,7 +12,7 @@ from graphs.transform_data import TransformWindow
 
 
 def perform_operation(_action, target, self):
-    operation = target.get_string().lower().replace(" ", "_")
+    operation = target.get_string().removesuffix("_button")
     if operation == "combine":
         return operations.combine(self)
     elif operation == "custom_transformation":

--- a/src/window.vala
+++ b/src/window.vala
@@ -78,8 +78,7 @@ namespace Graphs {
             var action = this.application.lookup_action (
                 "app.perform_operation"
             );
-            var content = (Adw.ButtonContent) button.get_child ();
-            action.activate (new Variant.string (content.get_label ()));
+            action.activate (new Variant.string (button.get_buildable_id ()));
         }
 
         public void add_toast (Adw.Toast toast) {


### PR DESCRIPTION
The current behaviour in `operations`, the action identifier is retrieved from the button label. This breaks down with localised versions where these strings have been translated. I just stumbled upon this, as I just happened to have Graphs set to Dutch from testing localization earlier.

In this PR, the buttons have been given a label as identifier, and the Variant string is retrieved from that instead. Making these Id's consistent for different locals.