### PR TITLE
Use delimiter dropdown

### DIFF
--- a/data/se.sjoerd.Graphs.gschema.xml
+++ b/data/se.sjoerd.Graphs.gschema.xml
@@ -49,6 +49,15 @@
     <value nick=". " value="1"/>
   </enum>
 
+  <enum id="se.sjoerd.Graphs.import-params.colums.delimiters">
+    <value nick="whitespace" value="0"/>
+    <value nick="tabs" value="1"/>
+    <value nick="comma" value="2"/>
+    <value nick="semicolon" value="3"/>
+    <value nick="period" value="4"/>
+    <value nick="custom" value="5"/>
+  </enum>
+
   <schema id="se.sjoerd.Graphs" path="/se/sjoerd/Graphs/">
     <child name="actions" schema="se.sjoerd.Graphs.actions"/>
     <child name="add-equation" schema="se.sjoerd.Graphs.add-equation"/>
@@ -169,12 +178,19 @@
     <key name="column-y" type="i">
       <default>1</default>
     </key>
-    <key name="delimiter" type="s">
-      <default>"\\s+"</default>
+
+    <key name="delimiter" enum="se.sjoerd.Graphs.import-params.colums.delimiters">
+      <default>"whitespace"</default>
     </key>
+
+    <key name="custom-delimiter" type="s">
+      <default>""</default>
+    </key>
+
     <key name="separator" enum="se.sjoerd.Graphs.import-params.colums.separators">
       <default>". "</default>
     </key>
+
     <key name="skip-rows" type="i">
       <default>0</default>
     </key>

--- a/data/se.sjoerd.Graphs.gschema.xml
+++ b/data/se.sjoerd.Graphs.gschema.xml
@@ -52,10 +52,11 @@
   <enum id="se.sjoerd.Graphs.import-params.colums.delimiters">
     <value nick="whitespace" value="0"/>
     <value nick="tabs" value="1"/>
-    <value nick="comma" value="2"/>
+    <value nick="colon" value="2"/>
     <value nick="semicolon" value="3"/>
-    <value nick="period" value="4"/>
-    <value nick="custom" value="5"/>
+    <value nick="comma" value="4"/>
+    <value nick="period" value="5"/>
+    <value nick="custom" value="6"/>
   </enum>
 
   <schema id="se.sjoerd.Graphs" path="/se/sjoerd/Graphs/">

--- a/data/ui/import.blp
+++ b/data/ui/import.blp
@@ -51,9 +51,18 @@ template $GraphsImportWindow : Adw.Window {
         spacing: 10;
         Adw.PreferencesGroup columns_group {
           visible: false;
-          Adw.EntryRow columns_delimiter {
+          Adw.ComboRow columns_delimiter {
+            title: _("Delimiter");
+            notify::selected => $on_delimiter_change();
+            model: StringList{
+              strings [_("Whitespace"), _("Tab"), _("Decimal comma (,)"),
+                       _("Semicolon (;)"), _("Decimal point (.)"), _("Custom")]
+            };
+          }
+          Adw.EntryRow columns_custom_delimiter {
+            visible: false;
             max-width-chars: 10;
-            title: _("Delimiter (\s+ for whitespace)");
+            title: _("Custom Delimiter");
           }
 
           Adw.ComboRow columns_separator {

--- a/data/ui/import.blp
+++ b/data/ui/import.blp
@@ -55,8 +55,8 @@ template $GraphsImportWindow : Adw.Window {
             title: _("Delimiter");
             notify::selected => $on_delimiter_change();
             model: StringList{
-              strings [_("Whitespace"), _("Tab"), _("Decimal comma (,)"),
-                       _("Semicolon (;)"), _("Decimal point (.)"), _("Custom")]
+              strings [_("Whitespace"), _("Tab"), _("Colon (:)"), _("Semicolon (;)"),
+                       _("Decimal comma (,)"), _("Decimal point (.)"), _("Custom")]
             };
           }
           Adw.EntryRow columns_custom_delimiter {

--- a/src/file_import.py
+++ b/src/file_import.py
@@ -64,6 +64,7 @@ class _ImportWindow(Adw.Window):
 
     columns_group = Gtk.Template.Child()
     columns_delimiter = Gtk.Template.Child()
+    columns_custom_delimiter = Gtk.Template.Child()
     columns_separator = Gtk.Template.Child()
     columns_column_x = Gtk.Template.Child()
     columns_column_y = Gtk.Template.Child()
@@ -85,6 +86,11 @@ class _ImportWindow(Adw.Window):
             )
             getattr(self, f"{mode}_group").set_visible(True)
         self.present()
+
+    @Gtk.Template.Callback()
+    def on_delimiter_change(self, _action, _target):
+        delimiter_choice = self.columns_delimiter.get_selected()
+        self.columns_custom_delimiter.set_visible(delimiter_choice == 5)
 
     @Gtk.Template.Callback()
     def on_reset(self, _widget):

--- a/src/file_import.py
+++ b/src/file_import.py
@@ -90,7 +90,7 @@ class _ImportWindow(Adw.Window):
     @Gtk.Template.Callback()
     def on_delimiter_change(self, _action, _target):
         delimiter_choice = self.columns_delimiter.get_selected()
-        self.columns_custom_delimiter.set_visible(delimiter_choice == 5)
+        self.columns_custom_delimiter.set_visible(delimiter_choice == 6)
 
     @Gtk.Template.Callback()
     def on_reset(self, _widget):

--- a/src/migrate.py
+++ b/src/migrate.py
@@ -77,6 +77,8 @@ def _migrate_import_params(settings_, import_file):
         for key, value in params.items():
             if key == "separator":
                 settings.set_string(key, f"{value} ")
+            if key == "delimiter":
+                settings.set_string("custom-delimiter", value)
                 continue
             elif isinstance(value, int):
                 key = key.replace("_", "-")

--- a/src/migrate.py
+++ b/src/migrate.py
@@ -78,7 +78,8 @@ def _migrate_import_params(settings_, import_file):
             if key == "separator":
                 settings.set_string(key, f"{value} ")
             if key == "delimiter":
-                settings.set_string("custom-delimiter", value)
+                settings.set_string("custom-delimiter",
+                    misc.delimiter(settings))
                 continue
             elif isinstance(value, int):
                 key = key.replace("_", "-")

--- a/src/migrate.py
+++ b/src/migrate.py
@@ -79,7 +79,7 @@ def _migrate_import_params(settings_, import_file):
                 settings.set_string(key, f"{value} ")
             if key == "delimiter":
                 settings.set_string("custom-delimiter",
-                    misc.delimiter(settings))
+                                    misc.get_delimiter(settings))
                 continue
             elif isinstance(value, int):
                 key = key.replace("_", "-")

--- a/src/migrate.py
+++ b/src/migrate.py
@@ -77,13 +77,20 @@ def _migrate_import_params(settings_, import_file):
         for key, value in params.items():
             if key == "separator":
                 settings.set_string(key, f"{value} ")
+                continue
             if key == "delimiter":
-                settings.set_string("custom-delimiter",
-                                    misc.get_delimiter(settings))
+                if value in misc.DELIMITERS.values():
+                    value = \
+                        next((key for key, delimiter in misc.DELIMITERS.items()
+                             if delimiter == value),
+                             misc.get_delimiter(settings))
+                    settings.set_string("delimiter", f"{value}")
+                else:
+                    settings.set_string("delimiter", "custom")
+                    settings.set_string("custom-delimiter", value)
                 continue
             elif isinstance(value, int):
                 key = key.replace("_", "-")
-            settings[key] = value
     import_file.delete(None)
 
 
@@ -145,6 +152,7 @@ PLOT_SETTINGS_MIGRATION_TABLE = {
     "yscale": "left_scale",
     "use_custom_plot_style": "use_custom_style",
     "custom_plot_style": "custom_style",
+    "mix_right": "min_right",
 }
 
 LEGEND_POSITIONS = [

--- a/src/misc.py
+++ b/src/misc.py
@@ -31,7 +31,7 @@ LIMITS = [
 ]
 
 
-def get_delimiters(settings):
+def get_delimiter(settings):
     columns_params = settings.get_child("import-params").get_child("columns")
     delimiter_value = DELIMITERS[columns_params.get_string("delimiter")]
     delimiter_value = columns_params.get_string("custom-delimiter") \

--- a/src/misc.py
+++ b/src/misc.py
@@ -16,6 +16,10 @@ LEGEND_POSITIONS = [
     "best", "upper right", "upper left", "lower left", "lower right",
     "center left", "center right", "lower center", "upper center", "center",
 ]
+DELIMITERS = {
+    "whitespace": "\\s+", "tabs": "\\t+", "comma": ",", "semicolon": ";",
+    "period": ".", "custom": "custom",
+}
 LINESTYLES = ["none", "solid", "dotted", "dashed", "dashdot"]
 MARKERSTYLES = [
     "none", ".", ",", "o", "v", "^", "<", ">", "8", "s", "p", "*", "h", "H",

--- a/src/misc.py
+++ b/src/misc.py
@@ -29,3 +29,10 @@ LIMITS = [
     "min_bottom", "max_bottom", "min_top", "max_top",
     "min_left", "max_left", "min_right", "max_right",
 ]
+
+def get_delimiters(settings):
+    columns_params = settings.get_child("import-params").get_child("columns")
+    delimiter_value = DELIMITERS[columns_params.get_string("delimiter")]
+    delimiter_value = columns_params.get_string("custom-delimiter") \
+        if delimiter_value == "custom" else delimiter_value
+    return delimiter_value

--- a/src/misc.py
+++ b/src/misc.py
@@ -30,6 +30,7 @@ LIMITS = [
     "min_left", "max_left", "min_right", "max_right",
 ]
 
+
 def get_delimiters(settings):
     columns_params = settings.get_child("import-params").get_child("columns")
     delimiter_value = DELIMITERS[columns_params.get_string("delimiter")]

--- a/src/misc.py
+++ b/src/misc.py
@@ -17,8 +17,8 @@ LEGEND_POSITIONS = [
     "center left", "center right", "lower center", "upper center", "center",
 ]
 DELIMITERS = {
-    "whitespace": "\\s+", "tabs": "\\t+", "comma": ",", "semicolon": ";",
-    "period": ".", "custom": "custom",
+    "whitespace": "\\s+", "tabs": "\\t+", "colon": ":", "semicolon": ";",
+    "comma": ",", "period": ".", "custom": "custom",
 }
 LINESTYLES = ["none", "solid", "dotted", "dashed", "dashdot"]
 MARKERSTYLES = [

--- a/src/parse_file.py
+++ b/src/parse_file.py
@@ -3,7 +3,7 @@ import re
 from gettext import gettext as _
 
 from graphs import file_io, item, migrate, utilities
-from graphs.misc import ParseError
+from graphs.misc import DELIMITERS, ParseError
 
 import numpy
 
@@ -104,9 +104,11 @@ def import_from_columns(self, file):
         "import-params").get_child("columns")
     column_x = columns_params.get_int("column-x")
     column_y = columns_params.get_int("column-y")
-    delimiter = columns_params.get_string("delimiter")
     separator = columns_params.get_string("separator").replace(" ", "")
     skip_rows = columns_params.get_int("skip-rows")
+    delimiter = DELIMITERS[columns_params.get_string("delimiter")]
+    delimiter = columns_params.get_string("custom-delimiter") \
+        if delimiter == "custom" else delimiter
     with file_io.open_wrapped(file, "rt") as wrapper:
         for index, line in enumerate(wrapper, -skip_rows):
             if index < 0:

--- a/src/parse_file.py
+++ b/src/parse_file.py
@@ -2,8 +2,8 @@
 import re
 from gettext import gettext as _
 
-from graphs import file_io, item, migrate, utilities
-from graphs.misc import DELIMITERS, ParseError
+from graphs import file_io, item, migrate, misc, utilities
+from graphs.misc import ParseError
 
 import numpy
 
@@ -106,9 +106,7 @@ def import_from_columns(self, file):
     column_y = columns_params.get_int("column-y")
     separator = columns_params.get_string("separator").replace(" ", "")
     skip_rows = columns_params.get_int("skip-rows")
-    delimiter = DELIMITERS[columns_params.get_string("delimiter")]
-    delimiter = columns_params.get_string("custom-delimiter") \
-        if delimiter == "custom" else delimiter
+    delimiter = misc.get_delimiter(self.get_settings())
     with file_io.open_wrapped(file, "rt") as wrapper:
         for index, line in enumerate(wrapper, -skip_rows):
             if index < 0:


### PR DESCRIPTION
Adds a dropdown menu for the delimiter choices with more understandable options. When a custom delimiter is chosen, an entry row is shown where the delimiter can be specified manually. Closes issue #627 

![image](https://github.com/Sjoerd1993/Graphs/assets/68477016/0bdb9b8f-73d8-46fe-96fb-6c04e2c0adb2)
