### PR TITLE
Hide unused axes settings

### DIFF
--- a/data/ui/figure_settings.blp
+++ b/data/ui/figure_settings.blp
@@ -65,7 +65,6 @@ template $GraphsFigureSettingsWindow : Adw.Window {
                     Box left_limits {
                       orientation: horizontal;
                       spacing: 6;
-                      visible: false;
                       Adw.PreferencesGroup {
                         Adw.EntryRow min_left {
                           title: _("Minimum Left-Hand Y-Axis");
@@ -80,7 +79,6 @@ template $GraphsFigureSettingsWindow : Adw.Window {
                     Box bottom_limits {
                       orientation: horizontal;
                       spacing: 6;
-                      visible: false;
                       Adw.PreferencesGroup {
                         Adw.EntryRow min_bottom {
                           title: _("Minimum Bottom X-Axis");
@@ -95,7 +93,6 @@ template $GraphsFigureSettingsWindow : Adw.Window {
                     Box right_limits {
                       orientation: horizontal;
                       spacing: 6;
-                      visible: false;
                       Adw.PreferencesGroup {
                         Adw.EntryRow min_right {
                           title: _("Minimum Right-Hand Y-Axis");
@@ -110,7 +107,6 @@ template $GraphsFigureSettingsWindow : Adw.Window {
                     Box top_limits {
                       spacing: 6;
                       orientation: horizontal;
-                      visible: false;
                       Adw.PreferencesGroup {
                         Adw.EntryRow min_top {
                           title: _("Minimum Top X-Axis");

--- a/data/ui/window.blp
+++ b/data/ui/window.blp
@@ -666,6 +666,9 @@ menu view_menu {
   section {
     submenu {
       label: _("Top X Scale");
+      hidden-when: "action-disabled";
+      action: "app.change-top-scale";
+      target: "0";
       item {
         label: _("Linear");
         action: "app.change-top-scale";
@@ -694,6 +697,9 @@ menu view_menu {
     }
     submenu {
       label: _("Bottom X Scale");
+      hidden-when: "action-disabled";
+      action: "app.change-bottom-scale";
+      target: "0";
       item {
         label: _("Linear");
         action: "app.change-bottom-scale";
@@ -723,6 +729,9 @@ menu view_menu {
     }
     submenu {
       label: _("Left Y Scale");
+      hidden-when: "action-disabled";
+      action: "app.change-left-scale";
+      target: "0";
       item {
         label: _("Linear");
         action: "app.change-left-scale";
@@ -751,6 +760,9 @@ menu view_menu {
     }
     submenu {
       label: _("Right Y Scale");
+      hidden-when: "action-disabled";
+      action: "app.change-right-scale";
+      target: "0";
       item {
         label: _("Linear");
         action: "app.change-right-scale";

--- a/src/application.py
+++ b/src/application.py
@@ -230,4 +230,7 @@ class PythonApplication(Graphs.Application):
             if "(Development)" in self.props.name:
                 window.add_css_class("devel")
             self.set_figure_style_manager(styles.StyleManager(self))
+            self.get_window().get_canvas().connect_after(
+                "notify::items", ui.enable_axes_actions, self)
+            ui.enable_axes_actions(self, None, self)
             window.present()

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -110,7 +110,6 @@ class Canvas(FigureCanvas, Graphs.CanvasInterface):
 
         self.highlight = _Highlight(self)
         self._legend = True
-        self._visible_axes = (False, False, False, False)
         self._legend_position = misc.LEGEND_POSITIONS[0]
         self._handles = []
         if interactive:
@@ -275,14 +274,6 @@ class Canvas(FigureCanvas, Graphs.CanvasInterface):
             self._renderer.dpi = self.figure.dpi
             self.figure.draw(self._renderer)
 
-    @property
-    def visible_axes(self):
-        return self._visible_axes
-
-    @visible_axes.setter
-    def visible_axes(self, visible_axes):
-        self._visible_axes = visible_axes
-
     def _redraw(self, *_args):
         # bottom, top, left, right
         used_axes = [False, False, False, False]
@@ -303,7 +294,6 @@ class Canvas(FigureCanvas, Graphs.CanvasInterface):
             visible_axes[xposition] = True
             visible_axes[2 + yposition] = True
             used_axes[xposition + 2 * yposition] = True
-        self.visible_axes = visible_axes
         axes_directions = (
             ("bottom", "left"),   # axis
             ("top", "left"),      # top_left_axis
@@ -311,8 +301,8 @@ class Canvas(FigureCanvas, Graphs.CanvasInterface):
             ("top", "right"),     # top_right_axis
         )
 
-        if not any(self.visible_axes):
-            self.visible_axes = (True, False, True, False)  # Left and bottom
+        if not any(visible_axes):
+            visible_axes = (True, False, True, False)  # Left and bottom
             used_axes = (True, False, False, False)  # self.axis visible
             self._legend_axis = self._axis
 
@@ -327,7 +317,7 @@ class Canvas(FigureCanvas, Graphs.CanvasInterface):
             # Set tick where requested, as long as that axis is not occupied
             # and visible
             axis.tick_params(which=ticks, **{
-                direction: (draw_frame and not self.visible_axes[i]
+                direction: (draw_frame and not visible_axes[i]
                             or direction in directions)
                 and params[f"{'x' if i < 2 else 'y'}tick.{direction}"]
                 for i, direction in enumerate(possible_directions)
@@ -344,10 +334,10 @@ class Canvas(FigureCanvas, Graphs.CanvasInterface):
             if used:
                 self._legend_axis = axis
 
-        self._axis.get_xaxis().set_visible(self.visible_axes[0])
-        self._top_left_axis.get_xaxis().set_visible(self.visible_axes[1])
-        self._axis.get_yaxis().set_visible(self.visible_axes[2])
-        self._right_axis.get_yaxis().set_visible(self.visible_axes[3])
+        self._axis.get_xaxis().set_visible(visible_axes[0])
+        self._top_left_axis.get_xaxis().set_visible(visible_axes[1])
+        self._axis.get_yaxis().set_visible(visible_axes[2])
+        self._right_axis.get_yaxis().set_visible(visible_axes[3])
 
         self._handles = [
             artist.new_for_item(self, item)

--- a/src/data.py
+++ b/src/data.py
@@ -150,6 +150,25 @@ class Data(GObject.Object, Graphs.DataInterface):
         """Get all managed items."""
         return list(self._items.values())
 
+    def get_used_positions(self) -> list:
+        """
+        Get the axes positions that the items are bound to
+        Returns an array in the form of [bool, bool, bool, bool], where
+        each element corresponds to the [bottom, top, left, right] positions.
+        """
+        # bottom, top, left, right
+        figure_settings = self.get_figure_settings()
+        used_positions = [False, False, False, False]
+
+        for item_ in self.items:
+            if (figure_settings.get_hide_unselected() and not item_.selected):
+                continue
+            used_positions[item_.get_xposition()] = True
+            used_positions[item_.get_yposition() + 2] = True
+        if not any(used_positions):
+            return [True, False, True, False]
+        return used_positions
+
     def set_items(self, items: misc.ItemList) -> None:
         """Set all managed items."""
         self._items = {}

--- a/src/figure_settings.py
+++ b/src/figure_settings.py
@@ -129,8 +129,7 @@ class FigureSettingsWindow(Adw.Window):
                 figure_settings.set_use_custom_style(True)
 
     def set_axes_entries(self):
-        canvas = self.get_application().get_window().get_canvas()
-        visible_axes = canvas.visible_axes
+        visible_axes = self.get_application().get_data().get_used_positions()
         for (direction, visible) in zip(_DIRECTIONS, visible_axes):
             if visible:
                 for s in ("min_", "max_"):

--- a/src/figure_settings.py
+++ b/src/figure_settings.py
@@ -6,7 +6,7 @@ from gi.repository import Adw, GObject, Graphs, Gtk
 
 from graphs import misc, styles, ui, utilities
 
-_DIRECTIONS = ["bottom", "left", "top", "right"]
+_DIRECTIONS = ["bottom", "top", "left", "right"]
 
 
 def _get_widget_factory(window):
@@ -68,7 +68,6 @@ class FigureSettingsWindow(Adw.Window):
             application=application, transient_for=application.get_window(),
             figure_settings=figure_settings,
         )
-
         notifiers = ("custom_style", "use_custom_style")
         for prop in notifiers:
             figure_settings.connect(
@@ -130,13 +129,9 @@ class FigureSettingsWindow(Adw.Window):
                 figure_settings.set_use_custom_style(True)
 
     def set_axes_entries(self):
-        used_axes = [False, False, False, False]
-        for item in self.get_application().get_data():
-            for i in item.get_xposition() * 2, 1 + item.get_yposition() * 2:
-                used_axes[i] = True
-        if not any(used_axes):
-            used_axes = [True, True, False, False]
-        for (direction, visible) in zip(_DIRECTIONS, used_axes):
+        canvas = self.get_application().get_window().get_canvas()
+        visible_axes = canvas.visible_axes
+        for (direction, visible) in zip(_DIRECTIONS, visible_axes):
             if visible:
                 for s in ("min_", "max_"):
                     entry = getattr(self, s + direction)
@@ -146,7 +141,9 @@ class FigureSettingsWindow(Adw.Window):
                     entry.connect(
                         "notify::text", self.on_entry_change, s + direction,
                     )
-                getattr(self, direction + "_limits").set_visible(True)
+            getattr(self, direction + "_limits").set_visible(visible)
+            getattr(self, direction + "_scale").set_visible(visible)
+            getattr(self, direction + "_label").set_visible(visible)
 
     def on_entry_change(self, entry, _param, prop):
         with contextlib.suppress(SyntaxError):

--- a/src/ui.py
+++ b/src/ui.py
@@ -26,8 +26,7 @@ def on_items_change(data, _ignored, self):
 
 
 def enable_axes_actions(self, _callback, application):
-    canvas = application.get_window().get_canvas()
-    visible_axes = canvas.visible_axes
+    visible_axes = application.get_data().get_used_positions()
     directions = ["bottom", "top", "left", "right"]
     for index, direction in enumerate(directions):
         action = application.lookup_action(f"change-{direction}-scale")

--- a/src/ui.py
+++ b/src/ui.py
@@ -25,6 +25,15 @@ def on_items_change(data, _ignored, self):
     data.add_view_history_state()
 
 
+def enable_axes_actions(self, _callback, application):
+    canvas = application.get_window().get_canvas()
+    visible_axes = canvas.visible_axes
+    directions = ["bottom", "top", "left", "right"]
+    for index, direction in enumerate(directions):
+        action = application.lookup_action(f"change-{direction}-scale")
+        action.set_enabled(visible_axes[index])
+
+
 def on_items_ignored(_data, _ignored, ignored, self):
     if len(ignored) > 1:
         toast = _("Items {} already exist").format(ignored)
@@ -83,7 +92,7 @@ def open_project_dialog(self):
 
 
 def export_data_dialog(self):
-    if self.get_data().props.unsaved:
+    if self.get_data().get_empty():
         self.get_window().add_toast_string(_("No data to export"))
         return
     multiple = len(self.get_data()) > 1


### PR DESCRIPTION
Hide all settings for each axis if they're currently not used.

![image](https://github.com/Sjoerd1993/Graphs/assets/68477016/198b0630-37b2-4c09-a40f-84f453cf1b4f)

![image](https://github.com/Sjoerd1993/Graphs/assets/68477016/35935319-3ebd-472a-a7ed-b683982d7bd4)

Second screenshot is slightly extended compared to default height to show all relevant fields.