### PR TITLE
Fix adwaita capitalization

### DIFF
--- a/src/figure_settings.vala
+++ b/src/figure_settings.vala
@@ -16,7 +16,7 @@ namespace Graphs {
         public bool legend { get; set; default = true; }
         public int legend_position { get; set; default = 0; }
         public bool use_custom_style { get; set; default = false; }
-        public string custom_style { get; set; default = "adwaita"; }
+        public string custom_style { get; set; default = "Adwaita"; }
         public bool hide_unselected { get; set; default = false; }
 
         public double min_bottom { get; set; default = 0; }

--- a/src/styles.py
+++ b/src/styles.py
@@ -36,7 +36,7 @@ class StyleManager(GObject.Object, Graphs.StyleManagerInterface):
 
     application = GObject.Property(type=Graphs.Application)
     use_custom_style = GObject.Property(type=bool, default=False)
-    custom_style = GObject.Property(type=str, default="adwaita")
+    custom_style = GObject.Property(type=str, default="Adwaita")
     style_model = GObject.Property(type=Gio.ListStore)
 
     def __init__(self, application: Graphs.Application):


### PR DESCRIPTION
Since styles now use the style name instead of the filename, the adwaita style should be loaded as "Adwaita". It is for this reason that you see a "adwaita does not exist, loading prefered style" right now when opening a new project. This fixes that by properly setting the default style to Adwaita instead of adwaita.