### PR TITLE
Fix ctrl button

### DIFF
--- a/src/application.py
+++ b/src/application.py
@@ -175,7 +175,7 @@ class PythonApplication(Graphs.Application):
         """
         if keyval == 65507 or keyval == 65508:  # Control_L or Control_R
             self.set_ctrl(True)
-        if keyval == 65505 or keyval == 65506:  # Left or right Shift
+        elif keyval == 65505 or keyval == 65506:  # Left or right Shift
             self.set_shift(True)
         else:  # Prevent keys from being true with key combos
             self.set_ctrl(False)


### PR DESCRIPTION
Literally a two-character PR.

Forgot to use an `elif` instead of an `if` earlier, breaking the ctrl button plus zoom. (Pressing `ctrl` means that the comparison for the shift key is false, thus triggering the 'else` condition) 

This fixes that.