### PR TITLE
Fix shift with single item

### DIFF
--- a/src/operations.py
+++ b/src/operations.py
@@ -186,7 +186,7 @@ def shift(item, xdata, ydata, left_scale, right_scale, items, ranges):
 
     for index, item_ in enumerate(data_list):
         # Compare first element with itself, not "previous" item
-        index = 1 if index == 0 else index
+        index = 1 if index == 0 and len(data_list) > 1 else index
 
         previous_item = data_list[index - 1]
 


### PR DESCRIPTION
The line `index = 1 if index == 0 > 1 else index` leads to an index error later on in cases when there's only one item loaded. This condition should only be triggered if there's at least two items.