### PR TITLE
Fix undo delete action

### DIFF
--- a/src/data.py
+++ b/src/data.py
@@ -343,7 +343,7 @@ class Data(GObject.Object, Graphs.DataInterface):
             elif change_type == 2:
                 item_ = item.new_from_dict(copy.deepcopy(change[1]))
                 self._add_item(item_)
-                self.change_position(change[0], len(self))
+                self.change_position(change[0], len(self) - 1)
                 items_changed = True
             elif change_type == 3:
                 self.change_position(change[0], change[1])


### PR DESCRIPTION
Currently performing an undo after deleting an item is a bit buggy. I think I found the issue, which comes down to the offset that's missing in `self.change_position(change[0], len(self))` (A single item will show a length of 1, but that will of course still be positioned at index 0).