### PR TITLE
Fix style overview columns to three

### DIFF
--- a/data/ui/figure_settings.blp
+++ b/data/ui/figure_settings.blp
@@ -230,6 +230,7 @@ template $GraphsFigureSettingsWindow : Adw.Window {
               GridView grid_view {
                 name: "style-grid";
                 max-columns: 3;
+                min-columns: 3;
                 model: SingleSelection {
                   selection-changed => $on_select();
                 };


### PR DESCRIPTION
It's a bit of a bandaid solution, as it'd still be preferable to allow resizing to fewer columns. But GtkGridView reserves the vertical space it needs for the case when there's only one column available. This leads to a large amount of whitespace in the scrollbar in the style overview.

We can maybe take a closer look at this later, I couldn't find a direct solution for now. But I think for now at least for the coming release it's sensible to just fix the amount of columns to three, which solves this issue:

![image](https://github.com/Sjoerd1993/Graphs/assets/68477016/ad53f169-6f6d-4f8a-9d1c-ee434e78a538)
