### PR TITLE
Update curve fitting

### DIFF
--- a/data/ui/curve_fitting.blp
+++ b/data/ui/curve_fitting.blp
@@ -3,7 +3,6 @@ using Adw 1;
 
 template $GraphsCurveFittingTool : Adw.Window {
   modal: true;
-  title: _("Curve Fitting");
   focus-widget: confirm_button;
   default-width: 1000;
   default-height: 650;
@@ -29,12 +28,12 @@ template $GraphsCurveFittingTool : Adw.Window {
     content: Adw.OverlaySplitView split_view {
       show-sidebar: bind show_sidebar_button.active;
       notify => $on_sidebar_toggle();
-      sidebar: Box {
-        orientation: vertical;
+      sidebar: Adw.ToolbarView {
+        [top]
         Adw.HeaderBar {
           styles ["flat"]
           title-widget: Adw.WindowTitle title_widget {
-            title: "Graphs";
+            title: _("Curve Fitting");
           };
         }
         ScrolledWindow fitting_param_entries {
@@ -89,6 +88,7 @@ template $GraphsCurveFittingTool : Adw.Window {
       orientation: vertical;
         Adw.HeaderBar {
           styles ["flat"]
+          show-title: false;
           ToggleButton show_sidebar_button {
             icon-name: "sidebar-show-symbolic";
             tooltip-text: _("Toggle Sidebar");

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -175,12 +175,32 @@ def preprocess(string: str):
         expression = match.group(1)  # Get the content inside the brackets
         return f"1/(sin({expression}))"
 
+    def convert_superscript(match):
+        superscript_mapping = {
+            "⁰": "0",
+            "¹": "1",
+            "²": "2",
+            "³": "3",
+            "⁴": "4",
+            "⁵": "5",
+            "⁶": "6",
+            "⁷": "7",
+            "⁸": "8",
+            "⁹": "9"
+        }
+        sequence = match.group(1)  # Get the content inside the superscript
+        sequence = "".join(superscript_mapping.get(char, char)
+                           for char in sequence)
+        return f"**{sequence}"
+
     string = string.replace("pi", f"({float(numpy.pi)})")
     string = string.replace("^", "**")
     string = re.sub(r"cot\((.*?)\)", convert_cot, string)
     string = re.sub(r"sec\((.*?)\)", convert_sec, string)
     string = re.sub(r"csc\((.*?)\)", convert_csc, string)
     string = re.sub(r"d\((.*?)\)", convert_degrees, string)
+    string = re.sub(r"([\u2070-\u209f\u00b0-\u00be]+)",
+                    convert_superscript, string)
     return string.lower()
 
 
@@ -193,6 +213,7 @@ def string_to_function(equation_name):
         r"\b(?!x\b|X\b|sin\b|cos\b|tan\b)[a-wy-zA-WY-Z]+\b",
         equation_name,
     )
+    print(variables)
     sym_vars = sympy.symbols(variables)
     with contextlib.suppress(sympy.SympifyError, TypeError, SyntaxError):
         symbolic = sympy.sympify(

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -186,7 +186,7 @@ def preprocess(string: str):
             "⁶": "6",
             "⁷": "7",
             "⁸": "8",
-            "⁹": "9"
+            "⁹": "9",
         }
         sequence = match.group(1)  # Get the content inside the superscript
         sequence = "".join(superscript_mapping.get(char, char)
@@ -213,7 +213,6 @@ def string_to_function(equation_name):
         r"\b(?!x\b|X\b|sin\b|cos\b|tan\b)[a-wy-zA-WY-Z]+\b",
         equation_name,
     )
-    print(variables)
     sym_vars = sympy.symbols(variables)
     with contextlib.suppress(sympy.SympifyError, TypeError, SyntaxError):
         symbolic = sympy.sympify(


### PR DESCRIPTION
Minor updates to the curve fitting dialog in line with the GNOME Circle Feedback.
Also adds support for superscript equations (e.g. y=x² instead of y=x^2), which was mainly added to fix this issue with the curve fitting but the fix has the added benefit that it works over all equation handling.