### PR TITLE
rework resetting item properties on style change

### DIFF
--- a/data/se.sjoerd.Graphs.gschema.xml
+++ b/data/se.sjoerd.Graphs.gschema.xml
@@ -70,9 +70,6 @@
     <key name="hide-unselected" type="b">
       <default>false</default>
     </key>
-    <key name="override-item-properties" type="b">
-      <default>true</default>
-    </key>
   </schema>
 
   <schema id="se.sjoerd.Graphs.figure">

--- a/data/ui/preferences.blp
+++ b/data/ui/preferences.blp
@@ -8,8 +8,6 @@ template $GraphsPreferencesWindow : Adw.PreferencesWindow {
 
   Adw.PreferencesPage {
     Adw.PreferencesGroup {
-      title: _("General");
-
       Adw.ComboRow center {
         title: _("Center Action Behaviour");
         subtitle: _("Which value to center on when performing a center action");
@@ -25,17 +23,9 @@ template $GraphsPreferencesWindow : Adw.PreferencesWindow {
           strings [_("Auto-rename duplicates"), _("Ignore duplicates"), _("Add duplicates"), _("Override existing items")]
         };
       }
-    }
-
-    Adw.PreferencesGroup {
-      title: _("Figure");
 
       Adw.SwitchRow hide_unselected {
         title: _("Hide Unselected Items");
-      }
-
-      Adw.SwitchRow override_item_properties {
-        title: _("Override Item Properties on Style Change");
       }
     }
   }

--- a/src/data.py
+++ b/src/data.py
@@ -414,7 +414,7 @@ class Data(GObject.Object, Graphs.DataInterface):
             for direction in ("bottom", "left", "top", "right")
         ]
         for item_ in self:
-            if item_.__gtype_name__ != "GraphsDataItem":
+            if not isinstance(item_, item.DataItem):
                 continue
             for index in \
                     item_.get_xposition() * 2, 1 + item_.get_yposition() * 2:

--- a/src/edit_item.py
+++ b/src/edit_item.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 from gi.repository import Adw, GObject, Graphs, Gtk
 
-from graphs import ui
+from graphs import item, ui
 
 _IGNORELIST = [
     "alpha", "color", "item_type", "uuid", "selected", "xdata", "xlabel",
@@ -58,9 +58,7 @@ class EditItemWindow(Adw.PreferencesWindow):
         self.props.bindings = ui.bind_values_to_object(
             self.props.item, self, ignorelist=_IGNORELIST,
         )
-        self.item_group.set_visible(
-            self.props.item.__gtype_name__ == "GraphsDataItem",
-        )
+        self.item_group.set_visible(isinstance(self.props.item, item.DataItem))
 
     @Gtk.Template.Callback()
     def on_close(self, _a):

--- a/src/edit_item.py
+++ b/src/edit_item.py
@@ -52,7 +52,7 @@ class EditItemWindow(Adw.PreferencesWindow):
 
     @Gtk.Template.Callback()
     def on_item_change(self, _a, _b):
-        self.set_title(self.props.item.props.name)
+        self.set_title(self.props.item.get_name())
         for binding in self.props.bindings:
             binding.unbind()
         self.props.bindings = ui.bind_values_to_object(

--- a/src/item_box.py
+++ b/src/item_box.py
@@ -101,8 +101,8 @@ class ItemBox(Gtk.Box):
     @Gtk.Template.Callback()
     def on_toggle(self, _a, _b):
         new_value = self.check_button.get_active()
-        if self.props.item.props.selected != new_value:
-            self.props.item.props.selected = new_value
+        if self.props.item.get_selected() != new_value:
+            self.props.item.set_selected(new_value)
             self.get_application().get_data().add_history_state()
 
     @Gtk.Template.Callback()
@@ -123,7 +123,7 @@ class ItemBox(Gtk.Box):
                 self.get_application().get_data().add_history_state()
 
     def delete(self, _action, _shortcut):
-        name = self.props.item.props.name
+        name = self.props.item.get_name()
         self.get_application().get_data().delete_items([self.props.item])
         toast = Adw.Toast.new(_("Deleted {name}").format(name=name))
         toast.set_button_label("Undo")

--- a/src/migrate.py
+++ b/src/migrate.py
@@ -20,7 +20,6 @@ CONFIG_MIGRATION_TABLE = {
     "export_figure_transparent": ("export-figure", "transparent"),
     "handle_duplicates": ("general", "handle-duplicates"),
     "hide_unselected": ("general", "hide-unselected"),
-    "override_style_change": ("general", "override-item-properties"),
     "plot_custom_style": ("figure", "custom-style"),
     "plot_legend": ("figure", "legend"),
     "plot_right_label": ("figure", "right-label"),

--- a/src/operations.py
+++ b/src/operations.py
@@ -18,8 +18,8 @@ def get_data(self, item):
     Retrieve item from datadict with start and stop index.
     If interaction_mode is set to "SELECT"
     """
-    xdata = item.xdata
-    ydata = item.ydata
+    xdata = item.props.xdata
+    ydata = item.props.ydata
     new_xdata = xdata.copy()
     new_ydata = ydata.copy()
     start_index = 0
@@ -71,7 +71,7 @@ def perform_operation(self, callback, *args):
     data = self.get_data()
     old_limits = data.get_figure_settings().get_limits()
     for item in data:
-        if not item.get_selected() or item.__gtype_name__ != "GraphsDataItem":
+        if not (item.get_selected() and isinstance(item, DataItem)):
             continue
         xdata, ydata, start_index, stop_index = get_data(self, item)
         if xdata is not None and len(xdata) != 0:
@@ -80,12 +80,12 @@ def perform_operation(self, callback, *args):
                 item, xdata, ydata, *args)
             if discard:
                 logging.debug("Discard is true")
-                item.xdata = new_xdata
-                item.ydata = new_ydata
+                item.props.xdata = new_xdata
+                item.props.ydata = new_ydata
             else:
                 logging.debug("Discard is false")
-                item.xdata[start_index:stop_index] = new_xdata
-                item.ydata[start_index:stop_index] = new_ydata
+                item.props.xdata[start_index:stop_index] = new_xdata
+                item.props.ydata[start_index:stop_index] = new_ydata
             if sort:
                 logging.debug("Sorting data")
                 item.xdata, item.ydata = sort_data(item.xdata, item.ydata)
@@ -176,7 +176,7 @@ def shift(item, xdata, ydata, left_scale, right_scale, items, ranges):
     """
     data_list = [
         item for item in items
-        if item.get_selected() and item.__gtype_name__ == "GraphsDataItem"
+        if item.get_selected() and isinstance(item, DataItem)
     ]
 
     y_range = ranges[1] if item.get_yposition() else ranges[0]
@@ -191,7 +191,7 @@ def shift(item, xdata, ydata, left_scale, right_scale, items, ranges):
         previous_item = data_list[index - 1]
 
         # Only use selected span when obtaining values to determine shift value
-        full_xdata = numpy.asarray(data_list[index].xdata)
+        full_xdata = numpy.asarray(data_list[index].props.xdata)
         start = 0
         stop = len(data_list[index].ydata)
         with contextlib.suppress(IndexError):
@@ -276,7 +276,7 @@ def combine(self):
     """Combine the selected data into a new data set"""
     new_xdata, new_ydata = [], []
     for item in self.get_data():
-        if not item.get_selected() or item.__gtype_name__ != "GraphsDataItem":
+        if not (item.get_selected() and isinstance(item, DataItem)):
             continue
         xdata, ydata = get_data(self, item)[:2]
         new_xdata.extend(xdata)

--- a/src/preferences.vala
+++ b/src/preferences.vala
@@ -16,9 +16,6 @@ namespace Graphs {
         [GtkChild]
         public unowned Adw.SwitchRow hide_unselected { get; }
 
-        [GtkChild]
-        public unowned Adw.SwitchRow override_item_properties { get; }
-
         public PreferencesWindow (Application application) {
             Object (
                 application: application,

--- a/src/styles.py
+++ b/src/styles.py
@@ -179,10 +179,10 @@ class StyleManager(GObject.Object, Graphs.StyleManagerInterface):
             count = 0
             for item in data:
                 if item.__gtype_name__ == "GraphsDataItem" \
-                        and item.props.color in old_colors:
+                        and item.get_color() in old_colors:
                     if count > len(color_cycle):
                         count = 0
-                    item.props.color = color_cycle[count]
+                    item.set_color(color_cycle[count])
                     count += 1
 
         canvas = graphs.canvas.Canvas(

--- a/src/styles.py
+++ b/src/styles.py
@@ -12,7 +12,7 @@ from cycler import cycler
 from gi.repository import Adw, GLib, GObject, Gdk, Gio, Graphs, Gtk, Pango
 
 import graphs
-from graphs import style_io, ui, utilities
+from graphs import item, style_io, ui, utilities
 
 from matplotlib import RcParams
 
@@ -174,15 +174,15 @@ class StyleManager(GObject.Object, Graphs.StyleManagerInterface):
             old_colors = old_style["axes.prop_cycle"].by_key()["color"]
             color_cycle = self._selected_style_params[
                 "axes.prop_cycle"].by_key()["color"]
-            for item in data:
-                item.reset(old_style, self._selected_style_params)
+            for item_ in data:
+                item_.reset(old_style, self._selected_style_params)
             count = 0
-            for item in data:
-                if item.__gtype_name__ == "GraphsDataItem" \
-                        and item.get_color() in old_colors:
+            for item_ in data:
+                if isinstance(item_, item.DataItem) \
+                        and item_.get_color() in old_colors:
                     if count > len(color_cycle):
                         count = 0
-                    item.set_color(color_cycle[count])
+                    item_.set_color(color_cycle[count])
                     count += 1
 
         canvas = graphs.canvas.Canvas(
@@ -506,8 +506,8 @@ class StyleEditor(Adw.NavigationPage):
             if value is not None:
                 with contextlib.suppress(KeyError):
                     value = VALUE_DICT[key][value]
-                for item in STYLE_DICT[key]:
-                    self.style_params[item] = value
+                for item_ in STYLE_DICT[key]:
+                    self.style_params[item_] = value
 
         # font
         font_description = self.font_chooser.get_font_desc()


### PR DESCRIPTION
As discussed in #563, remove the preference option in regards to item override.

For visual reasons this also removes the grouping in the preferences, as there are only three items now.
Creating items has also been made more modular using some of the logic necessary to handle reset() properly.
Also revert usage of `__gtype_name__` to check for instances of Item. This allows to have future items that inherit from e. g. DataItem.