### PR TITLE
Improve drag and drop

### DIFF
--- a/src/item_box.py
+++ b/src/item_box.py
@@ -43,9 +43,6 @@ class ItemBox(Gtk.Box):
 
         self.item.connect("notify::color", self.on_color_change)
         self.on_color_change(self.props.item, None)
-
-        self.add_controller(self.drag_source)
-        self.add_controller(self.drop_source)
         self.add_actions()
 
     def add_actions(self):
@@ -75,9 +72,9 @@ class ItemBox(Gtk.Box):
         self._change_position(int(value), int(drop_target.index))
 
     def on_dnd_prepare(self, drag_source, x, y):
-        snapshot = Gtk.Snapshot.new()
-        self.do_snapshot(self, snapshot)
-        paintable = snapshot.to_paintable()
+        widget = self.get_parent()
+        widget.add_css_class("card")
+        paintable = Gtk.WidgetPaintable(widget=widget)
         drag_source.set_icon(paintable, int(x), int(y))
         return Gdk.ContentProvider.new_for_value(str(self.props.index))
 

--- a/src/ui.py
+++ b/src/ui.py
@@ -17,7 +17,11 @@ def on_items_change(data, _ignored, self):
         item_list.remove(item_list.get_last_child())
 
     for index, item in enumerate(data):
-        item_list.append(ItemBox(self, item, index))
+        itembox = ItemBox(self, item, index)
+        item_list.append(itembox)
+        row = item_list.get_row_at_index(index)
+        row.add_controller(itembox.drag_source)
+        row.add_controller(itembox.drop_source)
     data.add_view_history_state()
 
 
@@ -253,3 +257,4 @@ def bind_values_to_object(source, window, ignorelist=None):
         except AttributeError:
             logging.warn(_("No way to apply “{}”").format(key))
     return bindings
+

--- a/src/ui.py
+++ b/src/ui.py
@@ -257,4 +257,3 @@ def bind_values_to_object(source, window, ignorelist=None):
         except AttributeError:
             logging.warn(_("No way to apply “{}”").format(key))
     return bindings
-


### PR DESCRIPTION
Improves drag and drop visuals. Unfortunately I'm a bit stuck trying to get the blue frame around the widget during the entire dragging phase.

[Skärminspelning från 2023-11-21 21-24-54.webm](https://github.com/Sjoerd1993/Graphs/assets/68477016/7c88dc44-e904-43ab-94e2-6ad25badb77d)
