### PR TITLE
Update dependencies

### DIFF
--- a/python-dependencies.json
+++ b/python-dependencies.json
@@ -22,8 +22,7 @@
             "only-arches": "x86_64",
             "x-checker-data": {
 				"type": "pypi",
-				"name": "numpy",
-				"packagetype": "bdist_wheel"
+				"name": "numpy"
 			}
         },
         {
@@ -33,8 +32,7 @@
             "only-arches": "aarch64",
             "x-checker-data": {
 				"type": "pypi",
-				"name": "numpy",
-				"packagetype": "bdist_wheel"
+				"name": "numpy"
 			}
         },
         {
@@ -44,8 +42,7 @@
             "only-arches": "x86_64",
             "x-checker-data": {
 				"type": "pypi",
-				"name": "scipy",
-				"packagetype": "bdist_wheel"
+				"name": "scipy"
 			}
         },
         {
@@ -55,8 +52,7 @@
             "only-arches": "aarch64",
             "x-checker-data": {
 				"type": "pypi",
-				"name": "scipy",
-				"packagetype": "bdist_wheel"
+				"name": "scipy"
 			}
         },
         {
@@ -86,8 +82,7 @@
             "only-arches": "x86_64",
             "x-checker-data": {
 				"type": "pypi",
-				"name": "Pillow",
-				"packagetype": "bdist_wheel"
+				"name": "Pillow"
 			}
         },
         {
@@ -97,8 +92,7 @@
             "only-arches": "aarch64",
             "x-checker-data": {
 				"type": "pypi",
-				"name": "Pillow",
-				"packagetype": "bdist_wheel"
+				"name": "Pillow"
 			}
         },
         {
@@ -118,8 +112,7 @@
             "only-arches": "x86_64",
             "x-checker-data": {
 				"type": "pypi",
-				"name": "contourpy",
-				"packagetype": "bdist_wheel"
+				"name": "contourpy"
 			}
         },
         {
@@ -129,8 +122,7 @@
             "only-arches": "aarch64",
             "x-checker-data": {
 				"type": "pypi",
-				"name": "contourpy",
-				"packagetype": "bdist_wheel"
+				"name": "contourpy"
 			}
         },
         {
@@ -140,8 +132,7 @@
             "only-arches": "x86_64",
             "x-checker-data": {
 				"type": "pypi",
-				"name": "kiwisolver",
-				"packagetype": "bdist_wheel"
+				"name": "kiwisolver"
 			}
         },
         {
@@ -151,14 +142,13 @@
             "only-arches": "aarch64",
             "x-checker-data": {
 				"type": "pypi",
-				"name": "kiwisolver",
-				"packagetype": "bdist_wheel"
+				"name": "kiwisolver"
 			}
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/7d/15/24ded19c2093614238aa9d161c89a85ac0a184ced564d28313ef3f5f46ca/fonttools-4.44.0-py3-none-any.whl",
-            "sha256": "b9beb0fa6ff3ea808ad4a6962d68ac0f140ddab080957b20d9e268e4d67fb335",
+            "url": "https://files.pythonhosted.org/packages/5b/b4/57610d82b1522002908d477f378e999b885d3fcbd92e7e7eb2dc402138bd/fonttools-4.45.0-py3-none-any.whl",
+            "sha256": "835cf5d0e1b37bbed1d64c286611cc4da9ff19df952400f191ba9142b3cb97f6",
             "x-checker-data": {
 				"type": "pypi",
 				"name": "fonttools",
@@ -182,8 +172,7 @@
             "only-arches": "x86_64",
             "x-checker-data": {
 				"type": "pypi",
-				"name": "matplotlib",
-				"packagetype": "bdist_wheel"
+				"name": "matplotlib"
 			}
         },
         {
@@ -193,8 +182,7 @@
             "only-arches": "aarch64",
             "x-checker-data": {
 				"type": "pypi",
-				"name": "matplotlib",
-				"packagetype": "bdist_wheel"
+				"name": "matplotlib"
 			}
         },
         {
@@ -204,8 +192,7 @@
             "only-arches": "x86_64",
             "x-checker-data": {
 				"type": "pypi",
-				"name": "numexpr",
-				"packagetype": "bdist_wheel"
+				"name": "numexpr"
 			}
         },
         {
@@ -215,8 +202,7 @@
             "only-arches": "aarch64",
             "x-checker-data": {
 				"type": "pypi",
-				"name": "numexpr",
-				"packagetype": "bdist_wheel"
+				"name": "numexpr"
 			}
         },
         {


### PR DESCRIPTION
Updates one dependency. But also removes the `packagetype` argument for the dependencies with a specific architecture. This is because checking the binaries is not supported yet for architecture-dependent packages. See [the Readme](https://github.com/flathub/flatpak-external-data-checker): _"By default it will check for source package (sdist package type). To check for binary package instead, set packagetype to bdist_wheel (only noarch wheels are supported currently)"_

See the build messages on the beta update. Where it fails on these dependencies: https://github.com/flathub/se.sjoerd.Graphs/pull/43 It did indeed fail correctly for outdated packages by the way. So that works.