### PR TITLE
hide dpi with vector based images

### DIFF
--- a/data/ui/export_figure.blp
+++ b/data/ui/export_figure.blp
@@ -47,7 +47,7 @@ template $GraphsExportFigureWindow : Adw.Window {
           title: _("Resolution (dpi)");
           adjustment: Adjustment {
               step-increment: 1;
-              upper: 9999;
+              upper: 999;
           };
         }
         Adw.SwitchRow transparent {

--- a/src/export_figure.py
+++ b/src/export_figure.py
@@ -31,8 +31,7 @@ class ExportFigureWindow(Adw.Window):
             Gtk.StringList.new(list(self.file_formats.keys())))
         ui.bind_values_to_settings(
             self.get_application().get_settings_child("export-figure"), self)
-        self.dpi.set_visible(self.file_format.get_selected()
-                             not in [0, 2, 4, 5])
+        self.on_file_format(None, None)
         self.file_format.connect("notify::selected", self.on_file_format)
         self.present()
 

--- a/src/export_figure.py
+++ b/src/export_figure.py
@@ -19,22 +19,26 @@ class ExportFigureWindow(Adw.Window):
 
     def __init__(self, application):
         self._canvas = application.get_window().get_canvas()
+        valid_formats = self._canvas.get_supported_filetypes_grouped()
+        valid_formats.pop("Tagged Image File Format")
+        valid_formats.pop("Raw RGBA bitmap")
+        valid_formats.pop("PGF code for LaTeX")
         super().__init__(
             application=application, transient_for=application.get_window(),
-            file_formats=self._canvas.get_supported_filetypes_grouped(),
+            file_formats=valid_formats,
         )
         self.file_format.set_model(
             Gtk.StringList.new(list(self.file_formats.keys())))
         ui.bind_values_to_settings(
             self.get_application().get_settings_child("export-figure"), self)
         self.dpi.set_visible(self.file_format.get_selected()
-                             not in [0, 2, 3, 7])
+                             not in [0, 2, 4, 5])
         self.file_format.connect("notify::selected", self.on_file_format)
         self.present()
 
     def on_file_format(self, _widget, _state):
         self.dpi.set_visible(self.file_format.get_selected()
-                             not in [0, 2, 3, 7])
+                             not in [0, 2, 4, 5])
 
     @Gtk.Template.Callback()
     def on_accept(self, _button):

--- a/src/export_figure.py
+++ b/src/export_figure.py
@@ -27,7 +27,14 @@ class ExportFigureWindow(Adw.Window):
             Gtk.StringList.new(list(self.file_formats.keys())))
         ui.bind_values_to_settings(
             self.get_application().get_settings_child("export-figure"), self)
+        self.dpi.set_visible(self.file_format.get_selected()
+                             not in [0, 2, 3, 7])
+        self.file_format.connect("notify::selected", self.on_file_format)
         self.present()
+
+    def on_file_format(self, _widget, _state):
+        self.dpi.set_visible(self.file_format.get_selected()
+                             not in [0, 2, 3, 7])
 
     @Gtk.Template.Callback()
     def on_accept(self, _button):


### PR DESCRIPTION
Hides the dpi when exporting images in vector-based formats. It's meaningless to talk about pixel density in vector images, and this setting doesn't even have an impact on the exported figure (not even on the rendered size), so it's best to hide them when not applicable.

Also removes unsupported filetypes, those were broken from the beginning.