### PR TITLE
Release 1.7.0

### DIFF
--- a/data/se.sjoerd.Graphs.appdata.xml.in.in
+++ b/data/se.sjoerd.Graphs.appdata.xml.in.in
@@ -51,10 +51,11 @@
     </screenshot>
   </screenshots>
   <releases>
-    <release version="1.7.0" date="2023-12-14">
+    <release version="1.7.0" date="2024-01-10">
       <description translatable="no">
         <p>Version 1.7 marks our biggest release yet. With a migration to GNOME 45 and a new UI overhaul with a revamped style editor.
-           Other major highlights include a new curve fitting functionality, the ability to open projects directly, and support for gestures in the canvas.
+           Other major highlights include a new curve fitting functionality, the ability to open projects directly, and support for gestures in the canvas. A full changelog,
+           can be found below:
         </p>
         <p>New in Graphs:</p>
         <ul>

--- a/data/se.sjoerd.Graphs.appdata.xml.in.in
+++ b/data/se.sjoerd.Graphs.appdata.xml.in.in
@@ -54,7 +54,7 @@
     <release version="1.7.0" date="2024-01-10">
       <description translatable="no">
         <p>Version 1.7 marks our biggest release yet. With a migration to GNOME 45 and a new UI overhaul with a revamped style editor.
-           Other major highlights include a new curve fitting functionality, the ability to open projects directly, and support for gestures in the canvas. A full changelog
+           Other major highlights include a new curve fitting functionality, the ability to open projects directly and support for gestures in the canvas. A full changelog
            can be found below:
         </p>
         <p>New in Graphs:</p>

--- a/data/se.sjoerd.Graphs.appdata.xml.in.in
+++ b/data/se.sjoerd.Graphs.appdata.xml.in.in
@@ -54,7 +54,7 @@
     <release version="1.7.0" date="2024-01-10">
       <description translatable="no">
         <p>Version 1.7 marks our biggest release yet. With a migration to GNOME 45 and a new UI overhaul with a revamped style editor.
-           Other major highlights include a new curve fitting functionality, the ability to open projects directly, and support for gestures in the canvas. A full changelog,
+           Other major highlights include a new curve fitting functionality, the ability to open projects directly, and support for gestures in the canvas. A full changelog
            can be found below:
         </p>
         <p>New in Graphs:</p>

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 project('graphs', 'c', 'vala',
-          version: '1.7.0-beta',
+          version: '1.7.0',
     meson_version: '>= 0.64.0',
   default_options: [ 'warning_level=2', 'werror=false', ],
 )

--- a/src/ui.py
+++ b/src/ui.py
@@ -172,7 +172,7 @@ def show_about_window(self):
     Adw.AboutWindow(
         transient_for=self.get_window(), application_name=self.get_name(),
         application_icon=self.get_application_id(), website=self.get_website(),
-        developer_name=self.get_author() + ", et al.",
+        developer_name=self.get_author() + " et al.",
         issue_url=self.get_issues(),
         version=self.get_version(), developers=[
             "Sjoerd Stendahl <contact@sjoerd.se>",


### PR DESCRIPTION
Updates the version number to 1.7.0, as well as the appdata.

If everything is OK otherwise, I was planning to tag this commit (after being merged) as release 1.7.0, and release on Flathub+Snap.