### PR TITLE
Set preview icon on axes facecolor

### DIFF
--- a/src/styles.py
+++ b/src/styles.py
@@ -304,10 +304,10 @@ class StylePreview(Gtk.AspectFrame):
         texture = Gdk.Texture.new_from_file(file)
         self.picture.set_paintable(texture)
         if self._style.get_mutable():
-            buffer = io.BytesIO(texture.save_to_png_bytes().get_data())
-            mean = ImageStat.Stat(Image.open(buffer).convert("L")).mean[0]
-            buffer.close()
-            color = "@dark_5" if mean > 200 else "@light_1"
+            params = style_io.parse(self.style.get_file())[0]
+            bg_color = params["axes.facecolor"]
+            contrast = utilities.get_luminance(bg_color)
+            color = "@dark_5" if contrast > 150 else "@light_1"
             self.provider.load_from_data(f"button {{ color: {color}; }}", -1)
 
 

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -18,6 +18,14 @@ def hex_to_rgba(hex_str):
     return rgba
 
 
+def get_luminance(hex_color):
+    color = hex_color[1:]
+    hex_red = int(color[0:2], base=16)
+    hex_green = int(color[2:4], base=16)
+    hex_blue = int(color[4:6], base=16)
+    return hex_red * 0.2126 + hex_green * 0.7152 + hex_blue * 0.0722
+
+
 def sig_fig_round(number, digits):
     """Round a number to the specified number of significant digits."""
     try:


### PR DESCRIPTION
Sets the color choice of the preview icon for the style on the axes facecolor, instead of the overall brightness. This because the pencil overlaps with the axes facecolor. Currently if the axes facecolor is white, and the figure facecolor is black, the pencil becomes white rendering it invisible. Looking at the axes facecolor, where the pencil is actually located, will be less prone to such issues.

See the dark background (1) style for comparison.

Before:
![bild](https://github.com/Sjoerd1993/Graphs/assets/68477016/03baa6e6-097b-43ac-a920-5eec1ae040ca)

After:
![bild](https://github.com/Sjoerd1993/Graphs/assets/68477016/11204d3d-0bc5-4d81-bf2e-5fdfc529f75b)
