### PR TITLE
hide linewidth and markersize

### DIFF
--- a/data/ui/edit_item.blp
+++ b/data/ui/edit_item.blp
@@ -53,10 +53,12 @@ template $GraphsEditItemWindow : Adw.PreferencesWindow {
         model: StringList {
           strings [_("None"), _("Solid"), _("Dotted"), _("Dashed"), _("Dashdot")]
         };
+        notify::selected => $on_linestyle();
       }
 
       Adw.ActionRow {
         title: _("Linewidth");
+        visible: bind linewidth.sensitive;
         Scale linewidth {
           draw-value: true;
           width-request: 200;
@@ -64,6 +66,7 @@ template $GraphsEditItemWindow : Adw.PreferencesWindow {
             lower: 0;
             upper: 10;
           };
+        sensitive: false;
         }
       }
 
@@ -80,10 +83,12 @@ template $GraphsEditItemWindow : Adw.PreferencesWindow {
             _("Filled plus"), _("Filled x"),
           ]
         };
+        notify::selected => $on_markers();
       }
 
       Adw.ActionRow {
         title: _("Marker Size");
+        visible: bind markersize.sensitive;
         Scale markersize {
           draw-value: true;
           width-request: 200;
@@ -91,6 +96,7 @@ template $GraphsEditItemWindow : Adw.PreferencesWindow {
             lower: 0;
             upper: 10;
           };
+        sensitive: false;
         }
       }
     }

--- a/src/edit_item.py
+++ b/src/edit_item.py
@@ -64,3 +64,11 @@ class EditItemWindow(Adw.PreferencesWindow):
     def on_close(self, _a):
         self.get_application().get_data().add_history_state()
         self.destroy()
+
+    @Gtk.Template.Callback()
+    def on_linestyle(self, comborow, _b):
+        self.linewidth.set_sensitive(comborow.get_selected() != 0)
+
+    @Gtk.Template.Callback()
+    def on_markers(self, comborow, _b):
+        self.markersize.set_sensitive(comborow.get_selected() != 0)


### PR DESCRIPTION
Adopts the same logic in the style editor, where the marker size and linewidth are hidden when these items are turned off.