### PR TITLE
Label update tweaks

### DIFF
--- a/src/data.py
+++ b/src/data.py
@@ -293,7 +293,7 @@ class Data(GObject.Object, Graphs.DataInterface):
             if ylabel:
                 original_position = new_item.get_yposition()
                 if original_position == 0:
-                    if _is_default("left-label") or not self.items:
+                    if _is_default("left-label") or self.props.empty:
                         figure_settings.set_left_label(ylabel)
                     elif ylabel != figure_settings.get_left_label():
                         new_item.set_yposition(1)

--- a/src/data.py
+++ b/src/data.py
@@ -280,7 +280,7 @@ class Data(GObject.Object, Graphs.DataInterface):
             if xlabel:
                 original_position = new_item.get_xposition()
                 if original_position == 0:
-                    if _is_default("bottom-label") or not self.items:
+                    if _is_default("bottom-label") or self.props.empty:
                         figure_settings.set_bottom_label(xlabel)
                     elif xlabel != figure_settings.get_bottom_label():
                         new_item.set_xposition(1)


### PR DESCRIPTION
Makes some tweaks to how labels are updated when removing and adding items:

- Generally the code is a bit more clean with the deleting part (I prefer the loop over the else-if statements)
- Now when deleting an item, it checks for each label if the corresponding axis is still occupied after deleting. If it is still occupied, it does not delete the label. This prevents the situation where you have two datasets with the same units, and then the axes labels dissapear when removing one of them. See screencast, as that may be clearer.
- If the list of data items is empty when loading the data set (so plot is empty), then it always ignores the axes labels and just overwrites those labels and places the data in the left/bottom axes.

General point of discussion: The last bullet point solves the issue that I initially was trying to solve, which is that when you remove your datasets, and then add a new one, that it places itself in the top/right corner because the labels from the now-removed dataset were still present. 

For cleanliness' sake, we could remove the logic where it resets the labels when deleting a dataset. As the underlying problem is solved with those two lines of code in the `add_item` logic. I'm fine with keeping it in (I see arguments either way), but I think it may be slightly redundant.

Screencast with the bug described in the second bullet point (note this is from the build in the main branch, and thus fixed in this PR):
![Skärminspelning från 2024-01-01 08-48-29.webm](https://github.com/Sjoerd1993/Graphs/assets/68477016/82c196c0-13b1-466b-a636-bae5963d8e6b)
Screencast of the other situation described, where deleting one of the data sets resets all labels when it shouldn't (also from main, fixed in this PR):
[Skärminspelning från 2024-01-01 08-56-23.webm](https://github.com/Sjoerd1993/Graphs/assets/68477016/19c9cf14-f6bd-4f18-bdea-222c22f14af1)
