### PR TITLE
Fix unselected item getter

### DIFF
--- a/src/data.py
+++ b/src/data.py
@@ -161,7 +161,8 @@ class Data(GObject.Object, Graphs.DataInterface):
         used_positions = [False, False, False, False]
 
         for item_ in self.items:
-            if (figure_settings.get_hide_unselected() and not item_.selected):
+            if (figure_settings.get_hide_unselected()
+                    and not item_.get_selected()):
                 continue
             used_positions[item_.get_xposition()] = True
             used_positions[item_.get_yposition() + 2] = True


### PR DESCRIPTION
When testing, I found that an error occurred when "Hide unselected items" was selected, and the Figure Settings was loaded. This is because it was trying to look for `item_,selected`, but this attribute needs to be retrieved using the getter/setter methods. Hence the error. This PR fixes that.