### PR TITLE
Fix hide unselected items

### DIFF
--- a/src/canvas.py
+++ b/src/canvas.py
@@ -276,7 +276,9 @@ class Canvas(FigureCanvas, Graphs.CanvasInterface):
         if self.props.hide_unselected:
             drawable_items = []
             for item in self.props.items:
-                item.connect("notify::selected", self._redraw)
+                if hasattr(item, "handler"):
+                    item.disconnect(item.handler)
+                item.handler = item.connect("notify::selected", self._redraw)
                 if item.get_selected():
                     drawable_items.append(item)
         else:


### PR DESCRIPTION
Currently when "hide unselected" is turned on, a handler is connected to them that redraws the canvas when the item is selected. This happens however on every single instance the canvas is redrawn, and thus a second handler is connected to the item when the item is selected a second time, and this keeps adding up. Eventually so many signals are sent, that selecting/deselecting an item becomes unusable. See screencast.

[Skärminspelning från 2023-12-08 21-29-01.webm](https://github.com/Sjoerd1993/Graphs/assets/68477016/c263402a-765e-4745-a83c-c7328e9bab5b)

This PR fixes this. It's not my favourite thing in the world to slap an attribute to the items, but the handler needs to be overwritten on each redraw. So basically this attribute is just used to check if a handler exists. If it does, we disconnect it before connecting a new one.