### PR TITLE
update style-preview CSS

### DIFF
--- a/data/style.css
+++ b/data/style.css
@@ -37,7 +37,8 @@ gridview#style-grid {
 }
 
 gridview#style-grid child {
-  margin: 6px 6px 6px 6px;
+  margin: 9px 9px 9px 9px;
+  border-radius: 15px;
 }
 
 gridview#style-grid child:selected {


### PR DESCRIPTION
Updates the style preview CSS to get the outline of the selected grid to match with the outline of the active theme. Open to suggestions to slightly different tweaks. But it adresses the point in the GNOME Circle review about the mismatch in border-radius. Thus closes issue #633 


![Skärmbild från 2023-12-08 13-56-09](https://github.com/Sjoerd1993/Graphs/assets/68477016/086be03a-47fc-4dbe-94f5-3f86c9764c0d)
![Skärmbild från 2023-12-08 13-50-46](https://github.com/Sjoerd1993/Graphs/assets/68477016/aec6b463-871a-41b6-bdc7-1e1064aa8a3e)
