### PR TITLE
Only draw minor ticks if spine visible

### DIFF
--- a/src/canvas.py
+++ b/src/canvas.py
@@ -162,12 +162,12 @@ class Canvas(FigureCanvas, Graphs.CanvasInterface):
         Determines what to do when a panning gesture is detected, pans the
         canvas in the gesture direction.
         """
-        if self.get_application().get_shift():
-            x, y = y, x
-        if event_controller.get_unit() == Gdk.ScrollUnit.WHEEL:
-            x *= 10
-            y *= 10
         if self.get_application().get_ctrl() is False:
+            if self.get_application().get_shift():
+                x, y = y, x
+            if event_controller.get_unit() == Gdk.ScrollUnit.WHEEL:
+                x *= 10
+                y *= 10
             for ax in self.axes:
                 xmin, xmax, ymin, ymax = \
                     self._calculate_pan_values(ax, x, y)

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -295,11 +295,12 @@ class Canvas(FigureCanvas, Graphs.CanvasInterface):
             visible_axes[2 + yposition] = True
             used_axes[xposition + 2 * yposition] = True
         axes_directions = (
-            ("bottom", "left"),   # axis
+            ("left", "bottom"),   # axis
             ("top", "left"),      # top_left_axis
             ("bottom", "right"),  # right_axis
-            ("top", "right"),     # top_right_axis
+            ("right", "top"),     # top_right_axis
         )
+        axes_ticks = ("ytick.left", "xtick.top", "xtick.bottom", "ytick.right")
 
         if not any(visible_axes):
             visible_axes = (True, False, True, False)  # Left and bottom
@@ -310,18 +311,19 @@ class Canvas(FigureCanvas, Graphs.CanvasInterface):
         draw_frame = params["axes.spines.bottom"]
         ticks = "both" if params["xtick.minor.visible"] else "major"
         possible_directions = ("bottom", "top", "left", "right")
-        for directions, axis, used \
-                in zip(axes_directions, self.axes, used_axes):
+        for directions, axis, used, axis_ticks \
+                in zip(axes_directions, self.axes, used_axes, axes_ticks):
             axis.get_xaxis().set_visible(False)
             axis.get_yaxis().set_visible(False)
             # Set tick where requested, as long as that axis is not occupied
             # and visible
-            axis.tick_params(which=ticks, **{
-                direction: (draw_frame and not visible_axes[i]
-                            or direction in directions)
-                and params[f"{'x' if i < 2 else 'y'}tick.{direction}"]
-                for i, direction in enumerate(possible_directions)
-            })
+            if params[axis_ticks]:
+                axis.tick_params(which=ticks, **{
+                    direction: (draw_frame and not visible_axes[i]
+                                or direction in directions)
+                    and params[f"{'x' if i < 2 else 'y'}tick.{direction}"]
+                    for i, direction in enumerate(possible_directions)
+                })
             for handle in axis.lines + axis.texts:
                 handle.remove()
             axis_legend = axis.get_legend()


### PR DESCRIPTION
Greatly enhances performance (e.g. when panning or zooming with the touchpad) for stylesheets where the splines are not drawn whilst ticks are turned on. For example the FiveThirtyEight style sheet, which is quite laggy at the moment. Skipping this line whenever the relevant axis' spline is turned off greatly improves performance.

I'll keep issue #672 open for now, to keep that as a tracker (I'd like to see what parameters affect performance for instance, and check if we're doing any redundant renderings). But this goes a long way at least.