### PR TITLE
Save curve fit result as list

### DIFF
--- a/src/curve_fitting.py
+++ b/src/curve_fitting.py
@@ -244,7 +244,8 @@ class CurveFittingWindow(Graphs.CurveFittingTool):
         application.get_data().add_items([DataItem.new(
             style_manager.get_selected_style_params(),
             name=self.fitted_curve.get_name(),
-            xdata=self.fitted_curve.xdata, ydata=self.fitted_curve.ydata,
+            xdata=list(self.fitted_curve.xdata),
+            ydata=list(self.fitted_curve.ydata),
         )])
         self.destroy()
 


### PR DESCRIPTION
See title. The exported list of xdata in the curve fitting tool is saved as a numpy list. This leads to some clashes with some operations, where we expect a regular list. Making it impossible to perform operations on data that has been added using the "Add fit to data" button.

This simply forces these results to be a list. Solving above issue.