### PR TITLE
move to_dict to mixin

### DIFF
--- a/src/data.py
+++ b/src/data.py
@@ -211,7 +211,7 @@ class Data(GObject.Object, Graphs.DataInterface):
                     index = names.index(new_item.get_name())
                     existing_item = self[index]
                     self._current_batch.append(
-                        (2, (index, item.to_dict(existing_item))),
+                        (2, (index, existing_item.to_dict())),
                     )
                     new_item.set_uuid(existing_item.get_uuid())
 
@@ -250,7 +250,7 @@ class Data(GObject.Object, Graphs.DataInterface):
 
             self._add_item(new_item)
             self._current_batch.append(
-                (1, copy.deepcopy(item.to_dict(new_item))),
+                (1, copy.deepcopy(new_item.to_dict())),
             )
         self.optimize_limits()
         self.add_history_state()
@@ -263,7 +263,7 @@ class Data(GObject.Object, Graphs.DataInterface):
         """Delete specified items."""
         for item_ in items:
             self._current_batch.append(
-                (2, (self.index(item_), item.to_dict(item_))),
+                (2, (self.index(item_), item_.to_dict())),
             )
             self._delete_item(item_.get_uuid())
         self.notify("items")
@@ -296,7 +296,7 @@ class Data(GObject.Object, Graphs.DataInterface):
     def _set_data_copy(self) -> None:
         self._current_batch: list = []
         self._data_copy = copy.deepcopy(
-            {item_.get_uuid(): item.to_dict(item_) for item_ in self},
+            {item_.get_uuid(): item_.to_dict() for item_ in self},
         )
 
     def add_history_state(self, old_limits: misc.Limits = None) -> None:
@@ -471,7 +471,7 @@ class Data(GObject.Object, Graphs.DataInterface):
         figure_settings = self.get_figure_settings()
         return {
             "version": self.get_application().get_version(),
-            "data": [item.to_dict(item_) for item_ in self],
+            "data": [item_.to_dict() for item_ in self],
             "figure-settings": {
                 key: figure_settings.get_property(key)
                 for key in dir(figure_settings.props)

--- a/src/item.py
+++ b/src/item.py
@@ -18,12 +18,6 @@ def new_from_dict(dictionary: dict):
     return cls(**dictionary)
 
 
-def to_dict(item):
-    dictionary = {key: item.get_property(key) for key in dir(item.props)}
-    dictionary["type"] = item.__gtype_name__
-    return dictionary
-
-
 class _ItemMixin():
     def reset(self, old_style, new_style):
         for prop, (key, function) in self._style_properties.items():
@@ -40,6 +34,11 @@ class _ItemMixin():
             prop: style[key] if function is None else function(style[key])
             for prop, (key, function) in self._style_properties.items()
         }
+
+    def to_dict(self):
+        dictionary = {key: self.get_property(key) for key in dir(self.props)}
+        dictionary["type"] = self.__gtype_name__
+        return dictionary
 
 
 class DataItem(Graphs.Item, _ItemMixin):

--- a/src/item.py
+++ b/src/item.py
@@ -94,7 +94,7 @@ class TextItem(Graphs.Item, _ItemMixin):
         )
 
 
-class FillItem(Graphs.Item):
+class FillItem(Graphs.Item, _ItemMixin):
     __gtype_name__ = "GraphsFillItem"
 
     data = GObject.Property(type=object)


### PR DESCRIPTION
Moves the `to_dict()` function to be a method of any items, now that the mixin for other stuff exists.