### PR TITLE
Shorten label using ellipsize

### DIFF
--- a/data/ui/item_box.blp
+++ b/data/ui/item_box.blp
@@ -19,6 +19,7 @@ template $GraphsItemBox : Box {
     margin-end: 6;
     halign: start;
     hexpand: true;
+    ellipsize: end;
   }
 
   Button color_button {

--- a/src/item_box.py
+++ b/src/item_box.py
@@ -147,7 +147,7 @@ class ItemBox(Gtk.Box):
 
     @name.setter
     def name(self, name: str):
-        self.label.set_label(utilities.shorten_label(name))
+        self.label.set_label(name)
 
     def get_application(self):
         """Get application property."""


### PR DESCRIPTION
Uses ellipsize to shorten labels. This ensures a consistent label length ("A" and "1" don't have the same character length so capping the characters leads to different max lengths), and also makes sure that all available space is actually used.