### PR TITLE
Fix undo delete

### DIFF
--- a/src/data.py
+++ b/src/data.py
@@ -343,7 +343,7 @@ class Data(GObject.Object, Graphs.DataInterface):
             elif change_type == 2:
                 item_ = item.new_from_dict(copy.deepcopy(change[1]))
                 self._add_item(item_)
-                self.change_position(change[0], len(self))
+                self.change_position(change[0], len(self) - 1)
                 items_changed = True
             elif change_type == 3:
                 self.change_position(change[0], change[1])

--- a/src/scales.py
+++ b/src/scales.py
@@ -160,6 +160,7 @@ class CustomScaleLocator(ticker.MaxNLocator):
         tick_pos *= 2 if self.axis.get_scale() == "squareroot" else 1
         return tick_pos
 
+
 class RadianLocator(ticker.MultipleLocator):
     """
     Dynamically place tick positions on radian scale.
@@ -190,22 +191,24 @@ class RadianLocator(ticker.MultipleLocator):
         if self.axis is None:
             return numpy.pi
 
-        distance = numpy.pi
         vmin, vmax = self.axis.get_view_interval()
-        num_ticks = (vmax-vmin) / distance
+        distance = numpy.pi
+        # Amount of ticks if we use a multiple of pi
+        num_ticks = (vmax - vmin) / distance
+        # Desired amount of ticks, should be between 3 and 9
         numticks_goal = max(1, self.axis.get_tick_space() - 4)
         numticks_goal = numpy.clip(numticks_goal, 3, 9)
-        ratio = (num_ticks/numticks_goal)
+        ratio = (num_ticks / numticks_goal)
         if num_ticks > 12:
-            if ratio < 2: # Use a distance of 2pi if reasonable
+            if ratio < 2:  # Use a distance of 2pi if reasonable
                 return distance * 2
             # Make sure ratio is never rounded to 0:
-            ratio = 5 if round(ratio/5) == 0 else ratio
-            return distance*round(ratio / 5) * 5
+            ratio = 5 if round(ratio / 5) == 0 else ratio
+            return distance * round(ratio / 5) * 5
         elif num_ticks < 4:
-            ratio = (num_ticks/numticks_goal)
+            ratio = (num_ticks / numticks_goal)
             exponent = int(numpy.log2(abs(ratio)))
-            result = 2 ** exponent # Return distance as a power of 2
+            result = 2 ** exponent  # Return distance as a power of 2
             return distance * result
         else:
             return distance

--- a/src/scales.py
+++ b/src/scales.py
@@ -36,7 +36,7 @@ class RadiansScale(scale.LinearScale):
         axis.set_major_formatter(
             ticker.FuncFormatter(lambda x, _pos=None: f"{x / numpy.pi:g}π"),
         )
-        axis.set_major_locator(RadianLocator(axis))
+        axis.set_major_locator(RadianLocator())
 
 
 class SquareRootScale(scale.ScaleBase):
@@ -124,7 +124,6 @@ class CustomScaleLocator(ticker.MaxNLocator):
     """Dynamically find tick positions on custom scales."""
     def __init__(self, is_minor=False):
         self.is_minor = is_minor
-        print(self.axis)
 
     @property
     def numticks(self):
@@ -170,7 +169,7 @@ class RadianLocator(ticker.MultipleLocator):
     At smaller values, the distances between the ticks are a power of 2,
     multiplied by pi. e.g. (1/2)pi, (1/4)pi, (1/8)pi etc..
     """
-    def __init__(self, is_minor=False):
+    def __init__(self):
         super().__init__(base=self.base)
 
     def tick_values(self, vmin, vmax):

--- a/src/scales.py
+++ b/src/scales.py
@@ -34,7 +34,7 @@ class RadiansScale(scale.LinearScale):
     def set_default_locators_and_formatters(self, axis):
         super().set_default_locators_and_formatters(axis)
         axis.set_major_formatter(
-            ticker.FuncFormatter(lambda x, _pos=None: f"{x / numpy.pi:g}π"),
+            ticker.FuncFormatter(lambda x, _pos=None: f"{x / numpy.pi:.3g}π"),
         )
         axis.set_major_locator(RadianLocator())
 
@@ -163,9 +163,9 @@ class CustomScaleLocator(ticker.MaxNLocator):
 class RadianLocator(ticker.MultipleLocator):
     """
     Dynamically place tick positions on radian scale.
-    Places ticks at a distance of pi if there's between 4 and 12 ticks
+    Places ticks at a distance of pi if there's between 4 and 8 ticks
     Otherwise it places ticks at a distance of 2pi if reasonable, or with
-    a multiple of 5 pi such that a number between 3 and 9 ticks are placed
+    a multiple of 5 pi such that a number between 3 and 8 ticks are placed
     At smaller values, the distances between the ticks are a power of 2,
     multiplied by pi. e.g. (1/2)pi, (1/4)pi, (1/8)pi etc..
     """
@@ -194,11 +194,11 @@ class RadianLocator(ticker.MultipleLocator):
         distance = numpy.pi
         # Amount of ticks if we use a multiple of pi
         num_ticks = (vmax - vmin) / distance
-        # Desired amount of ticks, should be between 3 and 9
+        # Desired amount of ticks, should be between 3 and 8
         numticks_goal = max(1, self.axis.get_tick_space() - 4)
-        numticks_goal = numpy.clip(numticks_goal, 3, 9)
+        numticks_goal = numpy.clip(numticks_goal, 3, 7)
         ratio = (num_ticks / numticks_goal)
-        if num_ticks > 12:
+        if num_ticks > 8:
             if ratio < 2:  # Use a distance of 2pi if reasonable
                 return distance * 2
             # Make sure ratio is never rounded to 0:


### PR DESCRIPTION
Currently performing an undo after deleting an item is a bit buggy. I think I found the issue, which comes down to the offset that's missing in `self.change_position(change[0], len(self))` (A single item will show a length of 1, but that will of course still be positioned at index 0).