### PR TITLE
Update metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,20 +43,21 @@ An official build is also available on the Snap store:
 The latest testing version of Graphs is available in the Flathub beta channel. To install the beta, first the Flatpak remote needs to be configured:
 
 ```sh
-flatpak remote-add --user --if-not-exists flathub-beta https://flathub.org/beta-repo/flathub-beta.flatpakrepo
+flatpak remote-add --if-not-exists flathub-beta https://flathub.org/beta-repo/flathub-beta.flatpakrepo
 ```
 
 Then, install the application:
 
 ```sh
-flatpak install --user flathub-beta se.sjoerd.Graphs
+flatpak install flathub-beta se.sjoerd.Graphs
 ```
 To run the beta version by default, the following command can be used:
 
 ```sh
-flatpak make-current se.sjoerd.Graphs beta
+sudo flatpak make-current se.sjoerd.Graphs beta
 ```
-To switch back to the stable version simply run the same command replacing `beta` with `stable`. A beta version is also available in the beta channel of the Snap Store.
+Note that the `sudo` is neccesary here, as it sets the current branch on the system level. To install this on a per-user basis, the flag `--user` can be used in the  previous commands. 
+To switch back to the stable version simply run the above command replacing `beta` with `stable`. A beta version is also available in the beta channel of the Snap Store.
 We are always looking for feedback, so feel free to report any issues or suggestions on the Github [issue tracker](https://github.com/Sjoerd1993/Graphs/issues).
 
 

--- a/data/se.sjoerd.Graphs.appdata.xml.in.in
+++ b/data/se.sjoerd.Graphs.appdata.xml.in.in
@@ -51,32 +51,46 @@
     </screenshot>
   </screenshots>
   <releases>
-    <release version="1.7.0" date="2023-10-18">
+    <release version="1.7.0" date="2023-12-14">
       <description translatable="no">
+        <p>Version 1.7 marks our biggest release yet. With a migration to GNOME 45 and a new UI overhaul with a revamped style editor.
+           Other major highlights include a new curve fitting functionality, the ability to open projects directly, and support for gestures in the canvas.
+        </p>
         <p>New in Graphs:</p>
         <ul>
-          <li>Curve fitting functionality has been added to Graphs</li>
-          <li>A new Yaru style has been added, which is set as the default system style for the Snap package when Yaru is used in the system, offering a more consistent experience</li>
           <li>The style editor has been revamped completely and now shows previews for each style</li>
-          <li>New scaling options are available for the axes, allowing for radian, square root and inverse scaling</li>
+          <li>Curve fitting functionality has been added to Graphs</li>
+          <li>Graphs can now open data as well as Graphs project files directly from the file manager</li>
+          <li>When closing the application while unsaved changes are present, a dialog is now shown allowing you to save the data</li>
+          <li>The active project and its directory are now shown in the headerbar, including an indicator for unsaved changes</li>
           <li>Graphs now includes forwards/backwards buttons to quickly navigate to the next and previous view</li>
-          <li>Transparent colours for the lines are now supported</li>
-          <li>Support has been added for cotangents, secants and cosecants</li>
-          <li>Headers are now written to exported files if present in the originally imported data</li>
-          <li>Importing column data is now more robust, supporting expressions as data points</li>
-          <li>Pinch and scroll to zoom gestures are now supported</li>
+          <li>The smoothening action can now be configured with a choice of two different filters, a rolling average and a LOESS Savitzky-Gotsky filter</li>
+          <li>A new Yaru style has been added, which is set as the default system style for the Snap package when Yaru is used in the system, offering a more consistent experience</li>
+          <li>The default matplotlib style has been added to Graphs</li>
           <li>The title font size can now be changed with respect to the overall font size</li>
+          <li>New scaling options are available for the axes, allowing for radian, square root and inverse scaling</li>
+          <li>Transparent colours for the curves are now supported</li>
+          <li>Superscript characters are now supported when entering equations</li>
+          <li>Support has been added for cotangents, secants and cosecants for equations and transformations</li>
+          <li>Headers are now written to exported files if present in the originally imported data</li>
+          <li>Style sheets now allow you to choose whether a frame should be drawn around the axes</li>
+          <li>Importing column data is now more robust, supporting expressions as data points</li>
+          <li>Pinch and ctrl+scroll to zoom gestures are now supported on the canvas</li>
+          <li>The canvas can now be panned using two fingers on a touch screen, as well as with the middle mouse button</li>
         </ul>
         <p>Changed behaviour:</p>
         <ul>
-          <li>Different changes and tweaks throughout the UI</li>
           <li>Several linguistic changes were made, to get a clearer and more consistent description</li>
-          <li>The syntax for equations have been simplified </li>
+          <li>The syntax for equations has been simplified </li>
+          <li>Delimiters can now be specified from a dropdown menu instead of having to rely on regex</li>
           <li>The used axes limits are now saved when saving/loading a project</li>
-          <li>The preferences have been redesigned for a more intuitive navigation</li>
+          <li>Settings related to specific axes are now only displayed when the axis is in use</li>
+          <li>The preferences have been redesigned and simplified, leaving only a single dialog for the figure settings</li>
+          <li>The drag and drop animation when moving items has been improved</li>
+          <li>The headerbar now follows the color of the used stylesheet, giving a more unified look</li>
           <li>The shortcuts have been modified to follow the rest of the GNOME ecosystem </li>
           <li>The logic for placing the legend has been changed, so that it now properly moves away when it intersects with a curve</li>
-          <li>The behaviour of the "Shift" action has been changed to be more consistent when only part of the data span is selected </li>
+          <li>The behaviour of the "Shift" action has been revamped to be more consistent when only part of the data span is selected </li>
         </ul>
         <p>Bugfixes and changes under the hood:</p>
         <ul>
@@ -88,6 +102,7 @@
           <li>Graphs now uses unit tests, reducing the risk of regression bugs </li>
           <li>Part of the code-base has been migrated to Vala</li>
           <li>Fixed a bug where "Skip rows" did not work properly with single-column data</li>
+          <li>Fixed a bug where rows would change width when selected in case they are adjecent to other entry rows.</li>
           <li>Graphs translations are now hosted on Weblate</li>
           <li>More smaller changes and fixes throughout the code-base</li>
         </ul>

--- a/data/whats_new
+++ b/data/whats_new
@@ -1,27 +1,41 @@
+        <p>Version 1.7 marks our biggest release yet. With a migration to GNOME 45 and a new UI overhaul with a revamped style editor.
+           Other major highlights include a new curve fitting functionality, the ability to open projects directly, and support for gestures in the canvas.
+        </p>
         <p>New in Graphs:</p>
         <ul>
-          <li>Curve fitting functionality has been added to Graphs</li>
-          <li>A new Yaru style has been added, which is set as the default system style for the Snap package when Yaru is used in the system, offering a more consistent experience</li>
           <li>The style editor has been revamped completely and now shows previews for each style</li>
-          <li>New scaling options are available for the axes, allowing for radian, square root and inverse scaling</li>
+          <li>Curve fitting functionality has been added to Graphs</li>
+          <li>Graphs can now open data as well as Graphs project files directly from the file manager</li>
+          <li>When closing the application while unsaved changes are present, a dialog is now shown allowing you to save the data</li>
+          <li>The active project and its directory are now shown in the headerbar, including an indicator for unsaved changes</li>
           <li>Graphs now includes forwards/backwards buttons to quickly navigate to the next and previous view</li>
-          <li>Transparent colours for the lines are now supported</li>
-          <li>Support has been added for cotangents, secants and cosecants</li>
-          <li>Headers are now written to exported files if present in the originally imported data</li>
-          <li>Importing column data is now more robust, supporting expressions as data points</li>
-          <li>Pinch and scroll to zoom gestures are now supported</li>
+          <li>The smoothening action can now be configured with a choice of two different filters, a rolling average and a LOESS Savitzky-Gotsky filter</li>
+          <li>A new Yaru style has been added, which is set as the default system style for the Snap package when Yaru is used in the system, offering a more consistent experience</li>
+          <li>The default matplotlib style has been added to Graphs</li>
           <li>The title font size can now be changed with respect to the overall font size</li>
+          <li>New scaling options are available for the axes, allowing for radian, square root and inverse scaling</li>
+          <li>Transparent colours for the curves are now supported</li>
+          <li>Superscript characters are now supported when entering equations</li>
+          <li>Support has been added for cotangents, secants and cosecants for equations and transformations</li>
+          <li>Headers are now written to exported files if present in the originally imported data</li>
+          <li>Style sheets now allow you to choose whether a frame should be drawn around the axes</li>
+          <li>Importing column data is now more robust, supporting expressions as data points</li>
+          <li>Pinch and ctrl+scroll to zoom gestures are now supported on the canvas</li>
+          <li>The canvas can now be panned using two fingers on a touch screen, as well as with the middle mouse button</li>
         </ul>
         <p>Changed behaviour:</p>
         <ul>
-          <li>Different changes and tweaks throughout the UI</li>
           <li>Several linguistic changes were made, to get a clearer and more consistent description</li>
-          <li>The syntax for equations have been simplified </li>
+          <li>The syntax for equations has been simplified </li>
+          <li>Delimiters can now be specified from a dropdown menu instead of having to rely on regex</li>
           <li>The used axes limits are now saved when saving/loading a project</li>
-          <li>The preferences have been redesigned for a more intuitive navigation</li>
+          <li>Settings related to specific axes are now only displayed when the axis is in use</li>
+          <li>The preferences have been redesigned and simplified, leaving only a single dialog for the figure settings</li>
+          <li>The drag and drop animation when moving items has been improved</li>
+          <li>The headerbar now follows the color of the used stylesheet, giving a more unified look</li>
           <li>The shortcuts have been modified to follow the rest of the GNOME ecosystem </li>
           <li>The logic for placing the legend has been changed, so that it now properly moves away when it intersects with a curve</li>
-          <li>The behaviour of the "Shift" action has been changed to be more consistent when only part of the data span is selected </li>
+          <li>The behaviour of the "Shift" action has been revamped to be more consistent when only part of the data span is selected </li>
         </ul>
         <p>Bugfixes and changes under the hood:</p>
         <ul>
@@ -33,6 +47,7 @@
           <li>Graphs now uses unit tests, reducing the risk of regression bugs </li>
           <li>Part of the code-base has been migrated to Vala</li>
           <li>Fixed a bug where "Skip rows" did not work properly with single-column data</li>
+          <li>Fixed a bug where rows would change width when selected in case they are adjecent to other entry rows.</li>
           <li>Graphs translations are now hosted on Weblate</li>
           <li>More smaller changes and fixes throughout the code-base</li>
         </ul>


### PR DESCRIPTION
Update metadata with the new changes, is becoming quite a long list now.
Also updates the instructions a bit to install the beta from Flathub, as the current instructions don't work when it comes to setting the active branch. The new instructions are now to install Graphs on a system scale, which is the default for Flatpaks anyway.