### PR TITLE
Fix export data

### DIFF
--- a/src/ui.py
+++ b/src/ui.py
@@ -126,7 +126,7 @@ def open_project_dialog(self):
 
 
 def export_data_dialog(self):
-    if self.get_data().get_empty():
+    if self.get_data().props.empty:
         self.get_window().add_toast_string(_("No data to export"))
         return
     multiple = len(self.get_data()) > 1


### PR DESCRIPTION
The export data gave an error when there was no data open, this was due to that it's now a prop from data, and can't be retrieved using the getter we used before. This now properly gives a toast.