### PR TITLE
Implement smoothen options

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -71,6 +71,7 @@ blueprints_source = [
   'ui/import.blp',
   'ui/help_overlay.blp',
   'ui/item_box.blp',
+  'ui/smoothen_settings.blp',
   'ui/style_color_box.blp',
   'ui/style_editor.blp',
   'ui/style_preview.blp',

--- a/data/se.sjoerd.Graphs.gresource.xml
+++ b/data/se.sjoerd.Graphs.gresource.xml
@@ -40,6 +40,7 @@
     <file preprocess="xml-stripblanks">ui/fitting_parameters.ui</file>
     <file preprocess="xml-stripblanks">ui/import.ui</file>
     <file preprocess="xml-stripblanks">ui/item_box.ui</file>
+    <file preprocess="xml-stripblanks">ui/smoothen_settings.ui</file>
     <file preprocess="xml-stripblanks">ui/style_color_box.ui</file>
     <file preprocess="xml-stripblanks">ui/style_editor.ui</file>
     <file preprocess="xml-stripblanks">ui/style_preview.ui</file>

--- a/data/se.sjoerd.Graphs.gschema.xml
+++ b/data/se.sjoerd.Graphs.gschema.xml
@@ -60,6 +60,7 @@
   </schema>
 
   <schema id="se.sjoerd.Graphs.actions">
+    <child name="smoothen" schema="se.sjoerd.Graphs.actions.smoothen"/>
     <key name="center" enum="se.sjoerd.Graphs.actions.center-values">
       <default>"middle-x"</default>
     </key>
@@ -68,7 +69,7 @@
     </key>
   </schema>
 
-  <schema id="se.sjoerd.Graphs.smoothen">
+  <schema id="se.sjoerd.Graphs.actions.smoothen">
     <key name="savgol-window" type="i">
       <default>10</default>
     </key>

--- a/data/se.sjoerd.Graphs.gschema.xml
+++ b/data/se.sjoerd.Graphs.gschema.xml
@@ -51,7 +51,6 @@
 
   <schema id="se.sjoerd.Graphs" path="/se/sjoerd/Graphs/">
     <child name="actions" schema="se.sjoerd.Graphs.actions"/>
-    <child name="smoothen" schema="se.sjoerd.Graphs.smoothen"/>
     <child name="add-equation" schema="se.sjoerd.Graphs.add-equation"/>
     <child name="curve-fitting" schema="se.sjoerd.Graphs.curve-fitting"/>
     <child name="export-figure" schema="se.sjoerd.Graphs.export-figure"/>

--- a/data/se.sjoerd.Graphs.gschema.xml
+++ b/data/se.sjoerd.Graphs.gschema.xml
@@ -5,6 +5,11 @@
     <value nick="middle-x" value="1"/>
   </enum>
 
+  <enum id="se.sjoerd.Graphs.actions.smoothen-types">
+    <value nick="savgol" value="0"/>
+    <value nick="moving-average" value="1"/>
+  </enum>
+
   <enum id="se.sjoerd.Graphs.export-figure.file-formats">
     <value nick="Encapsulated Postscript" value="0"/>
     <value nick="Joint Photographic Experts Group" value="1"/>
@@ -46,6 +51,7 @@
 
   <schema id="se.sjoerd.Graphs" path="/se/sjoerd/Graphs/">
     <child name="actions" schema="se.sjoerd.Graphs.actions"/>
+    <child name="smoothen" schema="se.sjoerd.Graphs.smoothen"/>
     <child name="add-equation" schema="se.sjoerd.Graphs.add-equation"/>
     <child name="curve-fitting" schema="se.sjoerd.Graphs.curve-fitting"/>
     <child name="export-figure" schema="se.sjoerd.Graphs.export-figure"/>
@@ -56,6 +62,21 @@
   <schema id="se.sjoerd.Graphs.actions">
     <key name="center" enum="se.sjoerd.Graphs.actions.center-values">
       <default>"middle-x"</default>
+    </key>
+    <key name="smoothen" enum="se.sjoerd.Graphs.actions.smoothen-types">
+      <default>"savgol"</default>
+    </key>
+  </schema>
+
+  <schema id="se.sjoerd.Graphs.smoothen">
+    <key name="savgol-window" type="i">
+      <default>10</default>
+    </key>
+    <key name="savgol-polynomial" type="i">
+      <default>3</default>
+    </key>
+    <key name="moving-average-box" type="i">
+      <default>4</default>
     </key>
   </schema>
 

--- a/data/ui/smoothen_settings.blp
+++ b/data/ui/smoothen_settings.blp
@@ -3,10 +3,9 @@ using Adw 1;
 
 template $GraphsSmoothenWindow : Adw.Window {
   modal: true;
-  default-width: 650;
   default-height: 125;
   title: _("Smoothen settings");
-  focus-widget: confirm_button;
+  focus-widget: reset_button;
 
   ShortcutController {
     Shortcut {
@@ -18,17 +17,10 @@ template $GraphsSmoothenWindow : Adw.Window {
   Adw.ToolbarView {
     [top]
     Adw.HeaderBar {
-      show-end-title-buttons: false;
       [start]
-      Button {
+      Button reset_button {
         icon-name: "history-undo-symbolic";
         clicked => $on_reset();
-      }
-      [end]
-      Button confirm_button {
-        label: _("Apply");
-        styles ["suggested-action"]
-        clicked => $on_accept();
       }
     }
 

--- a/data/ui/smoothen_settings.blp
+++ b/data/ui/smoothen_settings.blp
@@ -45,7 +45,7 @@ template $GraphsSmoothenWindow : Adw.Window {
           title: _("Savitzky–Golay filter");
           Adw.SpinRow savgol_window {
             title: _("Span percentage");
-            subtitle: _("What percentage of the data span to use for each window in the filter");
+            subtitle: _("What percentage of the data span to use for the filter window");
             adjustment: Adjustment {
               step-increment: 1;
               upper: 99;

--- a/data/ui/smoothen_settings.blp
+++ b/data/ui/smoothen_settings.blp
@@ -20,7 +20,6 @@ template $GraphsSmoothenWindow : Adw.Window {
       [start]
       Button reset_button {
         icon-name: "history-undo-symbolic";
-        clicked => $on_reset();
       }
     }
 

--- a/data/ui/smoothen_settings.blp
+++ b/data/ui/smoothen_settings.blp
@@ -1,0 +1,76 @@
+using Gtk 4.0;
+using Adw 1;
+
+template $GraphsSmoothenWindow : Adw.Window {
+  modal: true;
+  default-width: 650;
+  default-height: 125;
+  title: _("Smoothen settings");
+  focus-widget: confirm_button;
+
+  ShortcutController {
+    Shortcut {
+      trigger: "Escape";
+      action: "action(window.close)";
+    }
+  }
+
+  Adw.ToolbarView {
+    [top]
+    Adw.HeaderBar {
+      show-end-title-buttons: false;
+      [start]
+      Button {
+        icon-name: "history-undo-symbolic";
+        clicked => $on_reset();
+      }
+      [end]
+      Button confirm_button {
+        label: _("Apply");
+        styles ["suggested-action"]
+        clicked => $on_accept();
+      }
+    }
+
+    content: Adw.Clamp {
+      margin-start: 12;
+      margin-end: 12;
+      margin-top: 12;
+      margin-bottom: 12;
+
+      Box {
+        orientation: vertical;
+        spacing: 10;
+        Adw.PreferencesGroup {
+          title: _("Savitzky–Golay filter");
+          Adw.SpinRow savgol_window {
+            title: _("Span percentage");
+            subtitle: _("What percentage of the data span to use for each window in the filter");
+            adjustment: Adjustment {
+              step-increment: 1;
+              upper: 99;
+            };
+          }
+          Adw.SpinRow savgol_polynomial {
+            title: _("Polynomial degree");
+            adjustment: Adjustment {
+              step-increment: 1;
+              upper: 20;
+            };
+          }
+        }
+        Adw.PreferencesGroup {
+          title: _("Moving Average");
+          Adw.SpinRow moving_average_box {
+            title: _("Box points");
+            subtitle: _("Amount of points to use when calculating a moving average");
+            adjustment: Adjustment {
+              step-increment: 1;
+              upper: 9999;
+            };
+          }
+        }
+      }
+    };
+  }
+}

--- a/data/ui/window.blp
+++ b/data/ui/window.blp
@@ -147,7 +147,6 @@ template $GraphsWindow: Adw.ApplicationWindow {
         orientation: vertical;
         width-request: 350;
         Adw.HeaderBar sidebar_headerbar {
-          width-request: 350;
           styles ["flat"]
           [start]
           MenuButton add_button {
@@ -279,6 +278,7 @@ template $GraphsWindow: Adw.ApplicationWindow {
                       Button normalize_button {
                         hexpand: true;
                         sensitive: bind shift_button.sensitive;
+                        width-request: 130;
                         layout {
                           column: 1;
                           row: 0;
@@ -292,8 +292,9 @@ template $GraphsWindow: Adw.ApplicationWindow {
                         clicked => $perform_operation();
                       }
 
-                      Button smoothen_button {
-                        hexpand: true;
+                      Adw.SplitButton smoothen_button {
+                        hexpand: false;
+                        can-shrink: true;
                         sensitive: bind shift_button.sensitive;
                         layout {
                           column: 0;
@@ -301,10 +302,12 @@ template $GraphsWindow: Adw.ApplicationWindow {
                         }
                         Adw.ButtonContent {
                           halign: center;
+                          can-shrink: true;
                           icon-name: "smoothen-symbolic";
                           label: _("Smoothen");
                         }
                         tooltip-text: _("Smoothen data");
+                        menu-model: smoothen_menu;
                         clicked => $perform_operation();
                       }
 
@@ -771,5 +774,26 @@ menu center_menu {
     label: _("At middle X value");
     action: "app.center";
     target: "middle-x";
+  }
+}
+
+menu smoothen_menu {
+  section {
+    item {
+      label: _("Savitzky–Golay filter");
+      action: "app.smoothen";
+      target: "savgol";
+    }
+    item {
+      label: _("Moving average");
+      action: "app.smoothen";
+      target: "moving-average";
+    }
+  }
+  section {
+    item {
+      label: _("Advanced settings");
+      action: "app.smoothen_settings";
+    }
   }
 }

--- a/src/actions.py
+++ b/src/actions.py
@@ -2,7 +2,7 @@
 """Main actions."""
 from gettext import gettext as _
 
-from gi.repository import Adw, GObject, Gtk
+from gi.repository import Adw, Gtk
 
 from graphs import operations, ui, utilities
 from graphs.add_equation import AddEquationWindow
@@ -130,6 +130,7 @@ def export_figure_action(_action, _target, self):
 def save_project_action(_action, _target, self):
     ui.save_project_dialog(self)
 
+
 def smoothen_settings_action(_action, _target, self):
     SmoothenWindow(self)
 
@@ -164,6 +165,7 @@ def delete_selected_action(_action, _target, self):
     names = ", ".join(item.get_name() for item in items)
     self.get_data().delete_items(items)
     self.get_window().add_toast_string(_("Deleted {}").format(names))
+
 
 @Gtk.Template(resource_path="/se/sjoerd/Graphs/ui/smoothen_settings.ui")
 class SmoothenWindow(Adw.Window):

--- a/src/actions.py
+++ b/src/actions.py
@@ -2,7 +2,7 @@
 """Main actions."""
 from gettext import gettext as _
 
-from gi.repository import Adw, Gtk
+from gi.repository import Graphs
 
 from graphs import operations, ui, utilities
 from graphs.add_equation import AddEquationWindow
@@ -132,7 +132,13 @@ def save_project_action(_action, _target, self):
 
 
 def smoothen_settings_action(_action, _target, self):
-    SmoothenWindow(self)
+    def _on_reset(_button, self):
+        params = self.get_settings("actions").get_child("smoothen")
+        for key in params.list_keys():
+            params.reset(key)
+
+    window = Graphs.SmoothenWindow.new(self)
+    window.get_reset_button().connect("clicked", _on_reset, self)
 
 
 def zoom_in_action(_action, _target, self):
@@ -165,38 +171,3 @@ def delete_selected_action(_action, _target, self):
     names = ", ".join(item.get_name() for item in items)
     self.get_data().delete_items(items)
     self.get_window().add_toast_string(_("Deleted {}").format(names))
-
-
-@Gtk.Template(resource_path="/se/sjoerd/Graphs/ui/smoothen_settings.ui")
-class SmoothenWindow(Adw.Window):
-    __gtype_name__ = "GraphsSmoothenWindow"
-    savgol_window = Gtk.Template.Child()
-    savgol_polynomial = Gtk.Template.Child()
-    moving_average_box = Gtk.Template.Child()
-
-    def __init__(self, application):
-        super().__init__(
-            application=application, transient_for=application.get_window(),
-        )
-        settings = self.get_application().get_settings("actions").get_child(
-            "smoothen")
-        ui.bind_values_to_settings(settings, self)
-        self.present()
-
-    @Gtk.Template.Callback()
-    def on_reset(self, _widget):
-        def on_accept(_dialog, response):
-            if response == "reset":
-                self.reset_smoothen()
-        body = _("Are you sure you want to reset to defaults?")
-        dialog = ui.build_dialog("reset_to_defaults")
-        dialog.set_body(body)
-        dialog.set_transient_for(self)
-        dialog.connect("response", on_accept)
-        dialog.present()
-
-    def reset_smoothen(self):
-        params = \
-            self.get_application().get_settings("smoothen")
-        for key in params.list_keys():
-            params.reset(key)

--- a/src/actions.py
+++ b/src/actions.py
@@ -199,7 +199,3 @@ class SmoothenWindow(Adw.Window):
             self.get_application().get_settings("smoothen")
         for key in params.list_keys():
             params.reset(key)
-
-    @Gtk.Template.Callback()
-    def on_accept(self, _widget):
-        self.destroy()

--- a/src/actions.py
+++ b/src/actions.py
@@ -24,7 +24,7 @@ def perform_operation(_action, target, self):
         args = [self.get_settings("actions").get_enum(operation)]
     if operation == "smoothen":
         params = {}
-        settings = self.get_settings("smoothen")
+        settings = self.get_settings("actions").get_child("smoothen")
         for setting in settings:
             params[setting] = int(settings.get_int(setting))
         args += [params]
@@ -178,8 +178,9 @@ class SmoothenWindow(Adw.Window):
         super().__init__(
             application=application, transient_for=application.get_window(),
         )
-        ui.bind_values_to_settings(
-            self.get_application().get_settings("smoothen"), self)
+        settings = self.get_application().get_settings("actions").get_child(
+            "smoothen")
+        ui.bind_values_to_settings(settings, self)
         self.present()
 
     @Gtk.Template.Callback()

--- a/src/actions.py
+++ b/src/actions.py
@@ -28,7 +28,7 @@ def perform_operation(_action, target, self):
         for setting in settings:
             params[setting] = int(settings.get_int(setting))
         args += [params]
-    if operation == "shift":
+    elif operation == "shift":
         figure_settings = self.get_data().get_figure_settings()
         right_range = (figure_settings.get_max_right()
                        - figure_settings.get_min_right())

--- a/src/application.py
+++ b/src/application.py
@@ -100,12 +100,9 @@ class PythonApplication(Graphs.Application):
         operation_action.connect("activate", actions.perform_operation, self)
         self.add_action(operation_action)
 
-        center_action = settings.get_child("actions").create_action("center")
-        self.add_action(center_action)
-
-        smoothen_action = \
-            settings.get_child("actions").create_action("smoothen")
-        self.add_action(smoothen_action)
+        for action_key in ["center", "smoothen"]:
+            action = settings.get_child("actions").create_action(action_key)
+            self.add_action(action)
 
         self.get_data().connect(
             "notify::items", ui.on_items_change, self,

--- a/src/application.py
+++ b/src/application.py
@@ -20,7 +20,8 @@ _ACTIONS = [
     "quit", "about", "figure_settings", "add_data", "add_equation",
     "select_all", "select_none", "undo", "redo", "optimize_limits",
     "view_back", "view_forward", "export_data", "export_figure",
-    "save_project", "open_project", "delete_selected", "zoom_in", "zoom_out",
+    "save_project", "smoothen_settings", "open_project", "delete_selected",
+    "zoom_in", "zoom_out",
 ]
 
 
@@ -101,6 +102,10 @@ class PythonApplication(Graphs.Application):
 
         center_action = settings.get_child("actions").create_action("center")
         self.add_action(center_action)
+
+        smoothen_action = \
+            settings.get_child("actions").create_action("smoothen")
+        self.add_action(smoothen_action)
 
         self.get_data().connect(
             "notify::items", ui.on_items_change, self,

--- a/src/meson.build
+++ b/src/meson.build
@@ -49,6 +49,7 @@ graphs_lib = shared_library(
     'item.vala',
     'inline-stack-switcher.vala',
     'misc.vala',
+    'smoothen_settings.vala',
     'utilities.vala',
     'window.vala',
   ), blueprints_hack, gresource_bundle,

--- a/src/operations.py
+++ b/src/operations.py
@@ -144,11 +144,21 @@ def normalize(_item, xdata, ydata):
     return xdata, [value / max(ydata) for value in ydata], False, False
 
 
-def smoothen(_item, xdata, ydata):
+def smoothen(_item, xdata, ydata, smooth_type, params):
     """Smoothen y-data."""
-    box_points = 4
-    box = numpy.ones(box_points) / box_points
-    new_ydata = numpy.convolve(ydata, box, mode="same")
+    if smooth_type == 0:
+        minimum = params["savgol-polynomial"] + 1
+        window_percentage = params["savgol-window"]/100
+        window = max(minimum, int(len(xdata)*window_percentage)) # At least 2 data points
+        print(window)
+        print(window_percentage)
+        print(len(xdata))
+        new_ydata = scipy.signal.savgol_filter(ydata,
+            window, params["savgol-polynomial"])
+    elif smooth_type == 1:
+        box_points = params["moving-average-box"]
+        box = numpy.ones(box_points) / box_points
+        new_ydata = numpy.convolve(ydata, box, mode="same")
     return xdata, new_ydata, False, False
 
 

--- a/src/operations.py
+++ b/src/operations.py
@@ -148,13 +148,11 @@ def smoothen(_item, xdata, ydata, smooth_type, params):
     """Smoothen y-data."""
     if smooth_type == 0:
         minimum = params["savgol-polynomial"] + 1
-        window_percentage = params["savgol-window"]/100
-        window = max(minimum, int(len(xdata)*window_percentage)) # At least 2 data points
-        print(window)
-        print(window_percentage)
-        print(len(xdata))
+        window_percentage = params["savgol-window"] / 100
+        window = max(minimum, int(len(xdata) * window_percentage))
         new_ydata = scipy.signal.savgol_filter(ydata,
-            window, params["savgol-polynomial"])
+                                               window,
+                                               params["savgol-polynomial"])
     elif smooth_type == 1:
         box_points = params["moving-average-box"]
         box = numpy.ones(box_points) / box_points

--- a/src/smoothen_settings.vala
+++ b/src/smoothen_settings.vala
@@ -23,7 +23,7 @@ namespace Graphs {
                 transient_for: application.window
             );
             Tools.bind_settings_to_widgets (
-                application.settings.get_child("actions").get_child("smoothen"), this
+                application.settings.get_child ("actions").get_child ("smoothen"), this
             );
             present ();
         }

--- a/src/smoothen_settings.vala
+++ b/src/smoothen_settings.vala
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+using Adw;
+using Gtk;
+
+namespace Graphs {
+    [GtkTemplate (ui = "/se/sjoerd/Graphs/ui/smoothen_settings.ui")]
+    public class SmoothenWindow : Adw.Window {
+        [GtkChild]
+        public unowned Adw.SpinRow savgol_window { get; }
+
+        [GtkChild]
+        public unowned Adw.SpinRow savgol_polynomial { get; }
+
+        [GtkChild]
+        public unowned Adw.SpinRow moving_average_box { get; }
+
+        [GtkChild]
+        public unowned Button reset_button { get; }
+
+        public SmoothenWindow (Application application) {
+            Object (
+                application: application,
+                transient_for: application.window
+            );
+            Tools.bind_settings_to_widgets (
+                application.settings.get_child("actions").get_child("smoothen"), this
+            );
+            present ();
+        }
+    }
+}

--- a/src/utilities.vala
+++ b/src/utilities.vala
@@ -41,6 +41,9 @@ namespace Graphs {
                     settings.bind (key, widget, "enable-expansion", 0);
                     widget.set_expanded (true);
                 }
+                else if (widget is Adw.SpinRow) {
+                    settings.bind (key, widget, "value", 0);
+                }
             }
         }
     }


### PR DESCRIPTION
This implements extra options for smoothening. This includes a new filter technique, the Savitzky–Golay filter which allows to do some pretty cool filtering. See example in the screencast, where I'm filtering a noisy sine wave. The original sine wave is has an amplitude of one, with some `np.random` noise added to it. As you can see, with a moving average you won't really get a smooth sine back, but the Savitzky–Golay draws a polynomial using defined window ranges and comes with this much nicer graph.

This all works now, but it probably needs some cleaning and it will not pass linting likely. I'm already running late though, so I wanted to put this up before I start on work.

[Screencast from 2023-11-17 08-35-11.webm](https://github.com/Sjoerd1993/Graphs/assets/68477016/f82b8fbc-8491-452a-8d7b-64db6561d1f0)
