### PR TITLE
Curve fitting redesign

### DIFF
--- a/data/ui/curve_fitting.blp
+++ b/data/ui/curve_fitting.blp
@@ -7,6 +7,9 @@ template $GraphsCurveFittingTool : Adw.Window {
   focus-widget: confirm_button;
   default-width: 1000;
   default-height: 650;
+  width-request: 305;
+  height-request: 410;
+
   ShortcutController {
     Shortcut {
       trigger: "Escape";
@@ -14,79 +17,96 @@ template $GraphsCurveFittingTool : Adw.Window {
     }
   }
 
-  Adw.ToolbarView {
-    [top]
-    Adw.HeaderBar {
-      show-end-title-buttons: false;
-      [start]
-      Button {
-        label: _("Cancel");
-        action-name: "window.close";
-      }
-
-      [end]
-      Button confirm_button {
-        label: _("Add Fit to Data");
-        styles ["suggested-action"]
-      }
+  Adw.Breakpoint {
+    condition ("max-width: 725sp")
+    setters {
+      split_view.collapsed: true;
     }
+  }
 
-    Box {
-      Box{
+  content: Adw.ToolbarView {
+    top-bar-style: flat;
+    content: Adw.OverlaySplitView split_view {
+      show-sidebar: bind show_sidebar_button.active;
+      notify => $on_sidebar_toggle();
+      sidebar: Box {
         orientation: vertical;
-        vexpand: true;
-        width-request: 285;
-        Adw.EntryRow equation {
-          margin-top: 12;
-          margin-bottom: 12;
-          margin-start: 12;
-          margin-end: 3;
-          title: _("Equation");
-          styles ["card"]
+        Adw.HeaderBar {
+          styles ["flat"]
+          title-widget: Adw.WindowTitle title_widget {
+            title: "Graphs";
+          };
         }
-        ScrolledWindow {
+        ScrolledWindow fitting_param_entries {
           vexpand: true;
-          height-request: 100;
+          width-request: 275;
           hscrollbar-policy: never;
           Box {
             vexpand: true;
             orientation: vertical;
             margin-start: 12;
-            margin-end: 3;
-            Box fitting_params {
-              margin-top: 12;
-              spacing: 12;
-              orientation: vertical;
+            margin-end: 12;
+            margin-bottom: 12;
+            margin-top: 12;
+            Adw.PreferencesGroup {
+              Adw.EntryRow equation {
+                title: _("Equation");
+              }
+              Box fitting_params {
+                margin-top: 12;
+                margin-bottom: 12;
+                spacing: 12;
+                orientation: vertical;
+              }
+              ScrolledWindow {
+                vexpand: false;
+                hexpand: false;
+                hscrollbar-policy: automatic;
+                vscrollbar-policy: never;
+                TextView text_view {
+                  halign: fill;
+                  top-margin: 12;
+                  left-margin: 12;
+                  bottom-margin: 12;
+                  editable: false;
+                  styles ["card"]
+                }
+              }
+              Button confirm_button {
+                margin-start: 12;
+                margin-end: 12;
+                margin-bottom: 12;
+                margin-top: 12;
+                label: _("Add Fit to Data");
+                styles ["pill"]
+              }
             }
           }
         }
-        [end]
-        ScrolledWindow {
-          margin-top: 6;
-          height-request: 150;
-          margin-bottom: 12;
-          margin-start: 12;
-          margin-end: 3;
-          TextView text_view {
-            vexpand: false;
-            top-margin: 12;
-            left-margin: 12;
-            bottom-margin: 12;
-            editable: false;
-            styles ["card"]
+      };
+      content:
+      Box {
+      orientation: vertical;
+        Adw.HeaderBar {
+          styles ["flat"]
+          ToggleButton show_sidebar_button {
+            icon-name: "sidebar-show-symbolic";
+            tooltip-text: _("Toggle Sidebar");
+            active: bind split_view.show-sidebar;
+            visible: bind split_view.collapsed;
           }
         }
-      }
-      Adw.ToastOverlay toast_overlay {
-        focusable: true;
-        height-request: 150;
-        width-request: 300;
-        hexpand: true;
-        child: Adw.StatusPage {
-          icon-name: "dialog-error-symbolic";
-          title: _("Canvas Failed to Load");
-        };
-      }
-    }
-  }
+        Adw.ToastOverlay toast_overlay {
+          focusable: true;
+          height-request: 150;
+          width-request: 300;
+          hexpand: true;
+          child: Adw.StatusPage {
+            icon-name: "dialog-error-symbolic";
+            title: _("Canvas Failed to Load");
+          };
+        }
+      };
+    };
+  };
 }

--- a/data/ui/curve_fitting.blp
+++ b/data/ui/curve_fitting.blp
@@ -78,7 +78,7 @@ template $GraphsCurveFittingTool : Adw.Window {
                 margin-bottom: 12;
                 margin-top: 12;
                 label: _("Add Fit to Data");
-                styles ["pill"]
+                styles ["pill", "suggested-action"]
               }
             }
           }

--- a/data/ui/fitting_parameters.blp
+++ b/data/ui/fitting_parameters.blp
@@ -3,51 +3,52 @@ using Adw 1;
 
 template $GraphsFittingParameterEntry : Box {
   orientation: vertical;
-  Adw.PreferencesGroup {
-    Grid {
+  Grid {
+    margin-bottom: 4;
+    margin-top: 4;
+    column-spacing: 4;
+    row-spacing: 4;
+    Label label {
+      justify: left;
+      use-markup: true;
       margin-bottom: 4;
-      margin-top: 4;
-      column-spacing: 4;
-      row-spacing: 4;
-      Label label {
-        justify: left;
-        use-markup: true;
-        margin-bottom: 4;
-        hexpand: false;
-        halign: start;
-        layout {
-          column: 0;
-          row: 0;
-          column-span: 2;
-        }
+      hexpand: false;
+      halign: start;
+      layout {
+        column: 0;
+        row: 0;
+        column-span: 2;
       }
+    }
+    Adw.PreferencesGroup {
       Adw.EntryRow initial {
-        title: _("Initial guess");
+        title: _("Initial Guess");
         text: "1";
+        }
         layout {
           column: 0;
           row: 1;
           column-span: 2;
-        }
-        styles ["card"]
       }
+    }
+    Adw.PreferencesGroup {
       Adw.EntryRow lower_bound {
         title: _("Minimum");
         text: "-inf";
-        layout {
-          column: 0;
-          row: 2;
-        }
-        styles ["card"]
       }
+      layout {
+        column: 0;
+        row: 2;
+      }
+    }
+    Adw.PreferencesGroup {
       Adw.EntryRow upper_bound {
         title: _("Maximum");
         text: "inf";
-        layout {
-          column: 1;
-          row: 2;
-        }
-        styles ["card"]
+      }
+      layout {
+        column: 1;
+        row: 2;
       }
     }
   }

--- a/src/application.vala
+++ b/src/application.vala
@@ -15,6 +15,7 @@ namespace Graphs {
         public string author { get; construct set; default = ""; }
         public string pkgdatadir { get; construct set; default = ""; }
         public bool ctrl { get; construct set; default = false; }
+        public bool shift { get; construct set; default = false; }
 
         public Settings get_settings_child (string path) {
             Settings settings = this.settings;

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -78,7 +78,7 @@ class Canvas(FigureCanvas, Graphs.CanvasInterface):
     min_selected = GObject.Property(type=float, default=0)
     max_selected = GObject.Property(type=float, default=0)
 
-    def __init__(self, application, style_params):
+    def __init__(self, application, style_params, interactive=True):
         """
         Create the canvas.
 
@@ -107,26 +107,29 @@ class Canvas(FigureCanvas, Graphs.CanvasInterface):
         self.rubberband_edge_color = utilities.rgba_to_tuple(color_rgba, True)
         color_rgba.alpha = 0.3
         self.rubberband_fill_color = utilities.rgba_to_tuple(color_rgba, True)
-        # Reference is created by the toolbar itself
-        _DummyToolbar(self)
+
         self.highlight = _Highlight(self)
         self._legend = True
         self._legend_position = misc.LEGEND_POSITIONS[0]
         self._handles = []
-        self.mpl_connect("scroll_event", self._on_scroll_event)
-        self.mpl_connect("motion_notify_event", self._set_mouse_fraction)
-        self._xfrac, self._yfrac = None, None
-        zoom_gesture = Gtk.GestureZoom.new()
-        zoom_gesture.connect("scale-changed", self._on_zoom_gesture)
-        zoom_gesture.connect("end", self.figure.canvas.toolbar.push_current)
-        scroll_gesture =  \
-            Gtk.EventControllerScroll.new(
-                Gtk.EventControllerScrollFlags.BOTH_AXES)
-        scroll_gesture.connect("scroll", self._on_pan_gesture)
-        scroll_gesture.connect("scroll-end",
-                               self.figure.canvas.toolbar.push_current)
-        self.add_controller(zoom_gesture)
-        self.add_controller(scroll_gesture)
+        if interactive:
+            # Reference is created by the toolbar itself
+            _DummyToolbar(self)
+            self.mpl_connect("scroll_event", self._on_scroll_event)
+            self.mpl_connect("motion_notify_event", self._set_mouse_fraction)
+            self._xfrac, self._yfrac = None, None
+            zoom_gesture = Gtk.GestureZoom.new()
+            zoom_gesture.connect("scale-changed", self._on_zoom_gesture)
+            zoom_gesture.connect("end",
+                                 self.figure.canvas.toolbar.push_current)
+            scroll_gesture =  \
+                Gtk.EventControllerScroll.new(
+                    Gtk.EventControllerScrollFlags.BOTH_AXES)
+            scroll_gesture.connect("scroll", self._on_pan_gesture)
+            scroll_gesture.connect("scroll-end",
+                                   self.figure.canvas.toolbar.push_current)
+            self.add_controller(zoom_gesture)
+            self.add_controller(scroll_gesture)
 
         self.connect("notify::hide-unselected", self._redraw)
         self.connect("notify::items", self._redraw)

--- a/src/curve_fitting.py
+++ b/src/curve_fitting.py
@@ -27,17 +27,14 @@ class CurveFittingWindow(Graphs.CurveFittingTool):
         super().__init__(
             application=application, transient_for=application.get_window(),
         )
+        Adw.StyleManager.get_default().connect("notify", self.reload_canvas)
         self.equation = self.get_equation()
         ui.bind_values_to_settings(
             application.get_settings_child("curve-fitting"), self)
         self.get_confirm_button().connect("clicked", self.add_fit)
         style = application.get_figure_style_manager(
         ).get_system_style_params()
-        canvas = Canvas(application, style)
 
-        figure_settings_main = application.get_data().get_figure_settings()
-        canvas.left_label = figure_settings_main.get_property("left_label")
-        canvas.bottom_label = figure_settings_main.get_property("bottom_label")
         self.param = []
         self.sigma = []
         self.r2 = 0
@@ -48,7 +45,8 @@ class CurveFittingWindow(Graphs.CurveFittingTool):
 
         for var in self.get_free_variables():
             self.fitting_parameters.add_items([FittingParameter(name=var)])
-        # Generate item for the data that is fitted to
+
+        # Generate items for the canvas
         self.data_curve = DataItem.new(
             style, xdata=item.xdata, ydata=item.ydata,
             name=item.get_name(), color="#1A5FB4",
@@ -56,10 +54,7 @@ class CurveFittingWindow(Graphs.CurveFittingTool):
         self.data_curve.linestyle = 0
         self.data_curve.markerstyle = 1
         self.data_curve.markersize = 13
-
-        # Generate item for the fit
         self.fitted_curve = DataItem.new(style, color="#A51D2D")
-
         self.fill = FillItem.new(
             style,
             (self.fitted_curve.xdata,
@@ -69,19 +64,32 @@ class CurveFittingWindow(Graphs.CurveFittingTool):
         )
 
         # Set up canvas
-        canvas.props.items = [self.fitted_curve, self.data_curve, self.fill]
+        self.reload_canvas()
+        self.fit_curve()
+        self.set_entry_rows()
+        self.present()
 
+    def reload_canvas(self, *_args):
+        self.get_toast_overlay().set_child(None)
+        figure_settings = self.get_application().get_data(
+        ).get_figure_settings()
+        style = self.get_application().get_figure_style_manager(
+        ).get_system_style_params()
+        canvas = Canvas(self.get_application(), style)
+        canvas.props.items = [self.fitted_curve, self.data_curve, self.fill]
         axis = canvas.axes[0]
         axis.yscale = "linear"
         axis.xscale = "linear"
+        axis.xlabel = "X Value"
+        canvas.left_label = figure_settings.get_property("left_label")
+        canvas.bottom_label = figure_settings.get_property("bottom_label")
         canvas.highlight_enabled = False
-        canvas.toolbar = None
+        canvas = canvas
+        canvas._on_pan_gesture = None
         canvas._on_pick = None
+        canvas.toolbar = None
         self.canvas = canvas
-        self.fit_curve()
-        self.set_entry_rows()
-        self.get_toast_overlay().set_child(canvas)
-        self.present()
+        self.get_toast_overlay().set_child(self.canvas)
 
     def get_free_variables(self):
         return re.findall(
@@ -103,6 +111,8 @@ class CurveFittingWindow(Graphs.CurveFittingTool):
         Triggered whenever an entry changes. Update the parameters of the
         curve and perform a new subsequent fit.
         """
+        error = False
+
         def _is_float(value):
             """
             Checks if a value can be converted to a float. If not, it adds a
@@ -128,35 +138,52 @@ class CurveFittingWindow(Graphs.CurveFittingTool):
                 entries.lower_bound.get_child().remove_css_class("error")
                 entries.upper_bound.get_child().remove_css_class("error")
 
-                new_initial = float(initial) if _is_float(initial) else 1
-                new_lower_bound = float(lower_bound) \
-                    if _is_float(lower_bound) else float("inf")
-                new_upper_bound = float(upper_bound) \
-                    if _is_float(upper_bound) else float("-inf")
+                for bound in [initial, lower_bound, upper_bound]:
+                    if not _is_float(bound):
+                        self.set_results(error="value")
+                        return
 
-                if (new_initial < new_lower_bound
-                        or new_initial > new_upper_bound):
+                initial = float(initial)
+                lower_bound = float(lower_bound)
+                upper_bound = float(upper_bound)
+
+                if (initial < lower_bound
+                        or initial > upper_bound):
                     entries.initial.get_child().add_css_class("error")
-                if not new_lower_bound < new_upper_bound:
+                    self.set_results(error="bounds")
+                    error = True
+                if not lower_bound < upper_bound:
                     entries.lower_bound.get_child().add_css_class("error")
                     entries.upper_bound.get_child().add_css_class("error")
+                    error = True
+                    self.set_results(error="bounds")
 
-                params.set_initial(new_initial)
-                params.set_lower_bound(str(new_lower_bound))
-                params.set_upper_bound(str(new_upper_bound))
+                params.set_initial(initial)
+                params.set_lower_bound(str(lower_bound))
+                params.set_upper_bound(str(upper_bound))
 
-        self.fit_curve()
+        if not error:
+            self.fit_curve()
 
-    def set_results(self):
+    def set_results(self, error=""):
         initial_string = _("Results:") + "\n"
         buffer_string = initial_string
-        for index, arg in enumerate(self.get_free_variables()):
-            parameter = utilities.sig_fig_round(self.param[index], 3)
-            sigma = utilities.sig_fig_round(self.sigma[index], 3)
-            buffer_string += f"\n {arg}: {parameter}"
-            buffer_string += f" (± {sigma})"
-        buffer_string += "\n\n" + _("Sum of R²: {R2}").format(R2=self.r2)
-
+        if error == "value":
+            buffer_string += \
+                _("Please enter valid fitting \nparameters to start the fit")
+        elif error == "equation":
+            buffer_string += \
+                _("Please enter a valid equation \nto start the fit")
+        elif error == "bounds":
+            buffer_string += \
+                _("Please enter valid fitting bounds \nto start the fit")
+        else:
+            for index, arg in enumerate(self.get_free_variables()):
+                parameter = utilities.sig_fig_round(self.param[index], 3)
+                sigma = utilities.sig_fig_round(self.sigma[index], 3)
+                buffer_string += f"{arg}: {parameter}"
+                buffer_string += f" (± {sigma})\n"
+            buffer_string += "\n" + _("Sum of R²: {R2}").format(R2=self.r2)
         self.get_text_view().get_buffer().set_text(buffer_string)
         bold_tag = Gtk.TextTag(weight=700)
         self.get_text_view().get_buffer().get_tag_table().add(bold_tag)
@@ -196,6 +223,7 @@ class CurveFittingWindow(Graphs.CurveFittingTool):
         except (ValueError, TypeError, _minpack.error, RuntimeError):
             # Cancel fit if not successful
             self.get_equation().get_child().add_css_class("error")
+            self.set_results(error="equation")
             return
         xdata = numpy.linspace(
             min(self.data_curve.xdata), max(self.data_curve.xdata), 5000,
@@ -336,7 +364,7 @@ class FittingParameterEntry(Gtk.Box):
         super().__init__(application=parent.get_application())
         self.parent = parent
         self.params = parent.fitting_parameters[arg]
-        fitting_param_string = _("Fitting parameters for {param_name}").format(
+        fitting_param_string = _("Fitting Parameters for {param_name}").format(
             param_name=self.params.get_name())
         self.label.set_markup(
             f"<b> {fitting_param_string}: </b>")

--- a/src/curve_fitting.py
+++ b/src/curve_fitting.py
@@ -75,7 +75,7 @@ class CurveFittingWindow(Graphs.CurveFittingTool):
         ).get_figure_settings()
         style = self.get_application().get_figure_style_manager(
         ).get_system_style_params()
-        canvas = Canvas(self.get_application(), style)
+        canvas = Canvas(self.get_application(), style, interactive=False)
         canvas.props.items = [self.fitted_curve, self.data_curve, self.fill]
         axis = canvas.axes[0]
         axis.yscale = "linear"

--- a/src/curve_fitting.vala
+++ b/src/curve_fitting.vala
@@ -12,6 +12,9 @@ namespace Graphs {
         public unowned Gtk.Box fitting_params { get; }
 
         [GtkChild]
+        public unowned Adw.OverlaySplitView split_view { get; }
+
+        [GtkChild]
         public unowned Adw.ToastOverlay toast_overlay { get; }
 
         [GtkChild]
@@ -19,6 +22,16 @@ namespace Graphs {
 
         [GtkChild]
         public unowned Gtk.Button confirm_button { get; }
+
+        [GtkChild]
+        public unowned Adw.WindowTitle title_widget { get; }
+
+        [GtkCallback]
+        private void on_sidebar_toggle () {
+            this.application.lookup_action ("toggle_sidebar").change_state (
+                new Variant.boolean (this.split_view.get_collapsed ())
+            );
+        }
         }
 
     public class FittingParameter : Object {
@@ -28,3 +41,4 @@ namespace Graphs {
         public string upper_bound { get; construct set; default = "inf"; }
     }
 }
+


### PR DESCRIPTION
Redesigns Curve Fitting dialog according to [GNOME Circle Review](https://gitlab.gnome.org/Teams/Circle/-/issues/185):

[Skärminspelning från 2023-12-11 14-40-07.webm](https://github.com/Sjoerd1993/Graphs/assets/68477016/05a5d860-f3da-47b5-a96f-de51a1ebf9b5)


- [x]  The overall layout is awkward, I'd try just doing a split view, i.e. the Cancel button would go away (in favor of a normal close button) and the Apply button would probably be a pill button centered at the bottom of the right panel
- [x]  When switching between dark and light while the curve fitting dialog is open, the preview doesn't recolor until you close/reopen the dialog
- [x]  The empty box at the bottom of the sidebar is still weird, I'd hide it when it's empty
- [x]  The sidebar layout with fixed top and bottom elements and a scrollview in the middle is awkward. Is there a reason why we can't just put everything in a single scrollview?
- [x]  A few of the labels ("Fitting parameters", "Initial guess", etc.) don't use Title Case
- [x]  The entries have a darker hover state than normal rows/entries

The only point where I deviated is the ` The empty box at the bottom of the sidebar is still weird, I'd hide it when it's empty` comment. The results card there can only be empty when one of the values was wrong during initialization (e.g. when starting the curve fit while an invalid boundary or equation was set). Instead of hiding it, I put an error message in there instead. 