### PR TITLE
Style fixes

### DIFF
--- a/data/styles/fivethirtyeight.mplstyle
+++ b/data/styles/fivethirtyeight.mplstyle
@@ -76,10 +76,10 @@ grid.alpha: 1.0
 grid.linestyle: -
 
 # padding
-xtick.major.pad: 0
-xtick.minor.pad: 0
-ytick.major.pad: 0
-ytick.minor.pad: 0
+xtick.major.pad: 7
+xtick.minor.pad: 7
+ytick.major.pad: 7
+ytick.minor.pad: 7
 axes.labelpad: 5
 axes.titlepad: 15
 

--- a/src/styles.py
+++ b/src/styles.py
@@ -14,7 +14,7 @@ from gi.repository import Adw, GLib, GObject, Gdk, Gio, Graphs, Gtk, Pango
 import graphs
 from graphs import item, style_io, ui, utilities
 
-from matplotlib import RcParams
+from matplotlib import rcParams, RcParams, rcParamsDefault
 
 
 def _compare_styles(a: Graphs.Style, b: Graphs.Style) -> int:
@@ -167,6 +167,7 @@ class StyleManager(GObject.Object, Graphs.StyleManagerInterface):
 
     def _on_style_change(self, override: bool = False) -> None:
         old_style = self._selected_style_params
+        rcParams.update(rcParamsDefault)
         self._update_system_style()
         self._update_selected_style()
         data = self.props.application.get_data()

--- a/src/styles.py
+++ b/src/styles.py
@@ -166,8 +166,8 @@ class StyleManager(GObject.Object, Graphs.StyleManagerInterface):
             self._on_style_change()
 
     def _on_style_change(self, override: bool = False) -> None:
-        old_style = self._selected_style_params
         rcParams.update(rcParamsDefault)
+        old_style = self._selected_style_params
         self._update_system_style()
         self._update_selected_style()
         data = self.props.application.get_data()

--- a/src/styles.py
+++ b/src/styles.py
@@ -14,7 +14,7 @@ from gi.repository import Adw, GLib, GObject, Gdk, Gio, Graphs, Gtk, Pango
 import graphs
 from graphs import item, style_io, ui, utilities
 
-from matplotlib import rcParams, RcParams, rcParamsDefault
+from matplotlib import RcParams, rcParams, rcParamsDefault
 
 
 def _compare_styles(a: Graphs.Style, b: Graphs.Style) -> int:


### PR DESCRIPTION
1 - Sets the FiveThirtyEight label paddings to 7 like most other plots, to remove the overlap at these labels
2 - Clears rcParams to the defaults upon style change. This is because parameters that are not in the defaults do not get reset, so by setting rcParams to default first it is assured that all parameters are as expected. This fixes the bug that is visible in the followign video:

[Skärminspelning från 2023-11-20 15-58-00.webm](https://github.com/Sjoerd1993/Graphs/assets/68477016/a10a4892-8756-4ece-8325-28b4aff77b64)

As can been seen, the fonts get permanently smaller after having had "Classic" style open. This can only be fixed by a complete restart of Graphs.