### PR TITLE
Add shift to scroll horizontally

### DIFF
--- a/src/application.py
+++ b/src/application.py
@@ -175,7 +175,9 @@ class PythonApplication(Graphs.Application):
         """
         if keyval == 65507 or keyval == 65508:  # Control_L or Control_R
             self.set_ctrl(True)
-        else:  # Prevent Ctrl from being true with key combos
+        if keyval == 65505 or keyval == 65506:  # Left or right Shift
+            self.set_shift(True)
+        else:  # Prevent keys from being true with key combos
             self.set_ctrl(False)
 
     def on_key_release_event(self, _controller, _keyval, _keycode, _state):
@@ -184,6 +186,7 @@ class PythonApplication(Graphs.Application):
         as the key press event from matplotlib is not working properly atm.
         """
         self.set_ctrl(False)
+        self.set_shift(False)
 
     def do_activate(self):
         """

--- a/src/application.vala
+++ b/src/application.vala
@@ -15,6 +15,7 @@ namespace Graphs {
         public string author { get; construct set; default = ""; }
         public string pkgdatadir { get; construct set; default = ""; }
         public bool ctrl { get; construct set; default = false; }
+        public bool shift { get; construct set; default = false; }
 
         public Settings get_settings_child (string path) {
             Settings settings = this.settings;

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -159,6 +159,8 @@ class Canvas(FigureCanvas, Graphs.CanvasInterface):
         Determines what to do when a panning gesture is detected, pans the
         canvas in the gesture direction.
         """
+        if self.get_application().get_shift():
+            x, y = y, x
         if event_controller.get_unit() == Gdk.ScrollUnit.WHEEL:
             x *= 10
             y *= 10


### PR DESCRIPTION
Adds the option to scroll horizontally by holding shift. [See GNOME Circle Review](https://gitlab.gnome.org/Teams/Circle/-/issues/185).


 - [x]  `Shift + Scrollwheel` on the canvas should pan horizontally: