### PR TITLE
Add keywords

### DIFF
--- a/data/se.sjoerd.Graphs.desktop.in.in
+++ b/data/se.sjoerd.Graphs.desktop.in.in
@@ -6,4 +6,4 @@ Terminal=false
 Type=Application
 Categories=Education;Science
 StartupNotify=true
-Keywords=Plotting;Graphs;Mathematics;Equations;Data;Plot;Manipulation;
+Keywords=Plotting;Graph;Graphing;Science;Mathematics;Math;Equations;Data;Plot;Visualisation;Visualization;Fitting;xrdml;

--- a/data/se.sjoerd.Graphs.desktop.in.in
+++ b/data/se.sjoerd.Graphs.desktop.in.in
@@ -6,3 +6,4 @@ Terminal=false
 Type=Application
 Categories=Education;Science
 StartupNotify=true
+Keywords=Plotting;Graphs;Mathematics;Equations;Data;Plot;Manipulation;


### PR DESCRIPTION
Adds keywords to the .desktop` file. This should give Graphs tags at Flathub (see [this application](https://flathub.org/apps/io.github.veusz.Veusz) for example), but also means that it will pop up when searching for the keywords in e.g. GNOME Software or Flathub, making it more discoverable.

Open to suggestions about adding or removing keywords.