### PR TITLE
Improve style preview

### DIFF
--- a/src/style_io.py
+++ b/src/style_io.py
@@ -111,7 +111,7 @@ def write(file: Gio.File, name: str, style: RcParams):
                 wrapper.write(f"{key}: {value}\n")
 
 
-_PREVIEW_XDATA = numpy.linspace(0, 10, 1000)
+_PREVIEW_XDATA = numpy.linspace(0, 10, 30)
 _PREVIEW_YDATA1 = numpy.sin(_PREVIEW_XDATA)
 _PREVIEW_YDATA2 = numpy.cos(_PREVIEW_XDATA)
 
@@ -123,6 +123,10 @@ def generate_preview(style: RcParams) -> Gio.File:
         # set render size in inch
         figure = Figure(figsize=(5, 3))
         axis = figure.add_subplot()
+        axis.spines.bottom.set_visible(True)
+        axis.spines.left.set_visible(True)
+        if not style["axes.spines.top"]:
+            axis.tick_params(which="both", **{"top": False, "right": False})
         axis.plot(_PREVIEW_XDATA, _PREVIEW_YDATA1)
         axis.plot(_PREVIEW_XDATA, _PREVIEW_YDATA2)
         axis.set_xlabel(_("X Label"))


### PR DESCRIPTION
Makes some slight tweaks/fixes to the generated previews:

- Reduces the amount of data points so that distinct markers can be differentiated from each other
- Adds a spline for the bottom and left axes. These are currently missing if draw frame is turned off
- Removes the ticks from the top and right axes. Currently ticks are shown there, even if there's no spline. (When frame is off, and "ticks on right axes" or "ticks on top axes" are on)

![image](https://github.com/Sjoerd1993/Graphs/assets/68477016/8c56254c-813c-4aa8-aa83-80f6137a5e54)
