### PR TITLE
Add curve fitting options

### DIFF
--- a/data/se.sjoerd.Graphs.gschema.xml
+++ b/data/se.sjoerd.Graphs.gschema.xml
@@ -107,7 +107,7 @@
       <default>"linear"</default>
     </key>
     <key name="optimization" enum="se.sjoerd.Graphs.curve-fitting.optimization">
-      <default>"lm"</default>
+      <default>"trf"</default>
     </key>
     <key name="confidence" enum="se.sjoerd.Graphs.curve-fitting.confidence">
       <default>"1std"</default>

--- a/data/se.sjoerd.Graphs.gschema.xml
+++ b/data/se.sjoerd.Graphs.gschema.xml
@@ -10,6 +10,30 @@
     <value nick="moving-average" value="1"/>
   </enum>
 
+  <enum id="se.sjoerd.Graphs.curve-fitting.equation">
+    <value nick="linear" value="0"/>
+    <value nick="quadratic" value="1"/>
+    <value nick="exponential" value="2"/>
+    <value nick="power" value="3"/>
+    <value nick="log" value="4"/>
+    <value nick="sigmoid" value="5"/>
+    <value nick="gaussian" value="6"/>
+    <value nick="custom" value="7"/>
+  </enum>
+
+  <enum id="se.sjoerd.Graphs.curve-fitting.confidence">
+    <value nick="none" value="0"/>
+    <value nick="1std" value="1"/>
+    <value nick="2std" value="2"/>
+    <value nick="3std" value="3"/>
+  </enum>
+
+  <enum id="se.sjoerd.Graphs.curve-fitting.optimization">
+    <value nick="lm" value="0"/>
+    <value nick="trf" value="1"/>
+    <value nick="dogbox" value="2"/>
+  </enum>
+
   <enum id="se.sjoerd.Graphs.export-figure.file-formats">
     <value nick="Encapsulated Postscript" value="0"/>
     <value nick="Joint Photographic Experts Group" value="1"/>
@@ -75,6 +99,21 @@
     </key>
     <key name="smoothen" enum="se.sjoerd.Graphs.actions.smoothen-types">
       <default>"savgol"</default>
+    </key>
+  </schema>
+
+  <schema id="se.sjoerd.Graphs.curve-fitting">
+    <key name="equation" enum="se.sjoerd.Graphs.curve-fitting.equation">
+      <default>"linear"</default>
+    </key>
+    <key name="optimization" enum="se.sjoerd.Graphs.curve-fitting.optimization">
+      <default>"lm"</default>
+    </key>
+    <key name="confidence" enum="se.sjoerd.Graphs.curve-fitting.confidence">
+      <default>"1std"</default>
+    </key>
+    <key name="custom-equation" type="s">
+      <default>"a*x+b"</default>
     </key>
   </schema>
 
@@ -147,12 +186,6 @@
     </key>
     <key name="x-stop" type="s">
       <default>"10"</default>
-    </key>
-  </schema>
-
-  <schema id="se.sjoerd.Graphs.curve-fitting">
-    <key name="equation" type="s">
-      <default>"a*x+b"</default>
     </key>
   </schema>
 

--- a/data/ui/curve_fitting.blp
+++ b/data/ui/curve_fitting.blp
@@ -153,17 +153,17 @@ menu curve_fitting_menu {
         target: "none";
       }
       item {
-        label: _("One standard deviation");
+        label: _("±1SD (68% certainty)");
         action: "win.confidence";
         target: "1std";
       }
       item {
-        label: _("Two standard deviations");
+        label: _("±2SD (95% certainty)");
         action: "win.confidence";
         target: "2std";
       }
       item {
-        label: _("Three standard deviations");
+        label: _("±3SD (99.7% certainty)");
         action: "win.confidence";
         target: "3std";
       }

--- a/data/ui/curve_fitting.blp
+++ b/data/ui/curve_fitting.blp
@@ -153,17 +153,17 @@ menu curve_fitting_menu {
         target: "none";
       }
       item {
-        label: _("±1SD (68% certainty)");
+        label: _("1σ: 68% confidence");
         action: "win.confidence";
         target: "1std";
       }
       item {
-        label: _("±2SD (95% certainty)");
+        label: _("2σ: 95% confidence");
         action: "win.confidence";
         target: "2std";
       }
       item {
-        label: _("±3SD (99.7% certainty)");
+        label: _("3σ: 99.7% confidence");
         action: "win.confidence";
         target: "3std";
       }

--- a/data/ui/curve_fitting.blp
+++ b/data/ui/curve_fitting.blp
@@ -55,7 +55,6 @@ template $GraphsCurveFittingTool : Adw.Window {
             margin-top: 12;
             Adw.PreferencesGroup {
               Adw.ComboRow equation {
-                notify => $on_select();
                 title: _("Equation");
                 model: StringList{
                   strings [_("Linear"), _("Quadratic"), _("Exponential"), _("Power Law"),

--- a/data/ui/curve_fitting.blp
+++ b/data/ui/curve_fitting.blp
@@ -44,7 +44,7 @@ template $GraphsCurveFittingTool : Adw.Window {
         }
         ScrolledWindow fitting_param_entries {
           vexpand: true;
-          width-request: 275;
+          width-request: 280;
           hscrollbar-policy: never;
           Box {
             vexpand: true;

--- a/data/ui/curve_fitting.blp
+++ b/data/ui/curve_fitting.blp
@@ -35,6 +35,13 @@ template $GraphsCurveFittingTool : Adw.Window {
           title-widget: Adw.WindowTitle title_widget {
             title: _("Curve Fitting");
           };
+          [end]
+          MenuButton {
+            icon-name: "open-menu-symbolic";
+            menu-model: curve_fitting_menu;
+            tooltip-text: _("Open Curve Fitting Menu");
+            primary: true;
+          }
         }
         ScrolledWindow fitting_param_entries {
           vexpand: true;
@@ -48,7 +55,7 @@ template $GraphsCurveFittingTool : Adw.Window {
             margin-bottom: 12;
             margin-top: 12;
             Adw.PreferencesGroup {
-              Adw.EntryRow equation {
+              Adw.EntryRow custom_equation {
                 title: _("Equation");
               }
               Box fitting_params {
@@ -109,4 +116,93 @@ template $GraphsCurveFittingTool : Adw.Window {
       };
     };
   };
+}
+
+menu curve_fitting_menu {
+  section {
+    submenu {
+      label: _("Equation");
+      item {
+        label: _("Linear");
+        action: "win.equation";
+        target: "linear";
+      }
+      item {
+        label: _("Quadratic");
+        action: "win.equation";
+        target: "quadratic";
+      }
+      item {
+        label: _("Exponential");
+        action: "win.equation";
+        target: "exponential";
+      }
+      item {
+        label: _("Power law");
+        action: "win.equation";
+        target: "power";
+      }
+      item {
+        label: _("Logarithmic");
+        action: "win.equation";
+        target: "log";
+      }
+      item {
+        label: _("Sigmoid Logistic");
+        action: "win.equation";
+        target: "sigmoid";
+      }
+      item {
+        label: _("Gaussian");
+        action: "win.equation";
+        target: "gaussian";
+      }
+      item {
+        label: _("Custom");
+        action: "win.equation";
+        target: "custom";
+      }
+    }
+    submenu {
+      label: _("Optimization method");
+      item {
+        label: _("Levenberg-Marquardt");
+        action: "win.optimization";
+        target: "lm";
+      }
+      item {
+        label: _("Trust Region Reflective");
+        action: "win.optimization";
+        target: "trf";
+      }
+      item {
+        label: _("Dogbox");
+        action: "win.optimization";
+        target: "dogbox";
+      }
+    }
+    submenu {
+      label: _("Confidence bounds");
+      item {
+        label: _("None");
+        action: "win.confidence";
+        target: "none";
+      }
+      item {
+        label: _("One standard deviation");
+        action: "win.confidence";
+        target: "1std";
+      }
+      item {
+        label: _("Two standard deviations");
+        action: "win.confidence";
+        target: "2std";
+      }
+      item {
+        label: _("Three standard deviations");
+        action: "win.confidence";
+        target: "3std";
+      }
+    }
+  }
 }

--- a/data/ui/curve_fitting.blp
+++ b/data/ui/curve_fitting.blp
@@ -5,7 +5,7 @@ template $GraphsCurveFittingTool : Adw.Window {
   modal: true;
   focus-widget: confirm_button;
   default-width: 1000;
-  default-height: 650;
+  default-height: 660;
   width-request: 305;
   height-request: 410;
 
@@ -27,7 +27,6 @@ template $GraphsCurveFittingTool : Adw.Window {
     top-bar-style: flat;
     content: Adw.OverlaySplitView split_view {
       show-sidebar: bind show_sidebar_button.active;
-      notify => $on_sidebar_toggle();
       sidebar: Adw.ToolbarView {
         [top]
         Adw.HeaderBar {
@@ -55,8 +54,17 @@ template $GraphsCurveFittingTool : Adw.Window {
             margin-bottom: 12;
             margin-top: 12;
             Adw.PreferencesGroup {
-              Adw.EntryRow custom_equation {
+              Adw.ComboRow equation {
+                notify => $on_select();
                 title: _("Equation");
+                model: StringList{
+                  strings [_("Linear"), _("Quadratic"), _("Exponential"), _("Power Law"),
+                  _("Logarithmic"), _("Sigmoid Logistic"), _("Gaussian"), _("Custom")]
+                };
+              }
+              Adw.EntryRow custom_equation {
+                visible: false;
+                title: _("Y = ");
               }
               Box fitting_params {
                 margin-top: 12;
@@ -120,49 +128,9 @@ template $GraphsCurveFittingTool : Adw.Window {
 
 menu curve_fitting_menu {
   section {
-    submenu {
-      label: _("Equation");
-      item {
-        label: _("Linear");
-        action: "win.equation";
-        target: "linear";
-      }
-      item {
-        label: _("Quadratic");
-        action: "win.equation";
-        target: "quadratic";
-      }
-      item {
-        label: _("Exponential");
-        action: "win.equation";
-        target: "exponential";
-      }
-      item {
-        label: _("Power law");
-        action: "win.equation";
-        target: "power";
-      }
-      item {
-        label: _("Logarithmic");
-        action: "win.equation";
-        target: "log";
-      }
-      item {
-        label: _("Sigmoid Logistic");
-        action: "win.equation";
-        target: "sigmoid";
-      }
-      item {
-        label: _("Gaussian");
-        action: "win.equation";
-        target: "gaussian";
-      }
-      item {
-        label: _("Custom");
-        action: "win.equation";
-        target: "custom";
-      }
-    }
+    item (_("Toggle Sidebar"), "win.toggle_sidebar")
+  }
+  section {
     submenu {
       label: _("Optimization method");
       item {

--- a/data/ui/curve_fitting.blp
+++ b/data/ui/curve_fitting.blp
@@ -128,9 +128,6 @@ template $GraphsCurveFittingTool : Adw.Window {
 
 menu curve_fitting_menu {
   section {
-    item (_("Toggle Sidebar"), "win.toggle_sidebar")
-  }
-  section {
     submenu {
       label: _("Optimization method");
       item {

--- a/data/ui/fitting_parameters.blp
+++ b/data/ui/fitting_parameters.blp
@@ -32,7 +32,7 @@ template $GraphsFittingParameterEntry : Box {
           column-span: 2;
       }
     }
-    Adw.PreferencesGroup {
+    Adw.PreferencesGroup lower_bound_group {
       Adw.EntryRow lower_bound {
         title: _("Minimum");
         text: "-inf";
@@ -42,7 +42,7 @@ template $GraphsFittingParameterEntry : Box {
         row: 2;
       }
     }
-    Adw.PreferencesGroup {
+    Adw.PreferencesGroup upper_bound_group {
       Adw.EntryRow upper_bound {
         title: _("Maximum");
         text: "inf";

--- a/data/ui/fitting_parameters.blp
+++ b/data/ui/fitting_parameters.blp
@@ -5,8 +5,8 @@ template $GraphsFittingParameterEntry : Box {
   orientation: vertical;
   Grid {
     column-homogeneous: true;
-    margin-bottom: 4;
-    margin-top: 4;
+    margin-bottom: 3;
+    margin-top: 3;
     column-spacing: 4;
     row-spacing: 4;
     Label label {

--- a/src/curve_fitting.py
+++ b/src/curve_fitting.py
@@ -4,7 +4,7 @@ from gettext import gettext as _
 
 from gi.repository import Adw, GObject, Gio, Graphs, Gtk
 
-from graphs import utilities
+from graphs import ui, utilities
 from graphs.canvas import Canvas
 from graphs.data import Data
 from graphs.item import DataItem, FillItem
@@ -19,6 +19,7 @@ class CurveFittingWindow(Graphs.CurveFittingTool):
     __gtype_name__ = "GraphsCurveFittingWindow"
     confirm_button = GObject.Property(type=Gtk.Button)
     custom_equation = GObject.Property(type=Adw.EntryRow)
+    equation = GObject.Property(type=Adw.ComboRow)
     fitting_params = GObject.Property(type=Gtk.Box)
     text_view = GObject.Property(type=Gtk.TextView)
     title_widget = GObject.Property(type=Adw.WindowTitle)
@@ -32,6 +33,10 @@ class CurveFittingWindow(Graphs.CurveFittingTool):
         Adw.StyleManager.get_default().connect("notify", self.reload_canvas)
         self.settings = \
             self.get_application().get_settings_child("curve-fitting")
+        self.custom_equation = self.get_custom_equation()
+        self.equation = self.get_equation()
+        ignorelist = ["optimization", "confidence", "custom-equation"]
+        ui.bind_values_to_settings(self.settings, self, ignorelist=ignorelist)
         self.custom_equation = self.get_custom_equation()
         self.set_equation()
         self.connect_actions()
@@ -91,11 +96,13 @@ class CurveFittingWindow(Graphs.CurveFittingTool):
         equation = EQUATIONS[self.settings.get_string("equation")]
         custom_equation = self.settings.get_string("custom-equation")
         if equation != "custom":
+            self.equation.set_subtitle(equation)
             self.get_custom_equation().set_text(equation)
-            self.get_custom_equation().set_sensitive(False)
+            self.get_custom_equation().set_visible(False)
         else:
+            self.equation.set_subtitle("")
             self.get_custom_equation().set_text(custom_equation)
-            self.get_custom_equation().set_sensitive(True)
+            self.get_custom_equation().set_visible(True)
 
     def reload_canvas(self, *_args):
         """Reinitialise the currently used canvas"""

--- a/src/curve_fitting.py
+++ b/src/curve_fitting.py
@@ -266,7 +266,7 @@ class CurveFittingWindow(Graphs.CurveFittingTool):
         ydata = [function(x, *self.param) for x in xdata]
 
         name = _get_equation_name(
-            str(self.get_custom_equation().get_text()), self.param)
+            str(self.get_custom_equation().get_text()).lower(), self.param)
         self.fitted_curve.set_name(f"Y = {name}")
         self.fitted_curve.ydata, self.fitted_curve.xdata = (ydata, xdata)
         self.get_confidence(function)

--- a/src/curve_fitting.py
+++ b/src/curve_fitting.py
@@ -129,10 +129,11 @@ class CurveFittingWindow(Graphs.CurveFittingTool):
 
     def get_free_variables(self) -> str:
         """Get a list of free variables in the equation entry"""
-        return re.findall(
-            r"\b(?!x\b|X\b|sin\b|cos\b|tan\b)[a-wy-zA-WY-Z]+\b",
-            self.equation_string,
+        pattern = (
+            r"\b(?!x\b|X\b|csc\b|cot\b|sec\b|sin\b|cos\b|log\b|tan\b)"
+            r"[a-wy-zA-WY-Z]+\b"
         )
+        return re.findall(pattern, self.equation_string)
 
     def on_equation_change(self, _entry, _param):
         """
@@ -272,7 +273,7 @@ class CurveFittingWindow(Graphs.CurveFittingTool):
                 method=self.settings.get_string("optimization"),
             )
             self.get_custom_equation().get_child().remove_css_class("error")
-        except (ValueError, TypeError, _minpack.error, RuntimeError):
+        except (_minpack.error):
             # Cancel fit if not successful
             self.get_custom_equation().get_child().add_css_class("error")
             self.set_results(error="equation")

--- a/src/curve_fitting.py
+++ b/src/curve_fitting.py
@@ -273,7 +273,7 @@ class CurveFittingWindow(Graphs.CurveFittingTool):
                 method=self.settings.get_string("optimization"),
             )
             self.get_custom_equation().get_child().remove_css_class("error")
-        except (_minpack.error):
+        except (ValueError, TypeError, _minpack.error, RuntimeError):
             # Cancel fit if not successful
             self.get_custom_equation().get_child().add_css_class("error")
             self.set_results(error="equation")

--- a/src/curve_fitting.py
+++ b/src/curve_fitting.py
@@ -2,12 +2,13 @@
 import re
 from gettext import gettext as _
 
-from gi.repository import Adw, GObject, Graphs, Gtk
+from gi.repository import Adw, GObject, Gio, Graphs, Gtk
 
-from graphs import ui, utilities
+from graphs import utilities
 from graphs.canvas import Canvas
 from graphs.data import Data
 from graphs.item import DataItem, FillItem
+from graphs.misc import EQUATIONS
 
 import numpy
 
@@ -17,7 +18,7 @@ from scipy.optimize import _minpack, curve_fit
 class CurveFittingWindow(Graphs.CurveFittingTool):
     __gtype_name__ = "GraphsCurveFittingWindow"
     confirm_button = GObject.Property(type=Gtk.Button)
-    equation = GObject.Property(type=Adw.EntryRow)
+    custom_equation = GObject.Property(type=Adw.EntryRow)
     fitting_params = GObject.Property(type=Gtk.Box)
     text_view = GObject.Property(type=Gtk.TextView)
     title_widget = GObject.Property(type=Adw.WindowTitle)
@@ -28,9 +29,11 @@ class CurveFittingWindow(Graphs.CurveFittingTool):
             application=application, transient_for=application.get_window(),
         )
         Adw.StyleManager.get_default().connect("notify", self.reload_canvas)
-        self.equation = self.get_equation()
-        ui.bind_values_to_settings(
-            application.get_settings_child("curve-fitting"), self)
+        self.settings = \
+            self.get_application().get_settings_child("curve-fitting")
+        self.custom_equation = self.get_custom_equation()
+        self.set_equation()
+        self.connect_actions()
         self.get_confirm_button().connect("clicked", self.add_fit)
         style = application.get_figure_style_manager(
         ).get_system_style_params()
@@ -39,7 +42,8 @@ class CurveFittingWindow(Graphs.CurveFittingTool):
         self.sigma = []
         self.r2 = 0
 
-        self.get_equation().connect("notify::text", self.on_equation_change)
+        self.get_custom_equation().connect(
+            "notify::text", self.on_equation_change)
         self.fitting_parameters = \
             FittingParameterContainer(application, application.get_settings())
 
@@ -68,6 +72,27 @@ class CurveFittingWindow(Graphs.CurveFittingTool):
         self.fit_curve()
         self.set_entry_rows()
         self.present()
+
+    def connect_actions(self):
+        action_map = Gio.SimpleActionGroup.new()
+        self.insert_action_group("win", action_map)
+        for key in ["confidence", "optimization"]:
+            action = self.settings.create_action(key)
+            action.connect("notify", self.fit_curve)
+            action_map.add_action(action)
+        equation_action = self.settings.create_action("equation")
+        equation_action.connect("notify", self.set_equation)
+        action_map.add_action(equation_action)
+
+    def set_equation(self, *_args):
+        equation = EQUATIONS[self.settings.get_string("equation")]
+        custom_equation = self.settings.get_string("custom-equation")
+        if equation != "custom":
+            self.get_custom_equation().set_text(equation)
+            self.get_custom_equation().set_sensitive(False)
+        else:
+            self.get_custom_equation().set_text(custom_equation)
+            self.get_custom_equation().set_sensitive(True)
 
     def reload_canvas(self, *_args):
         self.get_toast_overlay().set_child(None)
@@ -98,6 +123,10 @@ class CurveFittingWindow(Graphs.CurveFittingTool):
         )
 
     def on_equation_change(self, _entry, _param):
+        """
+        Set the free variables and corresponding entry rows when the equation
+        has been changed.
+        """
         for var in self.get_free_variables():
             if var not in self.fitting_parameters.get_names():
                 self.fitting_parameters.add_items([FittingParameter(name=var)])
@@ -105,6 +134,9 @@ class CurveFittingWindow(Graphs.CurveFittingTool):
         fit = self.fit_curve()
         if fit:
             self.set_entry_rows()
+            if self.settings.get_string("equation") == "custom":
+                self.settings.set_string("custom-equation",
+                                         self.equation_string)
 
     def on_entry_change(self, entry, _param):
         """
@@ -182,7 +214,9 @@ class CurveFittingWindow(Graphs.CurveFittingTool):
                 parameter = utilities.sig_fig_round(self.param[index], 3)
                 sigma = utilities.sig_fig_round(self.sigma[index], 3)
                 buffer_string += f"{arg}: {parameter}"
-                buffer_string += f" (± {sigma})\n"
+                if self.settings.get_enum("confidence") != 0:
+                    buffer_string += f" (± {sigma})"
+                buffer_string += "\n"
             buffer_string += "\n" + _("Sum of R²: {R2}").format(R2=self.r2)
         self.get_text_view().get_buffer().set_text(buffer_string)
         bold_tag = Gtk.TextTag(weight=700)
@@ -199,9 +233,9 @@ class CurveFittingWindow(Graphs.CurveFittingTool):
 
     @property
     def equation_string(self):
-        return utilities.preprocess(str(self.get_equation().get_text()))
+        return utilities.preprocess(str(self.get_custom_equation().get_text()))
 
-    def fit_curve(self):
+    def fit_curve(self, *_args):
         def _get_equation_name(equation_name, values):
             var_to_val = dict(zip(self.get_free_variables(), values))
 
@@ -218,11 +252,12 @@ class CurveFittingWindow(Graphs.CurveFittingTool):
                 self.data_curve.xdata, self.data_curve.ydata,
                 p0=self.fitting_parameters.get_p0(),
                 bounds=self.fitting_parameters.get_bounds(), nan_policy="omit",
+                method=self.settings.get_string("optimization"),
             )
-            self.get_equation().get_child().remove_css_class("error")
+            self.get_custom_equation().get_child().remove_css_class("error")
         except (ValueError, TypeError, _minpack.error, RuntimeError):
             # Cancel fit if not successful
-            self.get_equation().get_child().add_css_class("error")
+            self.get_custom_equation().get_child().add_css_class("error")
             self.set_results(error="equation")
             return
         xdata = numpy.linspace(
@@ -231,7 +266,7 @@ class CurveFittingWindow(Graphs.CurveFittingTool):
         ydata = [function(x, *self.param) for x in xdata]
 
         name = _get_equation_name(
-            str(self.get_equation().get_text()), self.param)
+            str(self.get_custom_equation().get_text()), self.param)
         self.fitted_curve.set_name(f"Y = {name}")
         self.fitted_curve.ydata, self.fitted_curve.xdata = (ydata, xdata)
         self.get_confidence(function)
@@ -242,6 +277,7 @@ class CurveFittingWindow(Graphs.CurveFittingTool):
         # Get standard deviation
         self.canvas.axes[0].relim()  # Reset limits
         self.sigma = numpy.sqrt(numpy.diagonal(self.param_cov))
+        self.sigma *= self.settings.get_enum("confidence")
         try:
             fitted_y = \
                 [function(x, *self.param) for x in self.data_curve.xdata]
@@ -294,6 +330,10 @@ class CurveFittingWindow(Graphs.CurveFittingTool):
         self.destroy()
 
     def set_entry_rows(self):
+        """
+        Remove the old entry rows and replace them with new ones corresponding
+        to the free variables in the equation
+        """
         while self.get_fitting_params().get_last_child() is not None:
             self.get_fitting_params().remove(
                 self.get_fitting_params().get_last_child())

--- a/src/curve_fitting.py
+++ b/src/curve_fitting.py
@@ -310,7 +310,7 @@ class CurveFittingWindow(Graphs.CurveFittingTool):
         ss_res = numpy.sum((numpy.asarray(self.data_curve.ydata)
                             - numpy.asarray(fitted_y)) ** 2)
         ss_sum = numpy.sum((self.data_curve.ydata - numpy.mean(fitted_y)) ** 2)
-        self.r2 = 1 - (ss_res / ss_sum)
+        self.r2 = utilities.sig_fig_round(1 - (ss_res / ss_sum), 3)
 
         # Get confidence band
         upper_bound = \

--- a/src/curve_fitting.py
+++ b/src/curve_fitting.py
@@ -50,6 +50,8 @@ class CurveFittingWindow(Graphs.CurveFittingTool):
 
         self.get_custom_equation().connect(
             "notify::text", self.on_equation_change)
+        self.get_equation().connect(
+            "notify::selected", self.set_equation)
         self.fitting_parameters = \
             FittingParameterContainer(application, application.get_settings())
 
@@ -82,14 +84,12 @@ class CurveFittingWindow(Graphs.CurveFittingTool):
     def connect_actions(self) -> None:
         """Connect the actions in the dialog to the action map"""
         action_map = Gio.SimpleActionGroup.new()
+        self.insert_action_group("win", None)
         self.insert_action_group("win", action_map)
         for key in ["confidence", "optimization"]:
             action = self.settings.create_action(key)
             action.connect("notify", self.fit_curve)
             action_map.add_action(action)
-        equation_action = self.settings.create_action("equation")
-        equation_action.connect("notify", self.set_equation)
-        action_map.add_action(equation_action)
 
     def set_equation(self, *_args) -> None:
         """Set the equation entry based on the current settings"""

--- a/src/curve_fitting.py
+++ b/src/curve_fitting.py
@@ -96,7 +96,7 @@ class CurveFittingWindow(Graphs.CurveFittingTool):
         equation = EQUATIONS[self.settings.get_string("equation")]
         custom_equation = self.settings.get_string("custom-equation")
         if equation != "custom":
-            self.equation.set_subtitle(equation)
+            self.equation.set_subtitle(f"Y={equation}")
             self.get_custom_equation().set_text(equation)
             self.get_custom_equation().set_visible(False)
         else:

--- a/src/curve_fitting.vala
+++ b/src/curve_fitting.vala
@@ -29,11 +29,6 @@ namespace Graphs {
         [GtkChild]
         public unowned Adw.WindowTitle title_widget { get; }
 
-        [GtkCallback]
-        private void on_select () {
-            this.application.lookup_action ("win.equation").activate;
-        }
-
         }
 
     public class FittingParameter : Object {

--- a/src/curve_fitting.vala
+++ b/src/curve_fitting.vala
@@ -6,7 +6,7 @@ namespace Graphs {
     [GtkTemplate (ui = "/se/sjoerd/Graphs/ui/curve_fitting.ui")]
     public class CurveFittingTool : Adw.Window {
         [GtkChild]
-        public unowned Adw.EntryRow equation { get; }
+        public unowned Adw.EntryRow custom_equation { get; }
 
         [GtkChild]
         public unowned Gtk.Box fitting_params { get; }
@@ -41,4 +41,5 @@ namespace Graphs {
         public string upper_bound { get; construct set; default = "inf"; }
     }
 }
+
 

--- a/src/curve_fitting.vala
+++ b/src/curve_fitting.vala
@@ -9,6 +9,9 @@ namespace Graphs {
         public unowned Adw.EntryRow custom_equation { get; }
 
         [GtkChild]
+        public unowned Adw.ComboRow equation { get; }
+
+        [GtkChild]
         public unowned Gtk.Box fitting_params { get; }
 
         [GtkChild]
@@ -27,11 +30,10 @@ namespace Graphs {
         public unowned Adw.WindowTitle title_widget { get; }
 
         [GtkCallback]
-        private void on_sidebar_toggle () {
-            this.application.lookup_action ("toggle_sidebar").change_state (
-                new Variant.boolean (this.split_view.get_collapsed ())
-            );
+        private void on_select () {
+            this.application.lookup_action ("win.equation").activate;
         }
+
         }
 
     public class FittingParameter : Object {

--- a/src/misc.py
+++ b/src/misc.py
@@ -29,3 +29,11 @@ LIMITS = [
     "min_bottom", "max_bottom", "min_top", "max_top",
     "min_left", "max_left", "min_right", "max_right",
 ]
+
+EQUATIONS = {
+    "linear": "a*x+b", "quadratic": "a*x²+b*x+c", "exponential": "a*exp(b*x)",
+    "power": "a*x^b", "log": "a*log(x)+b",
+    "sigmoid": "L / (1 + exp(-k * (x - b)))",
+    "gaussian": "a*exp(-(x-mu)²/(2*s²))",
+    "custom": "custom",
+}

--- a/src/misc.py
+++ b/src/misc.py
@@ -33,7 +33,7 @@ LIMITS = [
 EQUATIONS = {
     "linear": "a*x+b", "quadratic": "a*x²+b*x+c", "exponential": "a*exp(b*x)",
     "power": "a*x^b", "log": "a*log(x)+b",
-    "sigmoid": "L / (1 + exp(-k * (x - b)))",
+    "sigmoid": "L/(1+exp(-k*(x-b)))",
     "gaussian": "a*exp(-(x-mu)²/(2*s²))",
     "custom": "custom",
 }

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -209,10 +209,11 @@ def get_filename(file: Gio.File):
 
 
 def string_to_function(equation_name):
-    variables = ["x"] + re.findall(
-        r"\b(?!x\b|X\b|sin\b|cos\b|tan\b)[a-wy-zA-WY-Z]+\b",
-        equation_name,
+    pattern = (
+        r"\b(?!x\b|X\b|csc\b|cot\b|sec\b|sin\b|cos\b|log\b|tan\b)"
+        r"[a-wy-zA-WY-Z]+\b"
     )
+    variables = ["x"] + re.findall(pattern, equation_name)
     sym_vars = sympy.symbols(variables)
     with contextlib.suppress(sympy.SympifyError, TypeError, SyntaxError):
         symbolic = sympy.sympify(


### PR DESCRIPTION
Adds the following options to the Curve Fitting dialog:

- **Equation**: Sets the equation that is currently used. I've set the default value to "Custom" for discoverability's sake, the idea there was that out of the box all entries are working and editable. Then when one discovers the setting, it is more obvious why this box is grayed out. The reason for not removing this box, is so that it's clear what the equation itself is that is being fitted to.
- **Optimization**: Sets the optimization algorithm that is being used for the fit. Typical Levenberg-Marquardt is the standard for most tools I've come across. But there may be reasons for prefering others.
- **Confidence bounds**: This sets the confidence bounds. Allowing this to turn them off, or to just set it to a multiple of the standard deviation. Which works well enough as a set of options for now at least.

Compared to the video below, I've removed the "Toggle Sidebar" option, as it seemed a bit unintuitive to actually use that in the dialog.

[Skärminspelning från 2023-12-19 09-58-44.webm](https://github.com/Sjoerd1993/Graphs/assets/68477016/db8bd2ef-6d9c-477d-9c08-098298db3a14)

Closes issue #494 
