### PR TITLE
Add discard toast

### DIFF
--- a/src/operations.py
+++ b/src/operations.py
@@ -103,6 +103,9 @@ def perform_operation(self, callback, *args):
             new_xdata, new_ydata = list(new_xdata), list(new_ydata)
             if discard:
                 logging.debug("Discard is true")
+                self.get_window().add_toast_string(
+                    _("Data that was outside of the highlighted area has been"
+                      " discarded"))
                 item.props.xdata = new_xdata
                 item.props.ydata = new_ydata
             else:


### PR DESCRIPTION
Adds a toast when an operation has been performed and the data outside of the higlighted area is discarded. The message is somewhat verbose, but that's because I wanted to have the past-tense in there ("that **was** outside of the") as to make it extra clear that the data that is highlighted _after_ the operation is fine.

![image](https://github.com/Sjoerd1993/Graphs/assets/68477016/2d4e0b11-4413-4936-b236-057f1344a448)


I know the general advice is to use informal title case, but for clarity's sake I followed the following exception here:

> In some cases, a heading can be given a more informal style by expressing it as a regular sentence. In this case:
> 
>   -  Write the heading as a sentence, including auxillary verbs and articles.
> 
>    - Use sentence capitalization.
> 
>    - Continue to use a bold font style.
> 