### PR TITLE
Update yaru style

### DIFF
--- a/data/styles/yaru-dark.mplstyle
+++ b/data/styles/yaru-dark.mplstyle
@@ -88,11 +88,11 @@ text.color: FFFFFF
 axes.labelcolor: FFFFFF
 xtick.labelcolor: FFFFFF
 ytick.labelcolor: FFFFFF
-xtick.color: FFFFFF
-ytick.color: FFFFFF
-axes.edgecolor: FFFFFF
-grid.color: 878787
-axes.facecolor: 242424
+xtick.color: C0BFBC
+ytick.color: C0BFBC
+axes.edgecolor: C0BFBC
+grid.color: 77767B
+axes.facecolor: 2C2C2C
 figure.facecolor: 2C2C2C
 figure.edgecolor: 2C2C2C
 

--- a/data/styles/yaru.mplstyle
+++ b/data/styles/yaru.mplstyle
@@ -88,11 +88,11 @@ text.color: 000000
 axes.labelcolor: 000000
 xtick.labelcolor: 000000
 ytick.labelcolor: 000000
-xtick.color: 000000
-ytick.color: 000000
-axes.edgecolor: 000000
-grid.color: 646464
-axes.facecolor: FFFFFF
+xtick.color: 5E5C64
+ytick.color: 5E5C64
+axes.edgecolor: 5E5C64
+grid.color: 9A9996
+axes.facecolor: FAFAFA
 figure.facecolor: FAFAFA
 figure.edgecolor: FAFAFA
 


### PR DESCRIPTION
Updates the Yaru style to be in line with the recent changes in the Adwaita styling. That is, softer colors for the grids and axes, and with identical axes `edgecolor` and `facecolor`.