### PR TITLE
Implement GNOME Circle Checklist

### DIFF
--- a/data/ui/help_overlay.blp
+++ b/data/ui/help_overlay.blp
@@ -21,11 +21,11 @@ ShortcutsWindow help_overlay {
       }
 
       ShortcutsShortcut {
-        title: C_("shortcut window", "Quit");
+        title: C_("shortcut window", "Close Application");
         accelerator: "<primary>q";
       }
       ShortcutsShortcut {
-        title: C_("shortcut window", "Quit");
+        title: C_("shortcut window", "Close Application Window");
         accelerator: "<primary>w";
       }
     }

--- a/data/ui/help_overlay.blp
+++ b/data/ui/help_overlay.blp
@@ -24,6 +24,10 @@ ShortcutsWindow help_overlay {
         title: C_("shortcut window", "Quit");
         accelerator: "<primary>q";
       }
+      ShortcutsShortcut {
+        title: C_("shortcut window", "Quit");
+        accelerator: "<primary>w";
+      }
     }
 
     ShortcutsGroup {

--- a/data/ui/item_box.blp
+++ b/data/ui/item_box.blp
@@ -44,8 +44,6 @@ PopoverMenu popover_menu {
   name: "popover_menu";
   has-arrow: false;
   menu-model: menu_app;
-  show => $set_focus();
-  closed => $set_focus();
 }
 
 menu menu_app {

--- a/data/ui/window.blp
+++ b/data/ui/window.blp
@@ -13,6 +13,10 @@ template $GraphsWindow: Adw.ApplicationWindow {
       action: "action(app.quit)";
     }
     Shortcut {
+      trigger: "<primary>w";
+      action: "action(app.quit)";
+    }
+    Shortcut {
       trigger: "<primary>comma";
       action: "action(app.figure_settings)";
     }

--- a/src/item_box.py
+++ b/src/item_box.py
@@ -135,14 +135,6 @@ class ItemBox(Gtk.Box):
     def edit(self, _action, _shortcut):
         EditItemWindow(self.get_application(), self.props.item)
 
-    @Gtk.Template.Callback()
-    def set_focus(self, widget):
-        """
-        Disable widget focus whenever the popover menu is shown to prevent
-        unwanted scrolling when hovering the mouse to different options.
-        """
-        self.set_can_focus(not widget.get_visible())
-
     def get_application(self):
         """Get application property."""
         return self.props.application


### PR DESCRIPTION
Some things from the GNOME Circle Feedback:

-  Ctrl+W should close the window
-  This context menu can be opened, but not navigated via keyboard:

![image](https://github.com/Sjoerd1993/Graphs/assets/68477016/aea0d973-5e5f-4690-b111-00c1b08a6e93)

Both are addressed now. The context menu's focus was disabled upon click, as it can scroll down in unexpected ways if there's a long list of items present. However this is at the cost of accessibility, so that fix has been reverted. This scrolling behaviour is probably a GTK-issue, but either way seems less present now probably since the latest changes with regard to breakpoints a while ago.