### PR TITLE
tweak style parameters

### DIFF
--- a/data/styles/adwaita-dark.mplstyle
+++ b/data/styles/adwaita-dark.mplstyle
@@ -82,10 +82,10 @@ text.color: FFFFFF
 axes.labelcolor: FFFFFF
 xtick.labelcolor: FFFFFF
 ytick.labelcolor: FFFFFF
-xtick.color: FFFFFF
-ytick.color: FFFFFF
-axes.edgecolor: FFFFFF
-grid.color: A7A7A7
+xtick.color: C0BFBC
+ytick.color: C0BFBC
+axes.edgecolor: C0BFBC
+grid.color: 77767B
 axes.facecolor: 242424
 figure.facecolor: 242424
 figure.edgecolor: 242424

--- a/data/styles/adwaita.mplstyle
+++ b/data/styles/adwaita.mplstyle
@@ -82,10 +82,10 @@ text.color: 000000
 axes.labelcolor: 000000
 xtick.labelcolor: 000000
 ytick.labelcolor: 000000
-xtick.color: 000000
-ytick.color: 000000
-axes.edgecolor: 000000
-grid.color: 646464
+xtick.color: 5E5C64
+ytick.color: 5E5C64
+axes.edgecolor: 5E5C64
+grid.color: 9A9996
 axes.facecolor: FFFFFF
 figure.facecolor: FAFAFA
 figure.edgecolor: FAFAFA


### PR DESCRIPTION
Slightly tweak the colors of the adwaita stylesheet for the Graphs. See below for previews:

![Bildschirmfoto vom 2023-11-13 10-34-50](https://github.com/Sjoerd1993/Graphs/assets/59118042/760b2426-b89e-41d2-bdb9-0f1cc08076e0)
![Bildschirmfoto vom 2023-11-13 10-34-40](https://github.com/Sjoerd1993/Graphs/assets/59118042/bd77371b-9c4b-4aa1-8b31-e086059094cf)
