### PR TITLE
Do not revert rcparams

### DIFF
--- a/src/canvas.py
+++ b/src/canvas.py
@@ -87,7 +87,6 @@ class Canvas(FigureCanvas, Graphs.CanvasInterface):
         style context. Bind `items` to `data.items` and all figure settings
         attributes to their respective values.
         """
-        orig_params = dict(pyplot.rcParams.copy())
         self._style_params = style_params
         pyplot.rcParams.update(self._style_params)  # apply style_params
         GObject.Object.__init__(self, application=application, can_focus=False)
@@ -119,7 +118,6 @@ class Canvas(FigureCanvas, Graphs.CanvasInterface):
         zoom_gesture = Gtk.GestureZoom.new()
         zoom_gesture.connect("scale-changed", self._on_zoom_gesture)
         self.add_controller(zoom_gesture)
-        dict.update(pyplot.rcParams, orig_params)  # revert rcParams
 
     def get_application(self):
         """Get application property."""


### PR DESCRIPTION
I found the root issue behind bug #567. The main issue is in line 122 in `canvas.py`:
```
        dict.update(pyplot.rcParams, orig_params)  # revert rcParams
```

The `orig_params` dictionary always holds `xtick.visible` and `ytick.visible` equal to `False`, as this is just simply the rcparams in the matplotlib defaults. For some reason, when setting `rcparams` back to the defaults, it copies the minor tick settings back to these defaults as well. I am a bit stumped about why this does not happen for e.g. `ytick.direction` though. If I set `        pyplot.rcParams["ytick.minor.visible"] = True` at the end of the init function, then the minor ticks on the y axis are turned on. Even though only rcParams have been updated, while these are not even used directly. From what I can tell, the `ax.tick_params` somehow gets trumped to whatever `pyplot.rcParams` has set. 

As far as I know, we do not need `rcParams` to be reset after init. But I am not 100% sure here, perhaps it's necessary to avoid left-overs from previous styles. I've noticed for instance that font settings do not always properly reset to the default value if a style with custom font was set, and then a style is set that does not have a font set. For this reason, this now updates the style to the default `rcParams` before applying a new style. So this issue with the fonts not setting seems fixed here at least.