### PR TITLE
Minor string changes

### DIFF
--- a/data/ui/figure_settings.blp
+++ b/data/ui/figure_settings.blp
@@ -166,7 +166,7 @@ template $GraphsFigureSettingsWindow : Adw.Window {
                       title: _("Legend Position");
                       model: StringList{
                         strings [
-                          _("Best"), _("Upper right"), _("Upper left"), _("Lower left"),
+                          _("Auto"), _("Upper right"), _("Upper left"), _("Lower left"),
                           _("Lower right"), _("Center left"), _("Center right"),
                           _("Lower center"), _("Upper center"), _("Center"),
                         ]

--- a/data/ui/figure_settings.blp
+++ b/data/ui/figure_settings.blp
@@ -68,12 +68,12 @@ template $GraphsFigureSettingsWindow : Adw.Window {
                       spacing: 6;
                       Adw.PreferencesGroup {
                         Adw.EntryRow min_left {
-                          title: _("Minimum Left-Hand Y-Axis");
+                          title: _("Minimum Left Y-Axis");
                         }
                       }
                       Adw.PreferencesGroup {
                   	    Adw.EntryRow max_left {
-                          title: _("Maximum Left-Hand Y-Axis");
+                          title: _("Maximum Left Y-Axis");
                         }
                       }
                     }
@@ -98,12 +98,12 @@ template $GraphsFigureSettingsWindow : Adw.Window {
                       spacing: 6;
                       Adw.PreferencesGroup {
                         Adw.EntryRow min_right {
-                          title: _("Minimum Right-Hand Y-Axis");
+                          title: _("Minimum Right Y-Axis");
                         }
                       }
                       Adw.PreferencesGroup {
                         Adw.EntryRow max_right {
-                          title: _("Maximum Right-Hand Y-Axis");
+                          title: _("Maximum Right Y-Axis");
                         }
                       }
                     }

--- a/data/ui/figure_settings.blp
+++ b/data/ui/figure_settings.blp
@@ -68,12 +68,12 @@ template $GraphsFigureSettingsWindow : Adw.Window {
                       spacing: 6;
                       Adw.PreferencesGroup {
                         Adw.EntryRow min_left {
-                          title: _("Minimum Left Y-Axis");
+                          title: _("Minimum Left Axis");
                         }
                       }
                       Adw.PreferencesGroup {
                   	    Adw.EntryRow max_left {
-                          title: _("Maximum Left Y-Axis");
+                          title: _("Maximum Left Axis");
                         }
                       }
                     }
@@ -83,12 +83,12 @@ template $GraphsFigureSettingsWindow : Adw.Window {
                       spacing: 6;
                       Adw.PreferencesGroup {
                         Adw.EntryRow min_bottom {
-                          title: _("Minimum Bottom X-Axis");
+                          title: _("Minimum Bottom Axis");
                         }
                       }
                       Adw.PreferencesGroup {
                         Adw.EntryRow max_bottom {
-                          title: _("Maximum Bottom X-Axis");
+                          title: _("Maximum Bottom Axis");
                         }
                       }
                     }
@@ -98,12 +98,12 @@ template $GraphsFigureSettingsWindow : Adw.Window {
                       spacing: 6;
                       Adw.PreferencesGroup {
                         Adw.EntryRow min_right {
-                          title: _("Minimum Right Y-Axis");
+                          title: _("Minimum Right Axis");
                         }
                       }
                       Adw.PreferencesGroup {
                         Adw.EntryRow max_right {
-                          title: _("Maximum Right Y-Axis");
+                          title: _("Maximum Right Axis");
                         }
                       }
                     }
@@ -113,12 +113,12 @@ template $GraphsFigureSettingsWindow : Adw.Window {
                       orientation: horizontal;
                       Adw.PreferencesGroup {
                         Adw.EntryRow min_top {
-                          title: _("Minimum Top X-Axis");
+                          title: _("Minimum Top Axis");
                         }
                       }
                       Adw.PreferencesGroup {
                         Adw.EntryRow max_top {
-                          title: _("Maximum Top Y-Axis");
+                          title: _("Maximum Top Axis");
                         }
                       }
                     }

--- a/data/ui/style_editor.blp
+++ b/data/ui/style_editor.blp
@@ -50,7 +50,7 @@ template $GraphsStyleEditor : Adw.NavigationPage {
 
             Adw.ActionRow {
               title: _("Title Size");
-              subtitle: _("Title size in relation to text Size");
+              subtitle: _("Title size in relation to text size");
 
               Scale titlesize {
                 draw-value: true;
@@ -63,7 +63,7 @@ template $GraphsStyleEditor : Adw.NavigationPage {
             }
             Adw.ActionRow {
               title: _("Label Size");
-              subtitle: _("Label size in relation to text Size");
+              subtitle: _("Label size in relation to text size");
 
               Scale labelsize {
                 draw-value: true;

--- a/data/ui/window.blp
+++ b/data/ui/window.blp
@@ -665,7 +665,7 @@ menu view_menu {
   }
   section {
     submenu {
-      label: _("Top X Scale");
+      label: _("Top Scale");
       hidden-when: "action-disabled";
       action: "app.change-top-scale";
       target: "0";
@@ -696,7 +696,7 @@ menu view_menu {
       }
     }
     submenu {
-      label: _("Bottom X Scale");
+      label: _("Bottom Scale");
       hidden-when: "action-disabled";
       action: "app.change-bottom-scale";
       target: "0";
@@ -728,7 +728,7 @@ menu view_menu {
       }
     }
     submenu {
-      label: _("Left Y Scale");
+      label: _("Left Scale");
       hidden-when: "action-disabled";
       action: "app.change-left-scale";
       target: "0";
@@ -759,7 +759,7 @@ menu view_menu {
       }
     }
     submenu {
-      label: _("Right Y Scale");
+      label: _("Right Scale");
       hidden-when: "action-disabled";
       action: "app.change-right-scale";
       target: "0";


### PR DESCRIPTION
- Removes the "hand" suffix for the direction in the axes limits so it's consistent with the rest of the application. (Could use it everywhere instead as well, but I guess removing it is somewhat cleaner)
- Fixes a capitalization in the subtitle of the text and label size, in the style editor.
- Removes the X and Y prefix when talking about e.g. "Bottom X axis", as the X/Y part is already implicitly specified when giving the direction.
- Change "Best" in the legend to "Auto", as the former is a bit confusing imo.