### PR TITLE
Redesign curve fitting dialog

### DIFF
--- a/data/ui/curve_fitting.blp
+++ b/data/ui/curve_fitting.blp
@@ -8,7 +8,7 @@ template $GraphsCurveFittingTool : Adw.Window {
   default-width: 1000;
   default-height: 650;
   width-request: 305;
-  height-request: 430;
+  height-request: 410;
 
   ShortcutController {
     Shortcut {
@@ -75,7 +75,7 @@ template $GraphsCurveFittingTool : Adw.Window {
             [end]
             ScrolledWindow {
               margin-top: 6;
-              height-request: 175;
+              height-request: 150;
               margin-bottom: 6;
               margin-start: 12;
               margin-end: 12;

--- a/data/ui/curve_fitting.blp
+++ b/data/ui/curve_fitting.blp
@@ -35,26 +35,26 @@ template $GraphsCurveFittingTool : Adw.Window {
       Box{
         orientation: vertical;
         vexpand: true;
-        width-request: 275;
+        width-request: 285;
         Adw.EntryRow equation {
           margin-top: 12;
-          margin-bottom: 6;
+          margin-bottom: 12;
           margin-start: 12;
-          margin-end: 12;
+          margin-end: 3;
           title: _("Equation");
           styles ["card"]
         }
         ScrolledWindow {
           vexpand: true;
-          height-request: 125;
+          height-request: 100;
           hscrollbar-policy: never;
           Box {
             vexpand: true;
             orientation: vertical;
             margin-start: 12;
-            margin-end: 12;
+            margin-end: 3;
             Box fitting_params {
-              margin-top: 6;
+              margin-top: 12;
               spacing: 12;
               orientation: vertical;
             }
@@ -64,9 +64,9 @@ template $GraphsCurveFittingTool : Adw.Window {
         ScrolledWindow {
           margin-top: 6;
           height-request: 150;
-          margin-bottom: 6;
+          margin-bottom: 12;
           margin-start: 12;
-          margin-end: 12;
+          margin-end: 3;
           TextView text_view {
             vexpand: false;
             top-margin: 12;
@@ -87,6 +87,6 @@ template $GraphsCurveFittingTool : Adw.Window {
           title: _("Canvas Failed to Load");
         };
       }
-    }
+    };
   }
 }

--- a/data/ui/curve_fitting.blp
+++ b/data/ui/curve_fitting.blp
@@ -7,6 +7,9 @@ template $GraphsCurveFittingTool : Adw.Window {
   focus-widget: confirm_button;
   default-width: 1000;
   default-height: 650;
+  width-request: 305;
+  height-request: 400;
+
   ShortcutController {
     Shortcut {
       trigger: "Escape";
@@ -14,89 +17,109 @@ template $GraphsCurveFittingTool : Adw.Window {
     }
   }
 
-  Adw.ToolbarView {
-    [top]
-    Adw.HeaderBar {
-      show-end-title-buttons: false;
-      [start]
-      Button {
-        label: _("Cancel");
-        action-name: "window.close";
-      }
-
-      [end]
-      Button confirm_button {
-        label: _("Add fit to data");
-        styles ["suggested-action"]
-      }
+  Adw.Breakpoint {
+    condition ("max-width: 725sp")
+    setters {
+      split_view.collapsed: true;
     }
+  }
 
-    content: Box {
-      Box{
+  content: Adw.ToolbarView {
+    top-bar-style: flat;
+    content: Adw.OverlaySplitView split_view {
+      show-sidebar: bind show_sidebar_button.active;
+      notify => $on_sidebar_toggle();
+      sidebar: Box {
         orientation: vertical;
-        vexpand: false;
-        width-request: 300;
-        Adw.EntryRow equation {
-          margin-top: 12;
-          margin-bottom: 12;
-          margin-start: 12;
-          margin-end: 12;
-          title: _("Equation");
-          styles ["card"]
+        Adw.HeaderBar {
+          styles ["flat"]
+          [start]
+          Button {
+            label: _("Cancel");
+            action-name: "window.close";
+          }
+          title-widget: Adw.WindowTitle title_widget {
+            title: "Graphs";
+          };
         }
-        Separator {
-          orientation: vertical;
-        }
-        ScrolledWindow {
-          vexpand: false;
-          height-request: 370;
-          hscrollbar-policy: never;
-          Box {
-            vexpand: false;
+
+        Box {
+          Box{
             orientation: vertical;
-            margin-start: 12;
-            margin-end: 12;
-            Box fitting_params {
+            vexpand: true;
+            width-request: 275;
+            Adw.EntryRow equation {
               margin-top: 12;
-              spacing: 12;
-              orientation: vertical;
+              margin-bottom: 6;
+              margin-start: 12;
+              margin-end: 12;
+              title: _("Equation");
+              styles ["card"]
+            }
+            ScrolledWindow fitting_param_entries {
+              vexpand: true;
+              height-request: 125;
+              hscrollbar-policy: never;
+              Box {
+                vexpand: true;
+                orientation: vertical;
+                margin-start: 12;
+                margin-end: 12;
+                Box fitting_params {
+                  margin-top: 6;
+                  spacing: 12;
+                  orientation: vertical;
+                }
+              }
+            }
+            [end]
+            ScrolledWindow {
+              margin-top: 6;
+              height-request: 80;
+              margin-bottom: 6;
+              margin-start: 12;
+              margin-end: 12;
+              TextView text_view {
+                vexpand: true;
+                top-margin: 12;
+                left-margin: 12;
+                bottom-margin: 12;
+                editable: false;
+                styles ["card"]
+              }
             }
           }
         }
-        [separator]
-        Separator {
-          orientation: horizontal;
-        }
-        ScrolledWindow {
-          vexpand: true;
-          margin-top: 6;
-          margin-bottom: 6;
-          margin-start: 12;
-          margin-end: 12;
-          TextView text_view {
-            valign: start;
-            top-margin: 12;
-            left-margin: 12;
-            bottom-margin: 12;
-            editable: false;
-            styles ["card"]
+      };
+      content:
+      Box {
+      orientation: vertical;
+        Adw.HeaderBar {
+          styles ["flat"]
+          show-end-title-buttons: false;
+          ToggleButton show_sidebar_button {
+            icon-name: "sidebar-show-symbolic";
+            tooltip-text: _("Toggle Sidebar");
+            active: bind split_view.show-sidebar;
+            visible: bind split_view.collapsed;
+          }
+          [end]
+          Button confirm_button {
+            label: _("Add Fit to Data");
+            styles ["suggested-action"]
           }
         }
-      }
-      [separator]
-      Separator {
-        orientation: vertical;
-      }
-      Adw.ToastOverlay toast_overlay {
-        focusable: true;
-        height-request: 150;
-        width-request: 300;
-        hexpand: true;
-        child: Adw.StatusPage {
-          icon-name: "dialog-error-symbolic";
-          title: _("Canvas Failed to Load");
-        };
-      }
+        Adw.ToastOverlay toast_overlay {
+          focusable: true;
+          height-request: 150;
+          width-request: 300;
+          hexpand: true;
+          child: Adw.StatusPage {
+            icon-name: "dialog-error-symbolic";
+            title: _("Canvas Failed to Load");
+          };
+        }
+      };
     };
-  }
+  };
 }

--- a/data/ui/curve_fitting.blp
+++ b/data/ui/curve_fitting.blp
@@ -87,6 +87,6 @@ template $GraphsCurveFittingTool : Adw.Window {
           title: _("Canvas Failed to Load");
         };
       }
-    };
+    }
   }
 }

--- a/data/ui/curve_fitting.blp
+++ b/data/ui/curve_fitting.blp
@@ -7,9 +7,6 @@ template $GraphsCurveFittingTool : Adw.Window {
   focus-widget: confirm_button;
   default-width: 1000;
   default-height: 650;
-  width-request: 305;
-  height-request: 410;
-
   ShortcutController {
     Shortcut {
       trigger: "Escape";
@@ -17,109 +14,79 @@ template $GraphsCurveFittingTool : Adw.Window {
     }
   }
 
-  Adw.Breakpoint {
-    condition ("max-width: 725sp")
-    setters {
-      split_view.collapsed: true;
+  Adw.ToolbarView {
+    [top]
+    Adw.HeaderBar {
+      show-end-title-buttons: false;
+      [start]
+      Button {
+        label: _("Cancel");
+        action-name: "window.close";
+      }
+
+      [end]
+      Button confirm_button {
+        label: _("Add Fit to Data");
+        styles ["suggested-action"]
+      }
+    }
+
+    Box {
+      Box{
+        orientation: vertical;
+        vexpand: true;
+        width-request: 275;
+        Adw.EntryRow equation {
+          margin-top: 12;
+          margin-bottom: 6;
+          margin-start: 12;
+          margin-end: 12;
+          title: _("Equation");
+          styles ["card"]
+        }
+        ScrolledWindow {
+          vexpand: true;
+          height-request: 125;
+          hscrollbar-policy: never;
+          Box {
+            vexpand: true;
+            orientation: vertical;
+            margin-start: 12;
+            margin-end: 12;
+            Box fitting_params {
+              margin-top: 6;
+              spacing: 12;
+              orientation: vertical;
+            }
+          }
+        }
+        [end]
+        ScrolledWindow {
+          margin-top: 6;
+          height-request: 150;
+          margin-bottom: 6;
+          margin-start: 12;
+          margin-end: 12;
+          TextView text_view {
+            vexpand: false;
+            top-margin: 12;
+            left-margin: 12;
+            bottom-margin: 12;
+            editable: false;
+            styles ["card"]
+          }
+        }
+      }
+      Adw.ToastOverlay toast_overlay {
+        focusable: true;
+        height-request: 150;
+        width-request: 300;
+        hexpand: true;
+        child: Adw.StatusPage {
+          icon-name: "dialog-error-symbolic";
+          title: _("Canvas Failed to Load");
+        };
+      }
     }
   }
-
-  content: Adw.ToolbarView {
-    top-bar-style: flat;
-    content: Adw.OverlaySplitView split_view {
-      show-sidebar: bind show_sidebar_button.active;
-      notify => $on_sidebar_toggle();
-      sidebar: Box {
-        orientation: vertical;
-        Adw.HeaderBar {
-          styles ["flat"]
-          [start]
-          Button {
-            label: _("Cancel");
-            action-name: "window.close";
-          }
-          title-widget: Adw.WindowTitle title_widget {
-            title: "Graphs";
-          };
-        }
-
-        Box {
-          Box{
-            orientation: vertical;
-            vexpand: true;
-            width-request: 275;
-            Adw.EntryRow equation {
-              margin-top: 12;
-              margin-bottom: 6;
-              margin-start: 12;
-              margin-end: 12;
-              title: _("Equation");
-              styles ["card"]
-            }
-            ScrolledWindow fitting_param_entries {
-              vexpand: true;
-              height-request: 125;
-              hscrollbar-policy: never;
-              Box {
-                vexpand: true;
-                orientation: vertical;
-                margin-start: 12;
-                margin-end: 12;
-                Box fitting_params {
-                  margin-top: 6;
-                  spacing: 12;
-                  orientation: vertical;
-                }
-              }
-            }
-            [end]
-            ScrolledWindow {
-              margin-top: 6;
-              height-request: 150;
-              margin-bottom: 6;
-              margin-start: 12;
-              margin-end: 12;
-              TextView text_view {
-                vexpand: false;
-                top-margin: 12;
-                left-margin: 12;
-                bottom-margin: 12;
-                editable: false;
-                styles ["card"]
-              }
-            }
-          }
-        }
-      };
-      content:
-      Box {
-      orientation: vertical;
-        Adw.HeaderBar {
-          styles ["flat"]
-          show-end-title-buttons: false;
-          ToggleButton show_sidebar_button {
-            icon-name: "sidebar-show-symbolic";
-            tooltip-text: _("Toggle Sidebar");
-            active: bind split_view.show-sidebar;
-            visible: bind split_view.collapsed;
-          }
-          [end]
-          Button confirm_button {
-            label: _("Add Fit to Data");
-            styles ["suggested-action"]
-          }
-        }
-        Adw.ToastOverlay toast_overlay {
-          focusable: true;
-          height-request: 150;
-          width-request: 300;
-          hexpand: true;
-          child: Adw.StatusPage {
-            icon-name: "dialog-error-symbolic";
-            title: _("Canvas Failed to Load");
-          };
-        }
-      };
-    };
-  };
 }

--- a/data/ui/curve_fitting.blp
+++ b/data/ui/curve_fitting.blp
@@ -8,7 +8,7 @@ template $GraphsCurveFittingTool : Adw.Window {
   default-width: 1000;
   default-height: 650;
   width-request: 305;
-  height-request: 400;
+  height-request: 430;
 
   ShortcutController {
     Shortcut {
@@ -75,12 +75,12 @@ template $GraphsCurveFittingTool : Adw.Window {
             [end]
             ScrolledWindow {
               margin-top: 6;
-              height-request: 80;
+              height-request: 175;
               margin-bottom: 6;
               margin-start: 12;
               margin-end: 12;
               TextView text_view {
-                vexpand: true;
+                vexpand: false;
                 top-margin: 12;
                 left-margin: 12;
                 bottom-margin: 12;

--- a/data/ui/fitting_parameters.blp
+++ b/data/ui/fitting_parameters.blp
@@ -22,7 +22,7 @@ template $GraphsFittingParameterEntry : Box {
         }
       }
       Adw.EntryRow initial {
-        title: "Initial guess";
+        title: _("Initial guess");
         text: "1";
         layout {
           column: 0;
@@ -32,7 +32,7 @@ template $GraphsFittingParameterEntry : Box {
         styles ["card"]
       }
       Adw.EntryRow lower_bound {
-        title: "Minimum";
+        title: _("Minimum");
         text: "-inf";
         layout {
           column: 0;
@@ -41,7 +41,7 @@ template $GraphsFittingParameterEntry : Box {
         styles ["card"]
       }
       Adw.EntryRow upper_bound {
-        title: "Maximum";
+        title: _("Maximum");
         text: "inf";
         layout {
           column: 1;

--- a/data/ui/fitting_parameters.blp
+++ b/data/ui/fitting_parameters.blp
@@ -12,7 +12,7 @@ template $GraphsFittingParameterEntry : Box {
       Label label {
         justify: left;
         use-markup: true;
-        margin-bottom: 6;
+        margin-bottom: 4;
         hexpand: false;
         halign: start;
         layout {

--- a/data/ui/fitting_parameters.blp
+++ b/data/ui/fitting_parameters.blp
@@ -4,67 +4,50 @@ using Adw 1;
 template $GraphsFittingParameterEntry : Box {
   orientation: vertical;
   Adw.PreferencesGroup {
-    styles ["card"]
     Grid {
-      margin-bottom: 12;
-      margin-top: 12;
-      margin-start: 12;
-      margin-end: 12;
-      row-spacing: 6;
-      column-spacing: 3;
+      margin-bottom: 4;
+      margin-top: 4;
+      column-spacing: 4;
+      row-spacing: 4;
       Label label {
+        justify: left;
         use-markup: true;
-        margin-bottom: 3;
-        layout {
-        column: 0;
-        row: 0;
-        column-span: 3;
-        }
-      }
-      Label {
+        margin-bottom: 6;
+        hexpand: false;
         halign: start;
-        label: _("Initial");
         layout {
           column: 0;
-          row: 1;
+          row: 0;
+          column-span: 2;
         }
       }
-      Label {
-        halign: start;
-        label: _("Min");
-        layout {
-          column: 1;
-          row: 1;
-        }
-      }
-      Label {
-        halign: start;
-        label: _("Max");
-        layout {
-          column: 2;
-          row: 1;
-        }
-      }
-      Entry initial {
+      Adw.EntryRow initial {
+        title: "Initial guess";
         text: "1";
         layout {
           column: 0;
+          row: 1;
+          column-span: 2;
+        }
+        styles ["card"]
+      }
+      Adw.EntryRow lower_bound {
+        title: "Minimum";
+        text: "-inf";
+        layout {
+          column: 0;
           row: 2;
         }
+        styles ["card"]
       }
-      Entry lower_bound {
-        text: "-inf";
+      Adw.EntryRow upper_bound {
+        title: "Maximum";
+        text: "inf";
         layout {
           column: 1;
           row: 2;
         }
-      }
-      Entry upper_bound {
-        text: "inf";
-        layout {
-          column: 2;
-          row: 2;
-        }
+        styles ["card"]
       }
     }
   }

--- a/src/curve_fitting.py
+++ b/src/curve_fitting.py
@@ -34,6 +34,10 @@ class CurveFittingWindow(Graphs.CurveFittingTool):
         style = application.get_figure_style_manager(
         ).get_system_style_params()
         canvas = Canvas(application, style)
+
+        figure_settings_main = application.get_data().get_figure_settings()
+        canvas.left_label = figure_settings_main.get_property("left_label")
+        canvas.bottom_label = figure_settings_main.get_property("bottom_label")
         self.param = []
         self.sigma = []
         self.r2 = 0
@@ -71,6 +75,8 @@ class CurveFittingWindow(Graphs.CurveFittingTool):
         axis.yscale = "linear"
         axis.xscale = "linear"
         canvas.highlight_enabled = False
+        canvas.toolbar = None
+        canvas._on_pick = None
         self.canvas = canvas
         self.fit_curve()
         self.set_entry_rows()

--- a/src/curve_fitting.py
+++ b/src/curve_fitting.py
@@ -27,7 +27,6 @@ class CurveFittingWindow(Graphs.CurveFittingTool):
         super().__init__(
             application=application, transient_for=application.get_window(),
         )
-        self.get_title_widget().set_title(application.props.name)
         self.equation = self.get_equation()
         ui.bind_values_to_settings(
             application.get_settings("curve-fitting"), self)

--- a/src/curve_fitting.py
+++ b/src/curve_fitting.py
@@ -20,12 +20,14 @@ class CurveFittingWindow(Graphs.CurveFittingTool):
     equation = GObject.Property(type=Adw.EntryRow)
     fitting_params = GObject.Property(type=Gtk.Box)
     text_view = GObject.Property(type=Gtk.TextView)
+    title_widget = GObject.Property(type=Adw.WindowTitle)
     toast_overlay = GObject.Property(type=Adw.ToastOverlay)
 
     def __init__(self, application, item):
         super().__init__(
             application=application, transient_for=application.get_window(),
         )
+        self.get_title_widget().set_title(application.props.name)
         self.equation = self.get_equation()
         ui.bind_values_to_settings(
             application.get_settings("curve-fitting"), self)

--- a/src/curve_fitting.vala
+++ b/src/curve_fitting.vala
@@ -12,6 +12,9 @@ namespace Graphs {
         public unowned Gtk.Box fitting_params { get; }
 
         [GtkChild]
+        public unowned Adw.OverlaySplitView split_view { get; }
+
+        [GtkChild]
         public unowned Adw.ToastOverlay toast_overlay { get; }
 
         [GtkChild]
@@ -19,6 +22,16 @@ namespace Graphs {
 
         [GtkChild]
         public unowned Gtk.Button confirm_button { get; }
+
+        [GtkChild]
+        public unowned Adw.WindowTitle title_widget { get; }
+
+        [GtkCallback]
+        private void on_sidebar_toggle () {
+            this.application.lookup_action ("toggle_sidebar").change_state (
+                new Variant.boolean (this.split_view.get_collapsed ())
+            );
+        }
         }
 
     public class FittingParameter : Object {

--- a/src/curve_fitting.vala
+++ b/src/curve_fitting.vala
@@ -12,9 +12,6 @@ namespace Graphs {
         public unowned Gtk.Box fitting_params { get; }
 
         [GtkChild]
-        public unowned Adw.OverlaySplitView split_view { get; }
-
-        [GtkChild]
         public unowned Adw.ToastOverlay toast_overlay { get; }
 
         [GtkChild]
@@ -22,16 +19,6 @@ namespace Graphs {
 
         [GtkChild]
         public unowned Gtk.Button confirm_button { get; }
-
-        [GtkChild]
-        public unowned Adw.WindowTitle title_widget { get; }
-
-        [GtkCallback]
-        private void on_sidebar_toggle () {
-            this.application.lookup_action ("toggle_sidebar").change_state (
-                new Variant.boolean (this.split_view.get_collapsed ())
-            );
-        }
         }
 
     public class FittingParameter : Object {


### PR DESCRIPTION
Redesigns the curve fitting dialog, addresses [the points in the GNOME Circle feedback](https://gitlab.gnome.org/Teams/Circle/-/issues/185), and makes the dialog more responsive for different screen sizes.

Before:
![image](https://github.com/Sjoerd1993/Graphs/assets/68477016/a1015d9c-5462-4282-81f7-e42404c4c1f2)

After:
![image](https://github.com/Sjoerd1993/Graphs/assets/68477016/ced53724-b0e0-4ea9-8615-02bd743e0854)
