### PR TITLE
Import and header adjustments

### DIFF
--- a/src/data.py
+++ b/src/data.py
@@ -323,10 +323,29 @@ class Data(GObject.Object, Graphs.DataInterface):
 
     def delete_items(self, items: misc.ItemList):
         """Delete specified items."""
+        settings = self.get_figure_settings()
+        default = self.get_application().get_settings_child("figure")
         for item_ in items:
             self._current_batch.append(
                 (2, (self.index(item_), item_.to_dict())),
             )
+            x_position = item_.get_xposition()
+            y_position = item_.get_yposition()
+
+            if (x_position == 0
+                    and item_.get_xlabel() == settings.get_bottom_label()):
+                settings.set_bottom_label(default.get_string("bottom-label"))
+            elif (x_position == 1
+                  and item_.get_xlabel() == settings.get_top_label()):
+                settings.set_top_label(default.get_string("top-label"))
+
+            if (y_position == 0
+                    and item_.get_ylabel() == settings.get_left_label()):
+                settings.set_left_label(default.get_string("left-label"))
+            elif (y_position == 1
+                  and item_.get_ylabel() == settings.get_right_label()):
+                settings.set_right_label(default.get_string("right-label"))
+
             self._delete_item(item_.get_uuid())
         self.notify("items")
         self.add_history_state()

--- a/src/parse_file.py
+++ b/src/parse_file.py
@@ -135,30 +135,16 @@ def import_from_columns(self, file):
             # If not all values in the line are floats, start looking for
             # headers instead
             except ValueError:
-                # By default it will check for headers using at least
-                # two whitespaces as delimiter (often tabs), but if
-                # that doesn"t work it will try the same delimiter as
-                # used for the data import itself The reasoning is that
-                # some people use tabs for the headers, but e.g. commas
-                # for the data
                 try:
-                    headers = re.split("\\s{2,}", line)
+                    headers = re.split(delimiter, line)
                     if len(values) == 1:
-                        item_.ylabel = headers[column_x]
+                        item_.set_ylabel(headers[column_x])
                     else:
-                        item_.xlabel = headers[column_x]
-                        item_.ylabel = headers[column_y]
+                        item_.set_xlabel(headers[column_x])
+                        item_.set_ylabel(headers[column_y])
+                # If no label could be found at the index, skip.
                 except IndexError:
-                    try:
-                        headers = re.split(delimiter, line)
-                        if len(values) == 1:
-                            item_.ylabel = headers[column_x]
-                        else:
-                            item_.xlabel = headers[column_x]
-                            item_.ylabel = headers[column_y]
-                    # If neither heuristic works, we just skip headers
-                    except IndexError:
-                        pass
+                    pass
     if not item_.xdata:
         raise ParseError(_("Unable to import from file"))
     return [item_]


### PR DESCRIPTION
Makes the following adjustments to importing and header handling:

- Stops looking for headers when data is detected. This makes it such that comments and other data at the bottom are just ignored
- Only add X and Y data if _both_ data can be added, otherwise skip that row. This prevents errors when one of the data points was valid but the other one was not
- Use the getters and setters for the labels, this was broken when we moved the item class to Vala, the relevant code was still trying to assign the attribute directly.
- Do not add X and Y data if either of them returns None. This still parses as a float, but leads to errors when doing fitting or limit optimisations
- Just use the delimiter to detect headers, stop detecting whitespaces as first choice by default. As I feel using two different heuretics to detect headers will lead to more issues than it solves, and you'd pretty much always use the same delimiter anyway
- Remove headers from the axis if the associated item is removed. This is because otherwise adding a dataset with headers, and then deleting it, and then adding another dataset, will put that new dataset in the top/right axis, even though it's the only dataset there. That is not intuitive behaviour and not what anyone would want probably. 

Solves issues #674, #675, #677