### PR TITLE
Fix NoneType on pan error

### DIFF
--- a/src/canvas.py
+++ b/src/canvas.py
@@ -316,7 +316,7 @@ class Canvas(FigureCanvas, Graphs.CanvasInterface):
             # Set tick where requested, as long as that axis is not occupied
             # and visible
             if (params[f"xtick.{directions[0]}"]
-                    or params[f"ytick.{directions[1]}"]) :
+                    or params[f"ytick.{directions[1]}"]):
                 axis.tick_params(which=ticks, **{
                     direction: (draw_frame and not visible_axes[i]
                                 or direction in directions)
@@ -693,11 +693,11 @@ class _DummyToolbar(NavigationToolbar2):
         This is intended to be overridden by new projection types.
         """
         points = self._get_pan_points(button, key, x, y)
-        ylim = points[:, 1]
-        xlim = points[:, 0]
         if points is not None:
             # Max and min needs to be defined at correct position for this to
             # work with inverted scaling
+            ylim = points[:, 1]
+            xlim = points[:, 0]
             self.set_xlim(min(xlim), max(xlim))
             self.set_ylim(min(ylim), max(ylim))
 


### PR DESCRIPTION
Fixes issue #691 

The problem is relatively obvious, when getting the pan points it uses the Matplotlib internal function `._get_pan_points(button, key, x, y)`.  This can sometimes return `None` for whatever reason, see also the original function here (line 4279 on [this code](https://fossies.org/linux/matplotlib/lib/matplotlib/axes/_base.py)). Matplotlib gets around this with the `if points is not None`, which we adapt. But we still try to retrieve the limits from this, even if it got `None`. 

The simple fix is to move the retrieval of the limits after this conditional as well. As we don't use it otherwise anyway. In fact, whenever 'points` is `None`, the rest of the method is not executed at all, so declaring the limits before the conditional is just wasted computational power anyway (no matter how small the impact). 