### PR TITLE
Panning tweaks

### DIFF
--- a/src/canvas.py
+++ b/src/canvas.py
@@ -11,7 +11,7 @@ interactive navigation in conjunction with graphs-specific structures.
 """
 from contextlib import nullcontext
 
-from gi.repository import GObject, Graphs, Gtk
+from gi.repository import GObject, Gdk, Graphs, Gtk
 
 from graphs import artist, misc, scales, utilities
 from graphs.figure_settings import FigureSettingsWindow
@@ -154,11 +154,14 @@ class Canvas(FigureCanvas, Graphs.CanvasInterface):
             return
         self.zoom(scale)
 
-    def _on_pan_gesture(self, _event_controller, x, y):
+    def _on_pan_gesture(self, event_controller, x, y):
         """
         Determines what to do when a panning gesture is detected, pans the
         canvas in the gesture direction.
         """
+        if event_controller.get_unit() == Gdk.ScrollUnit.WHEEL:
+            x *= 10
+            y *= 10
         if self.get_application().get_ctrl() is False:
             for ax in self.axes:
                 xmin, xmax, ymin, ymax = \
@@ -619,9 +622,12 @@ class _DummyToolbar(NavigationToolbar2):
 
     # Overwritten function - do not change name
     def _zoom_pan_handler(self, event):
-        if event.button != 1:
-            return
         mode = self.canvas.get_application().get_mode()
+        if event.button == 2:
+            event.button = 1
+            mode = 0
+        elif event.button != 1:
+            return
         if mode == 0:
             if event.name == "button_press_event":
                 self.press_pan(event)


### PR DESCRIPTION
- Enables middle-click to pan, regardless of current mode of operation. This mimics the same behaviour as other tools such as Inkscape, and is thus more consistent with regard to the new gestures
- Accelerates the panning values with a factor of 10 when a mouse wheel is used to pan, as it was way too slow now with the mouse wheel.

Open to suggestions with regard to the scrolling speed, as well as the implementation of middle click panning and its merits. The implementation itself very effective, but not the most beautiful code I've ever seen to just overwrite the event button and mode when a middle click is detected. 

Middle click to pan is not exactly essential, as there's a whole dedicated mode to it, so I'm fine with leaving that out. But it felt like an intuitive way to pan the canvas as it's the default panning behaviour for many applications.