### PR TITLE
Implement panning support

### DIFF
--- a/src/application.py
+++ b/src/application.py
@@ -8,7 +8,7 @@ Classes:
 import logging
 from gettext import gettext as _
 
-from gi.repository import GLib, Gio, Gtk, Graphs
+from gi.repository import GLib, Gio, Graphs, Gtk
 
 from graphs import actions, file_import, file_io, migrate, styles, ui
 from graphs.data import Data
@@ -131,7 +131,6 @@ class PythonApplication(Graphs.Application):
 
     def on_key_release_event(self, _controller, _keyval, _keycode, _state):
         self.set_ctrl(False)
-
 
     def do_activate(self):
         """

--- a/src/application.py
+++ b/src/application.py
@@ -8,7 +8,7 @@ Classes:
 import logging
 from gettext import gettext as _
 
-from gi.repository import GLib, Gio, Graphs
+from gi.repository import GLib, Gio, Gtk, Graphs
 
 from graphs import actions, file_import, file_io, migrate, styles, ui
 from graphs.data import Data
@@ -123,6 +123,16 @@ class PythonApplication(Graphs.Application):
         else:
             file_import.import_from_files(self, files)
 
+    def on_key_press_event(self, _controller, keyval, _keycode, _state):
+        if keyval == 65507 or keyval == 65508:  # Control_L or Control_R
+            self.set_ctrl(True)
+        else:  # Prevent Ctrl from being true with key combos
+            self.set_ctrl(False)
+
+    def on_key_release_event(self, _controller, _keyval, _keycode, _state):
+        self.set_ctrl(False)
+
+
     def do_activate(self):
         """
         Activate the application.
@@ -160,6 +170,10 @@ class PythonApplication(Graphs.Application):
             window.get_stack_switcher_box().prepend(stack_switcher)
             window.set_title(self.props.name)
             self.set_window(window)
+            controller = Gtk.EventControllerKey.new()
+            controller.connect("key-pressed", self.on_key_press_event)
+            controller.connect("key-released", self.on_key_release_event)
+            window.add_controller(controller)
             if "(Development)" in self.props.name:
                 window.add_css_class("devel")
             self.set_figure_style_manager(styles.StyleManager(self))

--- a/src/application.vala
+++ b/src/application.vala
@@ -25,3 +25,4 @@ namespace Graphs {
         }
     }
 }
+

--- a/src/application.vala
+++ b/src/application.vala
@@ -14,6 +14,7 @@ namespace Graphs {
         public string issues { get; construct set; default = ""; }
         public string author { get; construct set; default = ""; }
         public string pkgdatadir { get; construct set; default = ""; }
+        public bool ctrl { get; construct set; default = false; }
 
         public Settings get_settings_child (string path) {
             Settings settings = this.settings;

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -700,7 +700,7 @@ class _DummyToolbar(NavigationToolbar2):
         self.canvas.queue_draw()
 
     # Overwritten function - do not change name
-    def push_current(self, *args):
+    def push_current(self, *_args):
         """Use custom functionality for the view clipboard."""
         self.canvas.highlight.load(self.canvas)
         for direction in ("bottom", "left", "top", "right"):

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -21,9 +21,6 @@ from matplotlib.backend_bases import NavigationToolbar2
 from matplotlib.backends.backend_gtk4cairo import FigureCanvas
 from matplotlib.widgets import SpanSelector
 
-import numpy
-
-
 _SCROLL_SCALE = 1.06
 
 
@@ -120,19 +117,13 @@ class Canvas(FigureCanvas, Graphs.CanvasInterface):
         self.mpl_connect("motion_notify_event", self._set_mouse_fraction)
         self._xfrac, self._yfrac = None, None
         zoom_gesture = Gtk.GestureZoom.new()
-        horizontal_scroll =  \
-            Gtk.EventControllerScroll.new(
-                Gtk.EventControllerScrollFlags.HORIZONTAL)
-        vertical_scroll =  \
-            Gtk.EventControllerScroll.new(
-                Gtk.EventControllerScrollFlags.VERTICAL)
-
         zoom_gesture.connect("scale-changed", self._on_zoom_gesture)
-        horizontal_scroll.connect("scroll", self._on_pan_gesture)
-        vertical_scroll.connect("scroll", self._on_pan_gesture)
+        scroll_gesture =  \
+            Gtk.EventControllerScroll.new(
+                Gtk.EventControllerScrollFlags.BOTH_AXES)
+        scroll_gesture.connect("scroll", self._on_pan_gesture)
         self.add_controller(zoom_gesture)
-        self.add_controller(horizontal_scroll)
-        self.add_controller(vertical_scroll)
+        self.add_controller(scroll_gesture)
 
         self.connect("notify::hide-unselected", self._redraw)
         self.connect("notify::items", self._redraw)
@@ -159,7 +150,7 @@ class Canvas(FigureCanvas, Graphs.CanvasInterface):
             return
         self.zoom(scale)
 
-    def _on_pan_gesture(self, event_controller, x, y):
+    def _on_pan_gesture(self, _event_controller, x, y):
         if self.get_application().get_ctrl() is False:
             for ax in self.axes:
                 xmin, xmax, ymin, ymax = \
@@ -194,23 +185,24 @@ class Canvas(FigureCanvas, Graphs.CanvasInterface):
             ))
         self.queue_draw()
 
-    def _calculate_pan_values(self, ax, x_panspeed, y_panspeed):
+    @staticmethod
+    def _calculate_pan_values(ax, x_panspeed, y_panspeed):
         xmin, xmax = min(ax.get_xlim()), max(ax.get_xlim())
         ymin, ymax = min(ax.get_ylim()), max(ax.get_ylim())
         x_scale = scales.to_int(ax.get_xscale())
         y_scale = scales.to_int(ax.get_yscale())
-        pan_factor = 0.002
+        pan_scale = 0.002
         xvalue1 = utilities.get_value_at_fraction(
-            x_panspeed * pan_factor, xmin, xmax, x_scale,
+            x_panspeed * pan_scale, xmin, xmax, x_scale,
         )
         xvalue2 = utilities.get_value_at_fraction(
-            1 + x_panspeed * pan_factor, xmin, xmax, x_scale,
+            1 + x_panspeed * pan_scale, xmin, xmax, x_scale,
         )
         yvalue1 = utilities.get_value_at_fraction(
-            -y_panspeed * pan_factor, ymin, ymax, y_scale,
+            -y_panspeed * pan_scale, ymin, ymax, y_scale,
         )
         yvalue2 = utilities.get_value_at_fraction(
-            1 - y_panspeed * pan_factor, ymin, ymax, y_scale,
+            1 - y_panspeed * pan_scale, ymin, ymax, y_scale,
         )
         if x_scale == 4:
             xvalue1, xvalue2 = xvalue2, xvalue1
@@ -220,29 +212,15 @@ class Canvas(FigureCanvas, Graphs.CanvasInterface):
 
     @staticmethod
     def _calculate_zoomed_values(fraction, scale, limit, zoom_factor):
-        value = utilities.get_value_at_fraction(
-            fraction, limit[0], limit[1], scale,
+        value1 = utilities.get_value_at_fraction(
+            fraction - fraction / zoom_factor, limit[0], limit[1], scale,
         )
-        match scale:
-            case 0 | 2:
-                return (value - (value - limit[0]) / zoom_factor,
-                        value + (limit[1] - value) / zoom_factor)
-            case 1:
-                return (10 ** (numpy.log10(value) - (numpy.log10(value)
-                               - numpy.log10(limit[0])) / zoom_factor),
-                        10 ** (numpy.log10(value) + (numpy.log10(limit[1])
-                               - numpy.log10(value)) / zoom_factor))
-            case 3:
-                sqrt_value = numpy.sqrt(value)
-                return ((sqrt_value - (sqrt_value - numpy.sqrt(limit[0]))
-                         / zoom_factor) ** 2,
-                        (sqrt_value + (numpy.sqrt(limit[1]) - sqrt_value)
-                         / zoom_factor) ** 2)
-            case 4:
-                return (1 / (1 / value - (1 / value - 1 / limit[0])
-                             / zoom_factor),
-                        1 / (1 / value + (1 / limit[1] - 1 / value)
-                             / zoom_factor))
+        value2 = utilities.get_value_at_fraction(
+            fraction + (1 - fraction) / zoom_factor, limit[0], limit[1], scale,
+        )
+        if scale == 4:
+            value1, value2 = value2, value1
+        return value1, value2
 
     def on_draw_event(self, _widget, ctx):
         """

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -198,30 +198,30 @@ class Canvas(FigureCanvas, Graphs.CanvasInterface):
         ymin, ymax = min(ax.get_ylim()), max(ax.get_ylim())
         xspan = xmax - xmin
         yspan = ymax - ymin
-        pan_factor = 0.002
+        pan_factor = 0.00125
         scale = scales.to_int(ax.get_yscale()) if x_panspeed == 0 else scales.to_int(ax.get_xscale())
         match scale:
             case 0 | 2: # linear scale
                 return (xmin + xspan * x_panspeed * pan_factor, xmax + xspan * x_panspeed * pan_factor,
-                        ymin + yspan * y_panspeed * pan_factor, ymax + yspan * y_panspeed * pan_factor)
+                        ymin - yspan * y_panspeed * pan_factor, ymax - yspan * y_panspeed * pan_factor)
             case 1: #log scale
-                xmin *= 10**(x_panspeed * pan_factor * 0.1)
-                xmax *= 10**(x_panspeed * pan_factor * 0.1)
-                ymin *= 10**(y_panspeed * pan_factor * 0.1)
-                ymax *= 10**(y_panspeed * pan_factor * 0.1)
+                xmin *= 10**(x_panspeed * pan_factor * 0.3)
+                xmax *= 10**(x_panspeed * pan_factor * 0.3)
+                ymin /= 10**(y_panspeed * pan_factor * 0.3)
+                ymax /= 10**(y_panspeed * pan_factor * 0.3)
                 return xmin, xmax, ymin, ymax
             case 3: # square root scale
                 sqrt_xmin = xmin + numpy.sqrt(abs(xmin)) * x_panspeed * pan_factor
                 sqrt_xmax = xmax + numpy.sqrt(abs(xmax)) * x_panspeed * pan_factor
-                sqrt_ymin = ymin + numpy.sqrt(abs(ymin)) * y_panspeed * pan_factor
-                sqrt_ymax = ymax + numpy.sqrt(abs(ymax)) * y_panspeed * pan_factor
+                sqrt_ymin = ymin - numpy.sqrt(abs(ymin)) * y_panspeed * pan_factor
+                sqrt_ymax = ymax - numpy.sqrt(abs(ymax)) * y_panspeed * pan_factor
 
                 return sqrt_xmin, sqrt_xmax, sqrt_ymin, sqrt_ymax
             case 4: # inverted scale
                 inv_xmin = xmax + xspan * x_panspeed * pan_factor
                 inv_xmax = xmin + xspan * x_panspeed * pan_factor
-                inv_ymin = ymax + yspan * y_panspeed * pan_factor
-                inv_ymax = ymin + yspan * y_panspeed * pan_factor
+                inv_ymin = ymax - yspan * y_panspeed * pan_factor
+                inv_ymax = ymin - yspan * y_panspeed * pan_factor
                 return inv_xmin, inv_xmax, inv_ymin, inv_ymax
 
     @staticmethod


### PR DESCRIPTION
Implements drag to pan with two-fingers on the touchpad, or using horizontal/vertical scrolls. 
To zoom in with the scroll wheel a ctrl modifier now has to be used, resulting in the same behaviour as applications like Inkscape and LibreOffice.

Closes #595 

Still WIP, as this needs to be cleaned up and will probably not pass linting, haven't even checked the linter locally but thought I'd put this up before I call it a day. Also there's some slight bugs in the inverse scale at least, and need to tweak the values a bit.