### PR TITLE
Update shortcuts

### DIFF
--- a/data/ui/help_overlay.blp
+++ b/data/ui/help_overlay.blp
@@ -17,7 +17,7 @@ ShortcutsWindow help_overlay {
 
       ShortcutsShortcut {
         title: C_("shortcut window", "Open Figure Settings");
-        accelerator: "<primary><alt>comma";
+        accelerator: "<primary>comma";
       }
 
       ShortcutsShortcut {

--- a/data/ui/window.blp
+++ b/data/ui/window.blp
@@ -14,10 +14,6 @@ template $GraphsWindow: Adw.ApplicationWindow {
     }
     Shortcut {
       trigger: "<primary>comma";
-      action: "action(app.preferences)";
-    }
-    Shortcut {
-      trigger: "<primary><alt>comma";
       action: "action(app.figure_settings)";
     }
     Shortcut {


### PR DESCRIPTION
Removes the binding for the old Preferences dialog, and changes the figure settings shortcut to `ctrl+,` (GNOME default for preferences), without the `alt` modifier.