### PR TITLE
Add subtitles in preferences

### DIFF
--- a/data/se.sjoerd.Graphs.gschema.xml
+++ b/data/se.sjoerd.Graphs.gschema.xml
@@ -2,7 +2,7 @@
 <schemalist gettext-domain="graphs">
   <enum id="se.sjoerd.Graphs.general.center-values">
     <value nick="Center at maximum Y value" value="0"/>
-    <value nick="Center at middle coordinate" value="1"/>
+    <value nick="Center at middle X value" value="1"/>
   </enum>
 
   <enum id="se.sjoerd.Graphs.general.handle-duplicates-values">
@@ -62,7 +62,7 @@
 
   <schema id="se.sjoerd.Graphs.general">
     <key name="center" enum="se.sjoerd.Graphs.general.center-values">
-      <default>"Center at middle coordinate"</default>
+      <default>"Center at middle X value"</default>
     </key>
     <key name="handle-duplicates" enum="se.sjoerd.Graphs.general.handle-duplicates-values">
       <default>"Auto-rename duplicates"</default>

--- a/data/ui/preferences.blp
+++ b/data/ui/preferences.blp
@@ -12,13 +12,15 @@ template $GraphsPreferencesWindow : Adw.PreferencesWindow {
 
       Adw.ComboRow center {
         title: _("Center Action Behaviour");
+        subtitle: _("Which value to center on when performing a center action");
         model: StringList{
-          strings [_("Center at maximum Y value"), _("Center at middle coordinate")]
+          strings [_("Center at maximum Y value"), _("Center at middle X value")]
         };
       }
 
       Adw.ComboRow handle_duplicates {
         title: _("Handle Duplicate Items");
+        subtitle: _("How to treat imported files with identical filenames");
         model: StringList{
           strings [_("Auto-rename duplicates"), _("Ignore duplicates"), _("Add duplicates"), _("Override existing items")]
         };


### PR DESCRIPTION
Adds subtitles to the first two options in the preferences, basically due to comments from @bertob that the options were a bit unclear. https://gitlab.gnome.org/Teams/Circle/-/issues/185

Perhaps the last two also need some slight explanation. They seemed somewhat clear to me (at least "Hide unselected items" seemed OK to me personally), but to a new user they may be a bit unclear at first glance. So I'm open to suggestions to clarify these options somewhat.