### PR TITLE
Set translate/modify entry css

### DIFF
--- a/data/se.sjoerd.Graphs.appdata.xml.in.in
+++ b/data/se.sjoerd.Graphs.appdata.xml.in.in
@@ -78,6 +78,8 @@
           <li>Importing column data is now more robust, supporting expressions as data points</li>
           <li>Pinch and ctrl+scroll to zoom gestures are now supported on the canvas</li>
           <li>The canvas can now be panned using two fingers on a touch screen, as well as with the middle mouse button</li>
+          <li>Toasts now show an "Open Location" button when saving data, bringing you to the saved file location</li>
+          <li>Translate/multiply entries now get a red CSS when input value is invalid, while the corresponding button is disabled</li>
         </ul>
         <p>Changed behaviour:</p>
         <ul>

--- a/data/whats_new
+++ b/data/whats_new
@@ -23,6 +23,8 @@
           <li>Importing column data is now more robust, supporting expressions as data points</li>
           <li>Pinch and ctrl+scroll to zoom gestures are now supported on the canvas</li>
           <li>The canvas can now be panned using two fingers on a touch screen, as well as with the middle mouse button</li>
+          <li>Toasts now show an "Open Location" button when saving data, bringing you to the saved file location</li>
+          <li>Translate/multiply entries now get a red CSS when input value is invalid, while the corresponding button is disabled</li>
         </ul>
         <p>Changed behaviour:</p>
         <ul>

--- a/src/canvas.py
+++ b/src/canvas.py
@@ -316,7 +316,7 @@ class Canvas(FigureCanvas, Graphs.CanvasInterface):
             # Set tick where requested, as long as that axis is not occupied
             # and visible
             if (params[f"xtick.{directions[0]}"]
-                    or params[f"ytick.{directions[1]}"]) :
+                    or params[f"ytick.{directions[1]}"]):
                 axis.tick_params(which=ticks, **{
                     direction: (draw_frame and not visible_axes[i]
                                 or direction in directions)

--- a/src/window.vala
+++ b/src/window.vala
@@ -55,6 +55,18 @@ namespace Graphs {
         public unowned Entry multiply_y_entry { get; }
 
         [GtkChild]
+        public unowned Button translate_x_button { get; }
+
+        [GtkChild]
+        public unowned Button translate_y_button { get; }
+
+        [GtkChild]
+        public unowned Button multiply_x_button { get; }
+
+        [GtkChild]
+        public unowned Button multiply_y_button { get; }
+
+        [GtkChild]
         public unowned ListBox item_list { get; }
 
         [GtkChild]


### PR DESCRIPTION
Sets an "Error" CSS when the input value on the translate/modify entries are invalid, also disables the corresponding button. As discussed in issue #700.

[Skärminspelning från 2024-01-03 10-11-24.webm](https://github.com/Sjoerd1993/Graphs/assets/68477016/218e7188-db17-4780-95ed-731c4a1987e8)
