### PR TITLE
Adress more GNOME Circle Feedback

### DIFF
--- a/data/ui/curve_fitting.blp
+++ b/data/ui/curve_fitting.blp
@@ -36,7 +36,7 @@ template $GraphsCurveFittingTool : Adw.Window {
           };
           [end]
           MenuButton {
-            icon-name: "open-menu-symbolic";
+            icon-name: "view-more-symbolic";
             menu-model: curve_fitting_menu;
             tooltip-text: _("Open Curve Fitting Menu");
             primary: true;
@@ -127,8 +127,7 @@ template $GraphsCurveFittingTool : Adw.Window {
 
 menu curve_fitting_menu {
   section {
-    submenu {
-      label: _("Optimization method");
+      label: _("Optimization Method");
       item {
         label: _("Levenberg-Marquardt");
         action: "win.optimization";
@@ -145,28 +144,27 @@ menu curve_fitting_menu {
         target: "dogbox";
       }
     }
-    submenu {
-      label: _("Confidence bounds");
+    section {
+      label: _("Confidence Bounds");
       item {
         label: _("None");
         action: "win.confidence";
         target: "none";
       }
       item {
-        label: _("1σ: 68% confidence");
+        label: _("1σ: 68% Confidence");
         action: "win.confidence";
         target: "1std";
       }
       item {
-        label: _("2σ: 95% confidence");
+        label: _("2σ: 95% Confidence");
         action: "win.confidence";
         target: "2std";
       }
       item {
-        label: _("3σ: 99.7% confidence");
+        label: _("3σ: 99.7% Confidence");
         action: "win.confidence";
         target: "3std";
       }
     }
-  }
 }

--- a/data/ui/item_box.blp
+++ b/data/ui/item_box.blp
@@ -50,7 +50,7 @@ PopoverMenu popover_menu {
 
 menu menu_app {
   section {
-    label: _("Move item ");
+    label: _("Move Item ");
     display-hint: "inline-buttons";
     item {
       verb-icon: "down-symbolic";

--- a/src/item_box.py
+++ b/src/item_box.py
@@ -40,10 +40,11 @@ class ItemBox(Gtk.Box):
         self.drop_source = Gtk.DropTarget.new(str, Gdk.DragAction.COPY)
         self.drop_source.index = str(self.props.index)
         self.drop_source.connect("drop", self.on_dnd_drop)
-
         self.item.connect("notify::color", self.on_color_change)
         self.on_color_change(self.props.item, None)
         self.add_actions()
+        self.click_gesture = Gtk.GestureClick.new()
+        self.click_gesture.connect("released", self.on_click)
 
     def add_actions(self):
         data = self.get_application().get_data()
@@ -94,6 +95,10 @@ class ItemBox(Gtk.Box):
 
     def move_down(self, _action, _shortcut):
         self._change_position(self.props.index, self.props.index + 1)
+
+    def on_click(self, *_args):
+        self.check_button.set_active(not self.check_button.get_active())
+        self.on_toggle(None, None)
 
     @Gtk.Template.Callback()
     def on_toggle(self, _a, _b):

--- a/src/ui.py
+++ b/src/ui.py
@@ -22,6 +22,7 @@ def on_items_change(data, _ignored, self):
         row = item_list.get_row_at_index(index)
         row.add_controller(itembox.drag_source)
         row.add_controller(itembox.drop_source)
+        row.add_controller(itembox.click_gesture)
     data.add_view_history_state()
 
 


### PR DESCRIPTION
> - [x] Some menu entries are not using Title Case, e.g. "Move items" should be "Move Items"

I think I've now got them all


> - [x] Clicking the rows with the equations doesn't do anything, which is surprising given that it has a hover state. I would have expected this to allow editing the equation or checking the checkbox.

Clicking them right now checks the checkbox.

> - [ ]  "Bottom Scale" and "Left Scale" are a bit unclear at first glance, especially in the simple/default case where there's just two axes. Maybe the scale menu entries could be "X Axis Scale" and "Y Axis Scale"?

This still needs to be fixed. An easy solution is to just use "X Axis Scale" and "Y Axis Scale" for left and bottom scale and "Right X Axis Scale" and "Top Y Axis Scale" for the right and top scale. But it may make more sense to only use this directional prefix when two opposite axes are actually used at the same time. Since GMenuModels are immutable, they need to be dynamically generated in Python directly to get that to work.

> - [x]  A few issues with the new menu in the Curve Fitting dialog sidebar:
> - [x]  It should not use the primary menu icon, it's reserved to just the actual primary menu on the main window. The secondary menu icon (view-more) or some kind of settings icon would probably work here.

This has now been replaced with view-more.

> - [x]  It's also a bit odd because it only has two entries, given that the submenus are just 3-4 items long I'd move it all to the top level and just have both choices directly accessible in the menu.

These settings are now one level higher, so on the top level.

> - [x]  Some menu entries are not using Title Case, e.g. "method" and "bound"

Should be fixed in this PR.

With regard to the Y scale and X scale naming. That will require some more extensive changes that are probably best suited for a seperate PR. My current idea is that a directional prefix is used when double axis is detected. So if both the left and right X-axes are in used, then they're called "Left X Axis" and "Right X Axis", otherwise it should just be "X Axis". This should be implemented in the view menu, but also in the Figure settings for both the limits and scale.