### PR TITLE
Do not draw frame

### DIFF
--- a/data/styles/adwaita-dark.mplstyle
+++ b/data/styles/adwaita-dark.mplstyle
@@ -39,6 +39,12 @@ lines.dotted_pattern: 1, 3
 lines.scale_dashes: False
 markers.fillstyle: full
 
+# axes
+axes.spines.bottom: False
+axes.spines.left: False
+axes.spines.top: False
+axes.spines.right: False
+
 # ticks
 xtick.direction: in
 xtick.minor.visible: True

--- a/data/styles/adwaita.mplstyle
+++ b/data/styles/adwaita.mplstyle
@@ -86,7 +86,7 @@ xtick.color: 5E5C64
 ytick.color: 5E5C64
 axes.edgecolor: 5E5C64
 grid.color: 9A9996
-axes.facecolor: FFFFFF
+axes.facecolor: FAFAFA
 figure.facecolor: FAFAFA
 figure.edgecolor: FAFAFA
 

--- a/data/styles/adwaita.mplstyle
+++ b/data/styles/adwaita.mplstyle
@@ -39,6 +39,12 @@ lines.dotted_pattern: 1, 3
 lines.scale_dashes: False
 markers.fillstyle: full
 
+# axes
+axes.spines.bottom: False
+axes.spines.left: False
+axes.spines.top: False
+axes.spines.right: False
+
 # ticks
 xtick.direction: in
 xtick.minor.visible: True

--- a/data/styles/bmh.mplstyle
+++ b/data/styles/bmh.mplstyle
@@ -39,6 +39,12 @@ lines.dotted_pattern: 1, 3
 lines.scale_dashes: False
 markers.fillstyle: full
 
+# axes
+axes.spines.bottom: True
+axes.spines.left: True
+axes.spines.top: True
+axes.spines.right: True
+
 # ticks
 xtick.direction: in
 xtick.minor.visible: False

--- a/data/styles/classic.mplstyle
+++ b/data/styles/classic.mplstyle
@@ -39,6 +39,12 @@ lines.dotted_pattern: 1, 3
 lines.scale_dashes: False
 markers.fillstyle: full
 
+# axes
+axes.spines.bottom: True
+axes.spines.left: True
+axes.spines.top: True
+axes.spines.right: True
+
 # ticks
 xtick.direction: in
 xtick.minor.visible: False
@@ -144,10 +150,6 @@ axes.unicode_minus: True
 axes.autolimit_mode: round_numbers
 axes.xmargin: 0
 axes.ymargin: 0
-axes.spines.bottom: True
-axes.spines.left: True
-axes.spines.right: True
-axes.spines.top: True
 polaraxes.grid: True
 axes3d.grid: True
 

--- a/data/styles/dark-background.mplstyle
+++ b/data/styles/dark-background.mplstyle
@@ -39,6 +39,12 @@ lines.dotted_pattern: 1, 3
 lines.scale_dashes: False
 markers.fillstyle: full
 
+# axes
+axes.spines.bottom: True
+axes.spines.left: True
+axes.spines.top: True
+axes.spines.right: True
+
 # ticks
 xtick.direction: out
 xtick.minor.visible: False

--- a/data/styles/fivethirtyeight.mplstyle
+++ b/data/styles/fivethirtyeight.mplstyle
@@ -39,6 +39,12 @@ lines.dotted_pattern: 1, 3
 lines.scale_dashes: False
 markers.fillstyle: full
 
+# axes
+axes.spines.bottom: True
+axes.spines.left: True
+axes.spines.top: True
+axes.spines.right: True
+
 # ticks
 xtick.direction: out
 xtick.minor.visible: False

--- a/data/styles/ggplot.mplstyle
+++ b/data/styles/ggplot.mplstyle
@@ -39,6 +39,12 @@ lines.dotted_pattern: 1, 3
 lines.scale_dashes: False
 markers.fillstyle: full
 
+# axes
+axes.spines.bottom: True
+axes.spines.left: True
+axes.spines.top: True
+axes.spines.right: True
+
 # ticks
 xtick.direction: out
 xtick.minor.visible: False

--- a/data/styles/grayscale.mplstyle
+++ b/data/styles/grayscale.mplstyle
@@ -39,6 +39,12 @@ lines.dotted_pattern: 1, 3
 lines.scale_dashes: False
 markers.fillstyle: full
 
+# axes
+axes.spines.bottom: True
+axes.spines.left: True
+axes.spines.top: True
+axes.spines.right: True
+
 # ticks
 xtick.direction: out
 xtick.minor.visible: False

--- a/data/styles/seaborn-bright.mplstyle
+++ b/data/styles/seaborn-bright.mplstyle
@@ -39,6 +39,12 @@ lines.dotted_pattern: 1, 3
 lines.scale_dashes: False
 markers.fillstyle: full
 
+# axes
+axes.spines.bottom: True
+axes.spines.left: True
+axes.spines.top: True
+axes.spines.right: True
+
 # ticks
 xtick.direction: out
 xtick.minor.visible: False

--- a/data/styles/seaborn-colorblind.mplstyle
+++ b/data/styles/seaborn-colorblind.mplstyle
@@ -39,6 +39,12 @@ lines.dotted_pattern: 1, 3
 lines.scale_dashes: False
 markers.fillstyle: full
 
+# axes
+axes.spines.bottom: True
+axes.spines.left: True
+axes.spines.top: True
+axes.spines.right: True
+
 # ticks
 xtick.direction: out
 xtick.minor.visible: False

--- a/data/styles/seaborn-dark-palette.mplstyle
+++ b/data/styles/seaborn-dark-palette.mplstyle
@@ -39,6 +39,12 @@ lines.dotted_pattern: 1, 3
 lines.scale_dashes: False
 markers.fillstyle: full
 
+# axes
+axes.spines.bottom: True
+axes.spines.left: True
+axes.spines.top: True
+axes.spines.right: True
+
 # ticks
 xtick.direction: out
 xtick.minor.visible: False

--- a/data/styles/seaborn-dark.mplstyle
+++ b/data/styles/seaborn-dark.mplstyle
@@ -39,6 +39,12 @@ lines.dotted_pattern: 1, 3
 lines.scale_dashes: False
 markers.fillstyle: full
 
+# axes
+axes.spines.bottom: True
+axes.spines.left: True
+axes.spines.top: True
+axes.spines.right: True
+
 # ticks
 xtick.direction: out
 xtick.minor.visible: False

--- a/data/styles/seaborn-darkgrid.mplstyle
+++ b/data/styles/seaborn-darkgrid.mplstyle
@@ -39,6 +39,12 @@ lines.dotted_pattern: 1, 3
 lines.scale_dashes: False
 markers.fillstyle: full
 
+# axes
+axes.spines.bottom: True
+axes.spines.left: True
+axes.spines.top: True
+axes.spines.right: True
+
 # ticks
 xtick.direction: out
 xtick.minor.visible: False

--- a/data/styles/seaborn-deep.mplstyle
+++ b/data/styles/seaborn-deep.mplstyle
@@ -39,6 +39,12 @@ lines.dotted_pattern: 1, 3
 lines.scale_dashes: False
 markers.fillstyle: full
 
+# axes
+axes.spines.bottom: True
+axes.spines.left: True
+axes.spines.top: True
+axes.spines.right: True
+
 # ticks
 xtick.direction: out
 xtick.minor.visible: False

--- a/data/styles/seaborn-muted.mplstyle
+++ b/data/styles/seaborn-muted.mplstyle
@@ -39,6 +39,12 @@ lines.dotted_pattern: 1, 3
 lines.scale_dashes: False
 markers.fillstyle: full
 
+# axes
+axes.spines.bottom: True
+axes.spines.left: True
+axes.spines.top: True
+axes.spines.right: True
+
 # ticks
 xtick.direction: out
 xtick.minor.visible: False

--- a/data/styles/seaborn-notebook.mplstyle
+++ b/data/styles/seaborn-notebook.mplstyle
@@ -39,6 +39,12 @@ lines.dotted_pattern: 1, 3
 lines.scale_dashes: False
 markers.fillstyle: full
 
+# axes
+axes.spines.bottom: True
+axes.spines.left: True
+axes.spines.top: True
+axes.spines.right: True
+
 # ticks
 xtick.direction: out
 xtick.minor.visible: False

--- a/data/styles/seaborn-paper.mplstyle
+++ b/data/styles/seaborn-paper.mplstyle
@@ -39,6 +39,12 @@ lines.dotted_pattern: 1, 3
 lines.scale_dashes: False
 markers.fillstyle: full
 
+# axes
+axes.spines.bottom: True
+axes.spines.left: True
+axes.spines.top: True
+axes.spines.right: True
+
 # ticks
 xtick.direction: out
 xtick.minor.visible: False

--- a/data/styles/seaborn-pastel.mplstyle
+++ b/data/styles/seaborn-pastel.mplstyle
@@ -39,6 +39,12 @@ lines.dotted_pattern: 1, 3
 lines.scale_dashes: False
 markers.fillstyle: full
 
+# axes
+axes.spines.bottom: True
+axes.spines.left: True
+axes.spines.top: True
+axes.spines.right: True
+
 # ticks
 xtick.direction: out
 xtick.minor.visible: False

--- a/data/styles/seaborn-poster.mplstyle
+++ b/data/styles/seaborn-poster.mplstyle
@@ -39,6 +39,12 @@ lines.dotted_pattern: 1, 3
 lines.scale_dashes: False
 markers.fillstyle: full
 
+# axes
+axes.spines.bottom: True
+axes.spines.left: True
+axes.spines.top: True
+axes.spines.right: True
+
 # ticks
 xtick.direction: out
 xtick.minor.visible: False

--- a/data/styles/seaborn-talk.mplstyle
+++ b/data/styles/seaborn-talk.mplstyle
@@ -39,6 +39,12 @@ lines.dotted_pattern: 1, 3
 lines.scale_dashes: False
 markers.fillstyle: full
 
+# axes
+axes.spines.bottom: True
+axes.spines.left: True
+axes.spines.top: True
+axes.spines.right: True
+
 # ticks
 xtick.direction: out
 xtick.minor.visible: False

--- a/data/styles/seaborn-ticks.mplstyle
+++ b/data/styles/seaborn-ticks.mplstyle
@@ -39,6 +39,12 @@ lines.dotted_pattern: 1, 3
 lines.scale_dashes: False
 markers.fillstyle: full
 
+# axes
+axes.spines.bottom: True
+axes.spines.left: True
+axes.spines.top: True
+axes.spines.right: True
+
 # ticks
 xtick.direction: out
 xtick.minor.visible: False

--- a/data/styles/seaborn-white.mplstyle
+++ b/data/styles/seaborn-white.mplstyle
@@ -39,6 +39,12 @@ lines.dotted_pattern: 1, 3
 lines.scale_dashes: False
 markers.fillstyle: full
 
+# axes
+axes.spines.bottom: True
+axes.spines.left: True
+axes.spines.top: True
+axes.spines.right: True
+
 # ticks
 xtick.direction: out
 xtick.minor.visible: False

--- a/data/styles/seaborn-whitegrid.mplstyle
+++ b/data/styles/seaborn-whitegrid.mplstyle
@@ -39,6 +39,12 @@ lines.dotted_pattern: 1, 3
 lines.scale_dashes: False
 markers.fillstyle: full
 
+# axes
+axes.spines.bottom: True
+axes.spines.left: True
+axes.spines.top: True
+axes.spines.right: True
+
 # ticks
 xtick.direction: out
 xtick.minor.visible: False

--- a/data/styles/seaborn.mplstyle
+++ b/data/styles/seaborn.mplstyle
@@ -39,6 +39,12 @@ lines.dotted_pattern: 1, 3
 lines.scale_dashes: False
 markers.fillstyle: full
 
+# axes
+axes.spines.bottom: True
+axes.spines.left: True
+axes.spines.top: True
+axes.spines.right: True
+
 # ticks
 xtick.direction: out
 xtick.minor.visible: False

--- a/data/styles/solarized-light.mplstyle
+++ b/data/styles/solarized-light.mplstyle
@@ -39,6 +39,12 @@ lines.dotted_pattern: 1, 3
 lines.scale_dashes: False
 markers.fillstyle: full
 
+# axes
+axes.spines.bottom: True
+axes.spines.left: True
+axes.spines.top: True
+axes.spines.right: True
+
 # ticks
 xtick.direction: out
 xtick.minor.visible: False

--- a/data/styles/tableau-colorblind10.mplstyle
+++ b/data/styles/tableau-colorblind10.mplstyle
@@ -39,6 +39,12 @@ lines.dotted_pattern: 1, 3
 lines.scale_dashes: False
 markers.fillstyle: full
 
+# axes
+axes.spines.bottom: True
+axes.spines.left: True
+axes.spines.top: True
+axes.spines.right: True
+
 # ticks
 xtick.direction: out
 xtick.minor.visible: False

--- a/data/styles/thesis.mplstyle
+++ b/data/styles/thesis.mplstyle
@@ -39,6 +39,12 @@ lines.dotted_pattern: 1, 3
 lines.scale_dashes: False
 markers.fillstyle: full
 
+# axes
+axes.spines.bottom: True
+axes.spines.left: True
+axes.spines.top: True
+axes.spines.right: True
+
 
 # ticks
 xtick.direction: in

--- a/data/styles/yaru-dark.mplstyle
+++ b/data/styles/yaru-dark.mplstyle
@@ -39,6 +39,12 @@ lines.dotted_pattern: 1, 3
 lines.scale_dashes: False
 markers.fillstyle: full
 
+# axes
+axes.spines.bottom: False
+axes.spines.left: False
+axes.spines.top: False
+axes.spines.right: False
+
 # ticks
 xtick.direction: in
 xtick.minor.visible: True

--- a/data/styles/yaru.mplstyle
+++ b/data/styles/yaru.mplstyle
@@ -39,6 +39,12 @@ lines.dotted_pattern: 1, 3
 lines.scale_dashes: False
 markers.fillstyle: full
 
+# axes
+axes.spines.bottom: False
+axes.spines.left: False
+axes.spines.top: False
+axes.spines.right: False
+
 # ticks
 xtick.direction: in
 xtick.minor.visible: True

--- a/data/ui/style_editor.blp
+++ b/data/ui/style_editor.blp
@@ -467,6 +467,10 @@ template $GraphsStyleEditor : Adw.NavigationPage {
                 };
               }
             }
+
+            Adw.SwitchRow draw_frame {
+              title: _("Draw Frame");
+            }
           }
         }
       }

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -261,8 +261,8 @@ class Canvas(FigureCanvas, Graphs.CanvasInterface):
             # Set tick where requested, as long as that axis is not occupied
             # and visible
             axis.tick_params(which=ticks, **{
-                direction: draw_frame and not visible_axes[i]
-                or direction in directions
+                direction: (draw_frame and not visible_axes[i]
+                            or direction in directions)
                 and params[f"{'x' if i < 2 else 'y'}tick.{direction}"]
                 for i, direction in enumerate(possible_directions)
             })

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -246,8 +246,8 @@ class Canvas(FigureCanvas, Graphs.CanvasInterface):
             ["top", "right"],     # top_right_axis
         ]
         if not any(visible_axes):
-            visible_axes = [True, False, True, False] # Left and bottom
-            used_axes = [True, False, False, False] # self.axis visible
+            visible_axes = [True, False, True, False]  # Left and bottom
+            used_axes = [True, False, False, False]  # self.axis visible
             self._legend_axis = self._axis
 
         params = self._style_params
@@ -258,12 +258,11 @@ class Canvas(FigureCanvas, Graphs.CanvasInterface):
             axis.get_xaxis().set_visible(False)
             axis.get_yaxis().set_visible(False)
             # Set tick where requested, as long as that axis is not occupied
-            if used: # (Or if frame)
-                axis.tick_params(which=ticks, **{
-                    key: params[f"{'x' if i < 2 else 'y'}tick.{key}"]
-                    and (key in directions or not visible_axes[i])
-                    for i, key in enumerate(["bottom", "top", "left", "right"])
-                })
+            axis.tick_params(which=ticks, **{
+                key: params[f"{'x' if i < 2 else 'y'}tick.{key}"]
+                and (key in directions or not visible_axes[i])
+                for i, key in enumerate(["bottom", "top", "left", "right"])
+            })
             for handle in axis.lines + axis.texts:
                 handle.remove()
             axis_legend = axis.get_legend()
@@ -273,12 +272,14 @@ class Canvas(FigureCanvas, Graphs.CanvasInterface):
                 self._legend_axis = axis
                 used_directions += directions
 
+        used_directions = list(set(used_directions))  # Remove duplicates
         for direction in ["bottom", "left", "top", "right"]:
             for axis in self.axes:
                 axis.spines[direction].set_visible(
                     direction in used_directions)
-                axis.tick_params(which="both",
-                    **{direction: direction in used_directions})
+                # No ticks on unused axes, skip these lines if frame is on
+                if direction not in used_directions:
+                    axis.tick_params(which=ticks, **{direction: False})
 
         self._axis.get_xaxis().set_visible(visible_axes[0])
         self._top_left_axis.get_xaxis().set_visible(visible_axes[1])

--- a/src/styles.py
+++ b/src/styles.py
@@ -346,6 +346,8 @@ STYLE_DICT = {
     "linewidth": ["lines.linewidth"],
     "markers": ["lines.marker"],
     "markersize": ["lines.markersize"],
+    "draw_frame": ["axes.spines.bottom", "axes.spines.left",
+                   "axes.spines.top", "axes.spines.right"],
     "tick_direction": ["xtick.direction", "ytick.direction"],
     "minor_ticks": ["xtick.minor.visible", "ytick.minor.visible"],
     "major_tick_width": ["xtick.major.width", "ytick.major.width"],
@@ -404,6 +406,7 @@ class StyleEditor(Adw.NavigationPage):
     linewidth = Gtk.Template.Child()
     markers = Gtk.Template.Child()
     markersize = Gtk.Template.Child()
+    draw_frame = Gtk.Template.Child()
     tick_direction = Gtk.Template.Child()
     minor_ticks = Gtk.Template.Child()
     major_tick_width = Gtk.Template.Child()


### PR DESCRIPTION
Adapts some of the principles discussed in issue #570.
In this PR, only a line is drawn for the axes that are actually used, the ticks and line is hidden for unused axes. On top of that, the canvas background in light mode is set to match the rest of the application. See screenshot for the new default styling.

![image](https://github.com/Sjoerd1993/Graphs/assets/68477016/2d4a6f24-0042-4bf2-a11e-abc3ba3d5a54)


I'd also like to add the functionality to turn back on such a frame, I think it makes sense to set this on a per-style basis. Also, in that case it should be turned on in most of these style sheets, as those are all based on existing matplotlib styles that do have a frame around the entire plot. But again, I'm still open for discussion on this, also to the idea of integrating that in "Figure Settings" instead.

But adding the option to turn that on and skip this new logic could be done in a separate PR.