### PR TITLE
Fix modify toast

### DIFF
--- a/src/actions.py
+++ b/src/actions.py
@@ -48,7 +48,7 @@ def perform_operation(_action, target, self):
                 window.get_property(operation + "_entry").get_text(),
             )]
         except ValueError as error:
-            window.add_toast_string(error)
+            window.add_toast_string(str(error))
             return
     operations.perform_operation(self, getattr(operations, operation), *args)
 


### PR DESCRIPTION
This will probably redundant, once we fix #695. The fix there is not that difficult, just check upon the entry change if the value is parsable, and if it isn't make deactivate the button and maybe give a red error CSS. 

In the meantime, I noticed the error here isn't given as a string into the toast. So currently the toast is not working.