### PR TITLE
set default widgets in dialogs

### DIFF
--- a/data/ui/add_equation_window.blp
+++ b/data/ui/add_equation_window.blp
@@ -5,7 +5,7 @@ template $GraphsAddEquationWindow : Adw.Window {
   modal: true;
   default-width: 450;
   title: _("Add Equation");
-  focus-widget: confirm_button;
+  default-widget: confirm_button;
 
   ShortcutController {
     Shortcut {
@@ -46,6 +46,7 @@ template $GraphsAddEquationWindow : Adw.Window {
             Adw.EntryRow equation {
               max-width-chars: 25;
               title: _("Y =");
+              activates-default: true;
               styles ["preferencesgroup"]
             }
             Label {
@@ -61,6 +62,7 @@ template $GraphsAddEquationWindow : Adw.Window {
             Adw.EntryRow name {
               max-width-chars: 25;
               title: _("Name (optional)");
+              activates-default: true;
             }
           }
 
@@ -73,18 +75,21 @@ template $GraphsAddEquationWindow : Adw.Window {
               Adw.PreferencesGroup {
                 Adw.EntryRow x_start {
                   title: _("X Start");
+                  activates-default: true;
                 }
               }
 
               Adw.PreferencesGroup {
                 Adw.EntryRow x_stop {
                   title: _("X Stop");
+                  activates-default: true;
                 }
               }
 
               Adw.PreferencesGroup {
                 Adw.EntryRow step_size {
                   title: _("Step Size");
+                  activates-default: true;
                 }
               }
             }

--- a/data/ui/transform_window.blp
+++ b/data/ui/transform_window.blp
@@ -5,7 +5,7 @@ template $GraphsTransformWindow : Adw.Window {
   modal: true;
   default-width: 450;
   title: _("Transform Data");
-  focus-widget: confirm_button;
+  default-widget: confirm_button;
 
   ShortcutController {
     Shortcut {
@@ -56,10 +56,12 @@ template $GraphsTransformWindow : Adw.Window {
       Adw.PreferencesGroup {
         Adw.EntryRow transform_x_entry {
           title: _("X =");
+          activates-default: true;
         }
 
         Adw.EntryRow transform_y_entry {
           title: _("Y =");
+          activates-default: true;
         }
 
         Adw.SwitchRow discard {


### PR DESCRIPTION
Sets the default widgets in the dialogs with entry rows. Such that when pressing enter on the entry row, the action is performed. (e.g. you can add an equation by pressing enter on the entry fields). I think this covers all such dialogs we have. Closes issue #693 