### PR TITLE
Update pot file

### DIFF
--- a/po/graphs.pot
+++ b/po/graphs.pot
@@ -1,14 +1,14 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the graphs package.
+# This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: graphs\n"
+"Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-01 13:50+0100\n"
+"POT-Creation-Date: 2024-01-08 14:18+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -105,27 +105,27 @@ msgstr ""
 msgid "Add"
 msgstr ""
 
-#: data/ui/add_equation_window.blp:48 data/ui/transform_window.blp:62
+#: data/ui/add_equation_window.blp:48 data/ui/transform_window.blp:63
 msgid "Y ="
 msgstr ""
 
-#: data/ui/add_equation_window.blp:55
+#: data/ui/add_equation_window.blp:56
 msgid "Enter a mathematical expression to generate data from"
 msgstr ""
 
-#: data/ui/add_equation_window.blp:63
+#: data/ui/add_equation_window.blp:64
 msgid "Name (optional)"
 msgstr ""
 
-#: data/ui/add_equation_window.blp:75
+#: data/ui/add_equation_window.blp:77
 msgid "X Start"
 msgstr ""
 
-#: data/ui/add_equation_window.blp:81
+#: data/ui/add_equation_window.blp:84
 msgid "X Stop"
 msgstr ""
 
-#: data/ui/add_equation_window.blp:87
+#: data/ui/add_equation_window.blp:91
 msgid "Step Size"
 msgstr ""
 
@@ -443,7 +443,7 @@ msgstr ""
 msgid "Export Figure"
 msgstr ""
 
-#: data/ui/export_figure.blp:30 src/export_figure.py:64
+#: data/ui/export_figure.blp:30 src/export_figure.py:72
 msgid "Export"
 msgstr ""
 
@@ -815,7 +815,7 @@ msgid "Remove Item"
 msgstr ""
 
 #: data/ui/smoothen_settings.blp:7
-msgid "Smoothen settings"
+msgid "Smoothen Settings"
 msgstr ""
 
 #: data/ui/smoothen_settings.blp:37
@@ -1063,7 +1063,7 @@ msgstr ""
 msgid "X ="
 msgstr ""
 
-#: data/ui/transform_window.blp:66
+#: data/ui/transform_window.blp:68
 msgid "Discard Unselected Data"
 msgstr ""
 
@@ -1279,8 +1279,9 @@ msgstr ""
 msgid "Advanced Settings"
 msgstr ""
 
-#: src/actions.py:214
-msgid "Deleted {}"
+#: src/actions.py:214 src/item_box.py:130
+#, python-brace-format
+msgid "Deleted {name}"
 msgstr ""
 
 #: src/add_equation.py:64
@@ -1288,7 +1289,7 @@ msgstr ""
 msgid "{error} - Unable to add data from equation"
 msgstr ""
 
-#: src/application.py:49
+#: src/application.py:50
 #, python-format
 msgid "Could not load %s"
 msgstr ""
@@ -1325,8 +1326,12 @@ msgstr ""
 msgid "Fitting Parameters for {param_name}"
 msgstr ""
 
-#: src/export_figure.py:59
+#: src/export_figure.py:64
 msgid "Exported Figure"
+msgstr ""
+
+#: src/export_figure.py:65 src/ui.py:151
+msgid "Open Location"
 msgstr ""
 
 #: src/figure_settings.py:110 src/figure_settings.py:136 src/styles.py:82
@@ -1437,16 +1442,15 @@ msgstr ""
 msgid "Are you sure you want to reset the import settings?"
 msgstr ""
 
-#: src/item_box.py:130
-#, python-brace-format
-msgid "Deleted {name}"
+#: src/operations.py:107
+msgid "Data that was outside of the highlighted area has been discarded"
 msgstr ""
 
-#: src/operations.py:137
+#: src/operations.py:140
 msgid "No data found within the highlighted area"
 msgstr ""
 
-#: src/operations.py:339
+#: src/operations.py:342
 msgid "Combined Data"
 msgstr ""
 
@@ -1537,23 +1541,23 @@ msgstr ""
 msgid "No data to export"
 msgstr ""
 
-#: src/ui.py:146
+#: src/ui.py:150
 msgid "Exported Data"
 msgstr ""
 
-#: src/ui.py:154
+#: src/ui.py:161
 msgid "Text Files"
 msgstr ""
 
-#: src/ui.py:175
+#: src/ui.py:182
 msgid "translator-credits"
 msgstr ""
 
-#: src/ui.py:204 src/ui.py:268 src/ui.py:302
+#: src/ui.py:211 src/ui.py:275 src/ui.py:309
 msgid "Unsupported Widget {}"
 msgstr ""
 
-#: src/ui.py:206 src/ui.py:270 src/ui.py:304
+#: src/ui.py:213 src/ui.py:277 src/ui.py:311
 msgid "No way to apply “{}”"
 msgstr ""
 

--- a/po/graphs.pot
+++ b/po/graphs.pot
@@ -1,12 +1,12 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
+# This file is distributed under the same license as the graphs package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: graphs\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-01-08 14:18+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"


### PR DESCRIPTION
Just run gettext to update the pot file. Only real change (apart from the location of the lines in the code) is one more title case being added. 

Should be the last `pot` update before next release. I think we can push next release very soon (this week). If new things suddenly turn up in the GNOME Circle Review, we can probably push it in Graphs 1.7.1, as I'm not expecting really major UI-breaking stuff there.