### PR TITLE
Use rc context

### DIFF
--- a/src/actions.py
+++ b/src/actions.py
@@ -20,7 +20,7 @@ def perform_operation(_action, target, self):
     elif operation == "cut" and self.get_mode() != 2:
         return
     args = []
-    if operation in ["center"]:
+    if operation in ("center"):
         args = [self.get_settings("general").get_enum(operation)]
     if operation == "shift":
         figure_settings = self.get_data().get_figure_settings()

--- a/src/add_equation.py
+++ b/src/add_equation.py
@@ -51,9 +51,12 @@ class AddEquationWindow(Adw.Window):
             name = str(self.name.get_text())
             if name == "":
                 name = f"Y = {values['equation']}"
-            self.get_application().get_data().add_items([
-                DataItem.new(xdata, ydata, name=name),
-            ])
+            application = self.get_application()
+            style_manager = application.get_figure_style_manager()
+            application.get_data().add_items([DataItem.new(
+                style_manager.get_selected_style_params(),
+                xdata, ydata, name=name,
+            )])
             self.destroy()
         except ValueError as error:
             self.toast_overlay.add_toast(Adw.Toast(title=error))

--- a/src/application.py
+++ b/src/application.py
@@ -57,7 +57,7 @@ class PythonApplication(Graphs.Application):
             )
             self.add_action(action)
         figure_settings = self.get_data().get_figure_settings()
-        for val in ["left-scale", "right-scale", "top-scale", "bottom-scale"]:
+        for val in ("left-scale", "right-scale", "top-scale", "bottom-scale"):
             action = Gio.SimpleAction.new_stateful(
                 f"change-{val}", GLib.VariantType.new("s"),
                 GLib.Variant.new_string(

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -411,7 +411,7 @@ class Canvas(FigureCanvas, Graphs.CanvasInterface):
     @bottom_scale.setter
     def bottom_scale(self, scale: int):
         scale = scales.to_string(scale)
-        for axis in [self._axis, self._right_axis]:
+        for axis in (self._axis, self._right_axis):
             axis.set_xscale(scale)
             axis.set_xlim(None, None)
         self.queue_draw()
@@ -424,7 +424,7 @@ class Canvas(FigureCanvas, Graphs.CanvasInterface):
     @left_scale.setter
     def left_scale(self, scale: int):
         scale = scales.to_string(scale)
-        for axis in [self._axis, self._top_left_axis]:
+        for axis in (self._axis, self._top_left_axis):
             axis.set_yscale(scale)
             axis.set_ylim(None, None)
         self.queue_draw()
@@ -437,7 +437,7 @@ class Canvas(FigureCanvas, Graphs.CanvasInterface):
     @top_scale.setter
     def top_scale(self, scale: int):
         scale = scales.to_string(scale)
-        for axis in [self._top_right_axis, self._top_left_axis]:
+        for axis in (self._top_right_axis, self._top_left_axis):
             axis.set_xscale(scale)
             axis.set_xlim(None, None)
         self.queue_draw()
@@ -450,7 +450,7 @@ class Canvas(FigureCanvas, Graphs.CanvasInterface):
     @right_scale.setter
     def right_scale(self, scale: int):
         scale = scales.to_string(scale)
-        for axis in [self._top_right_axis, self._right_axis]:
+        for axis in (self._top_right_axis, self._right_axis):
             axis.set_yscale(scale)
             axis.set_ylim(None, None)
         self.queue_draw()
@@ -462,7 +462,7 @@ class Canvas(FigureCanvas, Graphs.CanvasInterface):
 
     @min_bottom.setter
     def min_bottom(self, value: float):
-        for axis in [self._axis, self._right_axis]:
+        for axis in (self._axis, self._right_axis):
             axis.set_xlim(value, None)
         self.queue_draw()
 
@@ -473,7 +473,7 @@ class Canvas(FigureCanvas, Graphs.CanvasInterface):
 
     @max_bottom.setter
     def max_bottom(self, value: float):
-        for axis in [self._axis, self._right_axis]:
+        for axis in (self._axis, self._right_axis):
             axis.set_xlim(None, value)
         self.queue_draw()
 
@@ -484,7 +484,7 @@ class Canvas(FigureCanvas, Graphs.CanvasInterface):
 
     @min_left.setter
     def min_left(self, value: float):
-        for axis in [self._axis, self._top_left_axis]:
+        for axis in (self._axis, self._top_left_axis):
             axis.set_ylim(value, None)
         self.queue_draw()
 
@@ -495,7 +495,7 @@ class Canvas(FigureCanvas, Graphs.CanvasInterface):
 
     @max_left.setter
     def max_left(self, value: float):
-        for axis in [self._axis, self._top_left_axis]:
+        for axis in (self._axis, self._top_left_axis):
             axis.set_ylim(None, value)
         self.queue_draw()
 
@@ -506,7 +506,7 @@ class Canvas(FigureCanvas, Graphs.CanvasInterface):
 
     @min_top.setter
     def min_top(self, value: float):
-        for axis in [self._top_left_axis, self._top_right_axis]:
+        for axis in (self._top_left_axis, self._top_right_axis):
             axis.set_xlim(value, None)
         self.highlight.load(self)
         self.queue_draw()
@@ -518,7 +518,7 @@ class Canvas(FigureCanvas, Graphs.CanvasInterface):
 
     @max_top.setter
     def max_top(self, value: float):
-        for axis in [self._top_left_axis, self._top_right_axis]:
+        for axis in (self._top_left_axis, self._top_right_axis):
             axis.set_xlim(None, value)
         self.highlight.load(self)
         self.queue_draw()
@@ -530,7 +530,7 @@ class Canvas(FigureCanvas, Graphs.CanvasInterface):
 
     @min_right.setter
     def min_right(self, value: float):
-        for axis in [self._right_axis, self._top_right_axis]:
+        for axis in (self._right_axis, self._top_right_axis):
             axis.set_ylim(value, None)
         self.queue_draw()
 
@@ -541,7 +541,7 @@ class Canvas(FigureCanvas, Graphs.CanvasInterface):
 
     @max_right.setter
     def max_right(self, value: float):
-        for axis in [self._right_axis, self._top_right_axis]:
+        for axis in (self._right_axis, self._top_right_axis):
             axis.set_ylim(None, value)
         self.queue_draw()
 
@@ -646,7 +646,7 @@ class _DummyToolbar(NavigationToolbar2):
     def push_current(self):
         """Use custom functionality for the view clipboard."""
         self.canvas.highlight.load(self.canvas)
-        for direction in ["bottom", "left", "top", "right"]:
+        for direction in ("bottom", "left", "top", "right"):
             self.canvas.notify(f"min-{direction}")
             self.canvas.notify(f"max-{direction}")
         self.canvas.application.get_data().add_view_history_state()

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -79,7 +79,7 @@ class Canvas(FigureCanvas, Graphs.CanvasInterface):
     min_selected = GObject.Property(type=float, default=0)
     max_selected = GObject.Property(type=float, default=0)
 
-    def __init__(self, application):
+    def __init__(self, application, style_params):
         """
         Create the canvas.
 
@@ -87,6 +87,9 @@ class Canvas(FigureCanvas, Graphs.CanvasInterface):
         style context. Bind `items` to `data.items` and all figure settings
         attributes to their respective values.
         """
+        orig_params = dict(pyplot.rcParams.copy())
+        self._style_params = style_params
+        pyplot.rcParams.update(self._style_params)  # apply style_params
         GObject.Object.__init__(self, application=application, can_focus=False)
         super().__init__()
         self.figure.set_tight_layout(True)
@@ -116,6 +119,7 @@ class Canvas(FigureCanvas, Graphs.CanvasInterface):
         zoom_gesture = Gtk.GestureZoom.new()
         zoom_gesture.connect("scale-changed", self._on_zoom_gesture)
         self.add_controller(zoom_gesture)
+        dict.update(pyplot.rcParams, orig_params)  # revert rcParams
 
     def get_application(self):
         """Get application property."""
@@ -247,7 +251,7 @@ class Canvas(FigureCanvas, Graphs.CanvasInterface):
             visible_axes = [True, False, True, False]
             self._legend_axis = self._axis
 
-        params = pyplot.rcParams
+        params = self._style_params
         ticks = "both" if params["xtick.minor.visible"] else "major"
         for directions, axis, used \
                 in zip(axes_directions, self.axes, used_axes):

--- a/src/curve_fitting.py
+++ b/src/curve_fitting.py
@@ -28,9 +28,11 @@ class CurveFittingWindow(Graphs.CurveFittingTool):
         )
         self.equation = self.get_equation()
         ui.bind_values_to_settings(
-            self.get_application().get_settings("curve-fitting"), self)
+            application.get_settings("curve-fitting"), self)
         self.get_confirm_button().connect("clicked", self.add_fit)
-        canvas = Canvas(application)
+        style = application.get_figure_style_manager(
+        ).get_system_style_params()
+        canvas = Canvas(application, style)
         self.param = []
         self.sigma = []
         self.r2 = 0
@@ -43,17 +45,18 @@ class CurveFittingWindow(Graphs.CurveFittingTool):
             self.fitting_parameters.add_items([FittingParameter(name=var)])
         # Generate item for the data that is fitted to
         self.data_curve = DataItem.new(
-            xdata=item.xdata, ydata=item.ydata, name=item.get_name(),
-            color="#1A5FB4",
+            style, xdata=item.xdata, ydata=item.ydata,
+            name=item.get_name(), color="#1A5FB4",
         )
         self.data_curve.linestyle = 0
         self.data_curve.markerstyle = 1
         self.data_curve.markersize = 13
 
         # Generate item for the fit
-        self.fitted_curve = DataItem.new(color="#A51D2D")
+        self.fitted_curve = DataItem.new(style, color="#A51D2D")
 
         self.fill = FillItem.new(
+            style,
             (self.fitted_curve.xdata,
              self.fitted_curve.ydata, self.fitted_curve.ydata),
             color="#1A5FB4",
@@ -229,7 +232,10 @@ class CurveFittingWindow(Graphs.CurveFittingTool):
 
     def add_fit(self, _widget):
         """Add fitted data to the items in the main application"""
-        self.get_application().get_data().add_items([DataItem.new(
+        application = self.get_application()
+        style_manager = application.get_figure_style_manager()
+        application.get_data().add_items([DataItem.new(
+            style_manager.get_selected_style_params(),
             name=self.fitted_curve.get_name(),
             xdata=self.fitted_curve.xdata, ydata=self.fitted_curve.ydata,
         )])

--- a/src/curve_fitting.py
+++ b/src/curve_fitting.py
@@ -7,7 +7,7 @@ from gi.repository import Adw, GObject, Graphs, Gtk
 from graphs import ui, utilities
 from graphs.canvas import Canvas
 from graphs.data import Data
-from graphs.item import DataItem
+from graphs.item import DataItem, FillItem
 
 import numpy
 
@@ -53,16 +53,17 @@ class CurveFittingWindow(Graphs.CurveFittingTool):
         # Generate item for the fit
         self.fitted_curve = DataItem.new(color="#A51D2D")
 
-        canvas.props.items = [self.fitted_curve, self.data_curve]
-
-        # Set up canvas
-        axis = canvas.axes[0]
-        self.fill = axis.fill_between(
-            self.fitted_curve.xdata,
-            [0], [1],
-            color=canvas.rubberband_fill_color,
+        self.fill = FillItem.new(
+            (self.fitted_curve.xdata,
+             self.fitted_curve.ydata, self.fitted_curve.ydata),
+            color="#1A5FB4",
             alpha=0.15,
         )
+
+        # Set up canvas
+        canvas.props.items = [self.fitted_curve, self.data_curve, self.fill]
+
+        axis = canvas.axes[0]
         axis.yscale = "linear"
         axis.xscale = "linear"
         canvas.highlight_enabled = False
@@ -222,12 +223,9 @@ class CurveFittingWindow(Graphs.CurveFittingTool):
         if min(lower_bound) < middle - 1e5 * span:
             lower_bound = [middle - 1e5 * span]
 
-        dummy = self.canvas.axes[0].fill_between(
-            self.fitted_curve.xdata, lower_bound, upper_bound,
+        self.fill.props.data = (
+            self.fitted_curve.props.xdata, lower_bound, upper_bound,
         )
-        dp = dummy.get_paths()[0]
-        dummy.remove()
-        self.fill.set_paths([dp.vertices])
 
     def add_fit(self, _widget):
         """Add fitted data to the items in the main application"""

--- a/src/data.py
+++ b/src/data.py
@@ -12,8 +12,6 @@ from gi.repository import GObject, Graphs
 
 from graphs import item, utilities
 
-from matplotlib import pyplot
-
 import numpy
 
 
@@ -168,7 +166,9 @@ class Data(GObject.Object, Graphs.DataInterface):
         settings = application.get_settings()
         handle_duplicates = \
             settings.get_child("general").get_enum("handle-duplicates")
-        color_cycle = pyplot.rcParams["axes.prop_cycle"].by_key()["color"]
+        style_manager = self.get_application().get_figure_style_manager()
+        selected_style = style_manager.get_selected_style_params()
+        color_cycle = selected_style["axes.prop_cycle"].by_key()["color"]
         used_colors = []
 
         def _append_used_color(color):

--- a/src/data.py
+++ b/src/data.py
@@ -262,7 +262,7 @@ class Data(GObject.Object, Graphs.DataInterface):
     def _connect_to_item(self, item_):
         item_.connect("notify::selected", self._on_item_select)
         item_.connect("notify", self._on_item_change)
-        for prop in ["xposition", "yposition"]:
+        for prop in ("xposition", "yposition"):
             item_.connect(f"notify::{prop}", self._on_item_position_change)
 
     def _on_item_position_change(self, _item, _ignored):
@@ -411,7 +411,7 @@ class Data(GObject.Object, Graphs.DataInterface):
         axes = [
             [direction, False, [], [],
              figure_settings.get_property(f"{direction}_scale")]
-            for direction in ["bottom", "left", "top", "right"]
+            for direction in ("bottom", "left", "top", "right")
         ]
         for item_ in self:
             if item_.__gtype_name__ != "GraphsDataItem":

--- a/src/figure_settings.py
+++ b/src/figure_settings.py
@@ -121,7 +121,7 @@ class FigureSettingsWindow(Adw.Window):
                 used_axes[i][1] = True
         for (direction, visible) in used_axes:
             if visible:
-                for s in ["min_", "max_"]:
+                for s in ("min_", "max_"):
                     entry = getattr(self, s + direction)
                     entry.set_text(str(self.props.figure_settings.get_property(
                         s + direction,

--- a/src/item.py
+++ b/src/item.py
@@ -3,8 +3,6 @@ from gi.repository import GObject, Graphs
 
 from graphs import misc
 
-from matplotlib import pyplot
-
 
 def new_from_dict(dictionary: dict):
     match dictionary["type"]:
@@ -37,8 +35,7 @@ class DataItem(Graphs.Item):
     markersize = GObject.Property(type=float, default=7)
 
     @staticmethod
-    def new(xdata=None, ydata=None, **kwargs):
-        params = pyplot.rcParams
+    def new(params, xdata=None, ydata=None, **kwargs):
         return DataItem(
             linestyle=misc.LINESTYLES.index(params["lines.linestyle"]),
             linewidth=params["lines.linewidth"],
@@ -53,8 +50,7 @@ class DataItem(Graphs.Item):
             if self.get_property(prop) is None:
                 self.set_property(prop, [])
 
-    def reset(self):
-        params = pyplot.rcParams
+    def reset(self, params):
         self.props.linestyle = misc.LINESTYLES.index(params["lines.linestyle"])
         self.props.linewidth = params["lines.linewidth"]
         self.props.markerstyle = \
@@ -73,15 +69,13 @@ class TextItem(Graphs.Item):
     rotation = GObject.Property(type=int, default=0, minimum=0, maximum=360)
 
     @staticmethod
-    def new(xanchor=0, yanchor=0, text="", **kwargs):
-        params = pyplot.rcParams
+    def new(params, xanchor=0, yanchor=0, text="", **kwargs):
         return TextItem(
             size=params["font.size"], color=params["text.color"],
             xanchor=xanchor, yanchor=yanchor, text=text, **kwargs,
         )
 
-    def reset(self):
-        params = pyplot.rcParams
+    def reset(self, params):
         self.props.size = params["font.size"]
         self.props.color = params["text.color"]
 
@@ -92,10 +86,13 @@ class FillItem(Graphs.Item):
     data = GObject.Property(type=object)
 
     @staticmethod
-    def new(data, **kwargs):
+    def new(_params, data, **kwargs):
         return FillItem(data=data, **kwargs)
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         if self.props.data is None:
             self.props.data = (None, None, None)
+
+    def reset(self):
+        pass

--- a/src/item.py
+++ b/src/item.py
@@ -12,6 +12,8 @@ def new_from_dict(dictionary: dict):
             cls = DataItem
         case "GrapsTextItem":
             cls = TextItem
+        case "GrapsFillItem":
+            cls = FillItem
         case _:
             pass
     dictionary.pop("type")
@@ -42,16 +44,14 @@ class DataItem(Graphs.Item):
             linewidth=params["lines.linewidth"],
             markerstyle=misc.MARKERSTYLES.index(params["lines.marker"]),
             markersize=params["lines.markersize"],
-            xdata=[] if xdata is None else xdata,
-            ydata=[] if ydata is None else ydata, **kwargs,
+            xdata=xdata, ydata=ydata, **kwargs,
         )
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        if self.props.xdata is None:
-            self.props.xdata = []
-        if self.props.ydata is None:
-            self.props.ydata = []
+        for prop in ("xdata", "ydata"):
+            if self.get_property(prop) is None:
+                self.set_property(prop, [])
 
     def reset(self):
         params = pyplot.rcParams
@@ -80,10 +80,22 @@ class TextItem(Graphs.Item):
             xanchor=xanchor, yanchor=yanchor, text=text, **kwargs,
         )
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-
     def reset(self):
         params = pyplot.rcParams
         self.props.size = params["font.size"]
         self.props.color = params["text.color"]
+
+
+class FillItem(Graphs.Item):
+    __gtype_name__ = "GraphsFillItem"
+
+    data = GObject.Property(type=object)
+
+    @staticmethod
+    def new(data, **kwargs):
+        return FillItem(data=data, **kwargs)
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        if self.props.data is None:
+            self.props.data = (None, None, None)

--- a/src/migrate.py
+++ b/src/migrate.py
@@ -101,18 +101,18 @@ def _migrate_styles(old_styles_dir, new_config_dir):
     if not new_styles_dir.query_exists(None):
         new_styles_dir.make_directory_with_parents()
     enumerator = old_styles_dir.enumerate_children("default::*", 0, None)
+    adwaita = style_io.parse(Gio.File.new_for_uri(
+        "resource:///se/sjoerd/Graphs/styles/adwaita.mplstyle",
+    ))
     for file in map(enumerator.get_child, enumerator):
         stylename = Path(utilities.get_filename(file)).stem
         if stylename not in SYSTEM_STYLES:
-            params = style_io.parse_style(file)
-            adwaita = Gio.File.new_for_uri(
-                "resource:///se/sjoerd/Graphs/styles/adwaita.mplstyle",
-            )
-            for key, value in style_io.parse_style(adwaita).items():
+            params = style_io.parse(file)
+            for key, value in adwaita.items():
                 if key not in params:
                     params[key] = value
             params.name = stylename
-            style_io.write_style(new_styles_dir.get_child_for_display_name(
+            style_io.write(new_styles_dir.get_child_for_display_name(
                 f"{stylename.lower().replace(' ', '-')}.mplstyle",
             ), params)
         file.delete(None)

--- a/src/operations.py
+++ b/src/operations.py
@@ -284,6 +284,7 @@ def combine(self):
 
     # Create the item itself
     new_xdata, new_ydata = sort_data(new_xdata, new_ydata)
+    style = self.get_figure_style_manager().get_selected_style_params()
     self.get_data().add_items(
-        [DataItem.new(new_xdata, new_ydata, name=_("Combined Data"))],
+        [DataItem.new(style, new_xdata, new_ydata, name=_("Combined Data"))],
     )

--- a/src/parse_file.py
+++ b/src/parse_file.py
@@ -42,8 +42,9 @@ def import_from_xrdml(self, file):
             end_pos = float(end_pos[0].firstChild.data)
             xdata = numpy.linspace(start_pos, end_pos, len(ydata))
             xdata = numpy.ndarray.tolist(xdata)
+    style = self.get_figure_style_manager().get_selected_style_params()
     return [item.DataItem.new(
-        xdata, ydata, name=utilities.get_filename(file),
+        style, xdata, ydata, name=utilities.get_filename(file),
         xlabel=f"{scan_axis} ({unit})", ylabel=_("Intensity (cps)"),
     )]
 
@@ -61,9 +62,10 @@ def import_from_xry(self, file):
     item_count = int(info[0])
 
     name = utilities.get_filename(file)
+    style = self.get_figure_style_manager().get_selected_style_params()
     items = [
         item.DataItem.new(
-            name=f"{name} - {i + 1}" if item_count > 1 else name,
+            style, name=f"{name} - {i + 1}" if item_count > 1 else name,
             xlabel=_("β (°)"), ylabel=_("R (1/s)"),
         ) for i in range(item_count)
     ]
@@ -79,7 +81,7 @@ def import_from_xry(self, file):
         values = row.strip().split()
         text = " ".join(values[7:])
         items.append(item.TextItem.new(
-            float(values[5]), float(values[6]), text, name=text,
+            style, float(values[5]), float(values[6]), text, name=text,
         ))
     return items
 
@@ -91,7 +93,8 @@ def _swap(string):
 
 
 def import_from_columns(self, file):
-    item_ = item.DataItem.new(name=utilities.get_filename(file))
+    style = self.get_figure_style_manager().get_selected_style_params()
+    item_ = item.DataItem.new(style, name=utilities.get_filename(file))
     columns_params = self.get_settings().get_child(
         "import-params").get_child("columns")
     column_x = columns_params.get_int("column-x")

--- a/src/style_io.py
+++ b/src/style_io.py
@@ -21,7 +21,7 @@ FONT_SIZE_KEYS = [
 ]
 
 
-def parse_style(file):
+def parse(file):
     """
     Parse a style to RcParams.
 
@@ -90,7 +90,7 @@ WRITE_IGNORELIST = STYLE_IGNORELIST + [
 ]
 
 
-def write_style(file, style):
+def write(file, style):
     stream = file_io.get_write_stream(file)
     file_io.write_string(stream, "# Generated via Graphs\n")
     file_io.write_string(stream, f"# {style.name}\n")

--- a/src/styles.py
+++ b/src/styles.py
@@ -99,7 +99,7 @@ class StyleManager(GObject.Object, Graphs.StyleManagerInterface):
         application.get_style_manager().connect(
             "notify", self._on_style_select,
         )
-        for prop in ["use-custom-style", "custom-style"]:
+        for prop in ("use-custom-style", "custom-style"):
             figure_settings.connect(
                 f"notify::{prop}", self._on_style_select,
             )
@@ -223,7 +223,7 @@ class StyleManager(GObject.Object, Graphs.StyleManagerInterface):
         canvas = graphs.canvas.Canvas(self.props.application)
         figure_settings = data.get_figure_settings()
         for prop in dir(figure_settings.props):
-            if prop not in ["use_custom_style", "custom_style"]:
+            if prop not in ("use_custom_style", "custom_style"):
                 figure_settings.bind_property(prop, canvas, prop, 1 | 2)
         data.bind_property("items", canvas, "items", 2)
         window.set_canvas(canvas)
@@ -541,15 +541,15 @@ class StyleEditor(Adw.NavigationPage):
         font_description = self.font_chooser.get_font_desc()
         self.style_params["font.sans-serif"] = [font_description.get_family()]
         font_size = font_description.get_size() / Pango.SCALE
-        for key in ["font.size", "axes.labelsize", "xtick.labelsize",
-                    "ytick.labelsize", "legend.fontsize", "figure.labelsize"]:
+        for key in ("font.size", "axes.labelsize", "xtick.labelsize",
+                    "ytick.labelsize", "legend.fontsize", "figure.labelsize"):
             self.style_params[key] = font_size
         titlesize = round(self.titlesize.get_value() * font_size, 1)
         self.style_params["figure.titlesize"] = titlesize
         self.style_params["axes.titlesize"] = titlesize
         font_weight = font_description.get_weight()
-        for key in ["font.weight", "axes.titleweight", "axes.labelweight",
-                    "figure.titleweight", "figure.labelweight"]:
+        for key in ("font.weight", "axes.titleweight", "axes.labelweight",
+                    "figure.titleweight", "figure.labelweight"):
             self.style_params[key] = font_weight
         self.style_params["font.style"] = FONT_STYLE_DICT[
             font_description.get_style()


### PR DESCRIPTION
Based on #556 

Use instanced version of rcParams instead of global one.
This should no longer break custom installs, where Graphs was running and somebody ran a simple mpl script (although that was never supported anyway)
This also allows to have the curve fitting canvas always follow the system:
![Bildschirmfoto vom 2023-10-25 18-28-49](https://github.com/Sjoerd1993/Graphs/assets/59118042/0a6cc3c4-1cab-4f73-99e3-ace0150380d6)
