### PR TITLE
Use homogenous rows

### DIFF
--- a/data/ui/add_equation_window.blp
+++ b/data/ui/add_equation_window.blp
@@ -68,6 +68,7 @@ template $GraphsAddEquationWindow : Adw.Window {
             Box {
               spacing: 12;
               orientation: horizontal;
+              homogeneous: true;
 
               Adw.PreferencesGroup {
                 Adw.EntryRow x_start {

--- a/data/ui/figure_settings.blp
+++ b/data/ui/figure_settings.blp
@@ -64,6 +64,7 @@ template $GraphsFigureSettingsWindow : Adw.Window {
                     spacing: 12;
                     Box left_limits {
                       orientation: horizontal;
+                      homogeneous: true;
                       spacing: 6;
                       visible: false;
                       Adw.PreferencesGroup {
@@ -79,6 +80,7 @@ template $GraphsFigureSettingsWindow : Adw.Window {
                     }
                     Box bottom_limits {
                       orientation: horizontal;
+                      homogeneous: true;
                       spacing: 6;
                       visible: false;
                       Adw.PreferencesGroup {
@@ -93,6 +95,7 @@ template $GraphsFigureSettingsWindow : Adw.Window {
                       }
                     }
                     Box right_limits {
+                      homogeneous: true;
                       orientation: horizontal;
                       spacing: 6;
                       visible: false;
@@ -109,6 +112,7 @@ template $GraphsFigureSettingsWindow : Adw.Window {
                     }
                     Box top_limits {
                       spacing: 6;
+                      homogeneous: true;
                       orientation: horizontal;
                       visible: false;
                       Adw.PreferencesGroup {

--- a/data/ui/fitting_parameters.blp
+++ b/data/ui/fitting_parameters.blp
@@ -4,6 +4,7 @@ using Adw 1;
 template $GraphsFittingParameterEntry : Box {
   orientation: vertical;
   Grid {
+    column-homogeneous: true;
     margin-bottom: 4;
     margin-top: 4;
     column-spacing: 4;


### PR DESCRIPTION
Uses homogenous entry rows where we've got multiple side-by-side. This finally fixes this stubborn bug where the entries become smaller when active

Before:
![image](https://github.com/Sjoerd1993/Graphs/assets/68477016/21bbc04a-2f14-4fe4-90c7-31fe00185348)


After:
![image](https://github.com/Sjoerd1993/Graphs/assets/68477016/702f1f08-a402-4541-9179-679d16c66d3b)
