### PR TITLE
Update Title Case

### DIFF
--- a/data/se.sjoerd.Graphs.appdata.xml.in.in
+++ b/data/se.sjoerd.Graphs.appdata.xml.in.in
@@ -51,6 +51,11 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="1.7.1" date="2024-01-11">
+      <description translatable="no">
+        <p>Minor patch that sets the legend position strings to title case, and updates the locals to the latest version on Weblate.</p>
+      </description>
+    </release>
     <release version="1.7.0" date="2024-01-10">
       <description translatable="no">
         <p>Version 1.7 marks our biggest release yet. With a migration to GNOME 45 and a new UI overhaul with a revamped style editor.

--- a/data/ui/edit_item.blp
+++ b/data/ui/edit_item.blp
@@ -75,12 +75,12 @@ template $GraphsEditItemWindow : Adw.PreferencesWindow {
         model: StringList {
           strings [
             _("Nothing"), _("Point"), _("Pixel"), _("Circle"),
-            _("Triangle down"), _("Triangle up"), _("Triangle left"),
-            _("Triangle right"), _("Octagon"), _("Square"),
+            _("Triangle Down"), _("Triangle Up"), _("Triangle Left"),
+            _("Triangle Right"), _("Octagon"), _("Square"),
             _("Pentagon"), _("Star"), _("Hexagon 1"),
-            _("Hexagon 2"), _("Plus"), _("x"), _("Diamond"),
-            _("Thin diamond"), _("Vertical line"), _("Horizontal line"),
-            _("Filled plus"), _("Filled x"),
+            _("Hexagon 2"), _("Plus"), _("X"), _("Diamond"),
+            _("Thin Diamond"), _("Vertical Line"), _("Horizontal Line"),
+            _("Filled Plus"), _("Filled X"),
           ]
         };
         notify::selected => $on_markers();

--- a/data/ui/figure_settings.blp
+++ b/data/ui/figure_settings.blp
@@ -150,9 +150,9 @@ template $GraphsFigureSettingsWindow : Adw.Window {
                       title: _("Legend Position");
                       model: StringList{
                         strings [
-                          _("Auto"), _("Upper right"), _("Upper left"), _("Lower left"),
-                          _("Lower right"), _("Center left"), _("Center right"),
-                          _("Lower center"), _("Upper center"), _("Center"),
+                          _("Auto"), _("Upper Right"), _("Upper Left"), _("Lower Left"),
+                          _("Lower Right"), _("Center Left"), _("Center Right"),
+                          _("Lower Center"), _("Upper Center"), _("Center"),
                         ]
                       };
                     }

--- a/data/ui/style_editor.blp
+++ b/data/ui/style_editor.blp
@@ -107,12 +107,12 @@ template $GraphsStyleEditor : Adw.NavigationPage {
               model: StringList {
                 strings [
                   _("Nothing"), _("Point"), _("Pixel"), _("Circle"),
-                  _("Triangle down"), _("Triangle up"), _("Triangle left"),
-                  _("Triangle right"), _("Octagon"), _("Square"),
+                  _("Triangle Down"), _("Triangle Up"), _("Triangle Left"),
+                  _("Triangle Right"), _("Octagon"), _("Square"),
                   _("Pentagon"), _("Star"), _("Hexagon 1"),
-                  _("Hexagon 2"), _("Plus"), _("x"), _("Diamond"),
-                  _("Thin diamond"), _("Vertical line"), _("Horizontal line"),
-                  _("Filled plus"), _("Filled x"),
+                  _("Hexagon 2"), _("Plus"), _("X"), _("Diamond"),
+                  _("Thin Diamond"), _("Vertical Line"), _("Horizontal Line"),
+                  _("Filled Plus"), _("Filled X"),
                 ]
               };
               notify::selected => $on_markers();

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 project('graphs', 'c', 'vala',
-          version: '1.7.0',
+          version: '1.7.1',
     meson_version: '>= 0.64.0',
   default_options: [ 'warning_level=2', 'werror=false', ],
 )

--- a/po/graphs.pot
+++ b/po/graphs.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: graphs\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-09 13:42+0100\n"
+"POT-Creation-Date: 2024-01-11 13:49+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -511,35 +511,35 @@ msgid "Auto"
 msgstr ""
 
 #: data/ui/figure_settings.blp:153
-msgid "Upper right"
+msgid "Upper Right"
 msgstr ""
 
 #: data/ui/figure_settings.blp:153
-msgid "Upper left"
+msgid "Upper Left"
 msgstr ""
 
 #: data/ui/figure_settings.blp:153
-msgid "Lower left"
+msgid "Lower Left"
 msgstr ""
 
 #: data/ui/figure_settings.blp:154
-msgid "Lower right"
+msgid "Lower Right"
 msgstr ""
 
 #: data/ui/figure_settings.blp:154
-msgid "Center left"
+msgid "Center Left"
 msgstr ""
 
 #: data/ui/figure_settings.blp:154
-msgid "Center right"
+msgid "Center Right"
 msgstr ""
 
 #: data/ui/figure_settings.blp:155
-msgid "Lower center"
+msgid "Lower Center"
 msgstr ""
 
 #: data/ui/figure_settings.blp:155
-msgid "Upper center"
+msgid "Upper Center"
 msgstr ""
 
 #: data/ui/figure_settings.blp:155 data/ui/window.blp:338
@@ -1545,15 +1545,15 @@ msgstr ""
 msgid "Text Files"
 msgstr ""
 
-#: src/ui.py:182
+#: src/ui.py:188
 msgid "translator-credits"
 msgstr ""
 
-#: src/ui.py:211 src/ui.py:275 src/ui.py:309
+#: src/ui.py:217 src/ui.py:281 src/ui.py:315
 msgid "Unsupported Widget {}"
 msgstr ""
 
-#: src/ui.py:213 src/ui.py:277 src/ui.py:311
+#: src/ui.py:219 src/ui.py:283 src/ui.py:317
 msgid "No way to apply “{}”"
 msgstr ""
 

--- a/po/graphs.pot
+++ b/po/graphs.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: graphs\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-11 13:59+0100\n"
+"POT-Creation-Date: 2024-01-11 15:54+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -363,19 +363,19 @@ msgstr ""
 msgid "Circle"
 msgstr ""
 
-#: data/ui/edit_item.blp:78
+#: data/ui/edit_item.blp:78 data/ui/style_editor.blp:110
 msgid "Triangle Down"
 msgstr ""
 
-#: data/ui/edit_item.blp:78
+#: data/ui/edit_item.blp:78 data/ui/style_editor.blp:110
 msgid "Triangle Up"
 msgstr ""
 
-#: data/ui/edit_item.blp:78
+#: data/ui/edit_item.blp:78 data/ui/style_editor.blp:110
 msgid "Triangle Left"
 msgstr ""
 
-#: data/ui/edit_item.blp:79
+#: data/ui/edit_item.blp:79 data/ui/style_editor.blp:111
 msgid "Triangle Right"
 msgstr ""
 
@@ -407,7 +407,7 @@ msgstr ""
 msgid "Plus"
 msgstr ""
 
-#: data/ui/edit_item.blp:81
+#: data/ui/edit_item.blp:81 data/ui/style_editor.blp:113
 msgid "X"
 msgstr ""
 
@@ -415,23 +415,23 @@ msgstr ""
 msgid "Diamond"
 msgstr ""
 
-#: data/ui/edit_item.blp:82
+#: data/ui/edit_item.blp:82 data/ui/style_editor.blp:114
 msgid "Thin Diamond"
 msgstr ""
 
-#: data/ui/edit_item.blp:82
+#: data/ui/edit_item.blp:82 data/ui/style_editor.blp:114
 msgid "Vertical Line"
 msgstr ""
 
-#: data/ui/edit_item.blp:82
+#: data/ui/edit_item.blp:82 data/ui/style_editor.blp:114
 msgid "Horizontal Line"
 msgstr ""
 
-#: data/ui/edit_item.blp:83
+#: data/ui/edit_item.blp:83 data/ui/style_editor.blp:115
 msgid "Filled Plus"
 msgstr ""
 
-#: data/ui/edit_item.blp:83
+#: data/ui/edit_item.blp:83 data/ui/style_editor.blp:115
 msgid "Filled X"
 msgstr ""
 
@@ -880,46 +880,6 @@ msgstr ""
 
 #: data/ui/style_editor.blp:80
 msgid "Lines"
-msgstr ""
-
-#: data/ui/style_editor.blp:110
-msgid "Triangle down"
-msgstr ""
-
-#: data/ui/style_editor.blp:110
-msgid "Triangle up"
-msgstr ""
-
-#: data/ui/style_editor.blp:110
-msgid "Triangle left"
-msgstr ""
-
-#: data/ui/style_editor.blp:111
-msgid "Triangle right"
-msgstr ""
-
-#: data/ui/style_editor.blp:113
-msgid "x"
-msgstr ""
-
-#: data/ui/style_editor.blp:114
-msgid "Thin diamond"
-msgstr ""
-
-#: data/ui/style_editor.blp:114
-msgid "Vertical line"
-msgstr ""
-
-#: data/ui/style_editor.blp:114
-msgid "Horizontal line"
-msgstr ""
-
-#: data/ui/style_editor.blp:115
-msgid "Filled plus"
-msgstr ""
-
-#: data/ui/style_editor.blp:115
-msgid "Filled x"
 msgstr ""
 
 #: data/ui/style_editor.blp:138

--- a/po/graphs.pot
+++ b/po/graphs.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: graphs\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-11 13:49+0100\n"
+"POT-Creation-Date: 2024-01-11 13:59+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -363,20 +363,20 @@ msgstr ""
 msgid "Circle"
 msgstr ""
 
-#: data/ui/edit_item.blp:78 data/ui/style_editor.blp:110
-msgid "Triangle down"
+#: data/ui/edit_item.blp:78
+msgid "Triangle Down"
 msgstr ""
 
-#: data/ui/edit_item.blp:78 data/ui/style_editor.blp:110
-msgid "Triangle up"
+#: data/ui/edit_item.blp:78
+msgid "Triangle Up"
 msgstr ""
 
-#: data/ui/edit_item.blp:78 data/ui/style_editor.blp:110
-msgid "Triangle left"
+#: data/ui/edit_item.blp:78
+msgid "Triangle Left"
 msgstr ""
 
-#: data/ui/edit_item.blp:79 data/ui/style_editor.blp:111
-msgid "Triangle right"
+#: data/ui/edit_item.blp:79
+msgid "Triangle Right"
 msgstr ""
 
 #: data/ui/edit_item.blp:79 data/ui/style_editor.blp:111
@@ -407,32 +407,32 @@ msgstr ""
 msgid "Plus"
 msgstr ""
 
-#: data/ui/edit_item.blp:81 data/ui/style_editor.blp:113
-msgid "x"
+#: data/ui/edit_item.blp:81
+msgid "X"
 msgstr ""
 
 #: data/ui/edit_item.blp:81 data/ui/style_editor.blp:113
 msgid "Diamond"
 msgstr ""
 
-#: data/ui/edit_item.blp:82 data/ui/style_editor.blp:114
-msgid "Thin diamond"
+#: data/ui/edit_item.blp:82
+msgid "Thin Diamond"
 msgstr ""
 
-#: data/ui/edit_item.blp:82 data/ui/style_editor.blp:114
-msgid "Vertical line"
+#: data/ui/edit_item.blp:82
+msgid "Vertical Line"
 msgstr ""
 
-#: data/ui/edit_item.blp:82 data/ui/style_editor.blp:114
-msgid "Horizontal line"
+#: data/ui/edit_item.blp:82
+msgid "Horizontal Line"
 msgstr ""
 
-#: data/ui/edit_item.blp:83 data/ui/style_editor.blp:115
-msgid "Filled plus"
+#: data/ui/edit_item.blp:83
+msgid "Filled Plus"
 msgstr ""
 
-#: data/ui/edit_item.blp:83 data/ui/style_editor.blp:115
-msgid "Filled x"
+#: data/ui/edit_item.blp:83
+msgid "Filled X"
 msgstr ""
 
 #: data/ui/edit_item.blp:90 data/ui/style_editor.blp:122
@@ -880,6 +880,46 @@ msgstr ""
 
 #: data/ui/style_editor.blp:80
 msgid "Lines"
+msgstr ""
+
+#: data/ui/style_editor.blp:110
+msgid "Triangle down"
+msgstr ""
+
+#: data/ui/style_editor.blp:110
+msgid "Triangle up"
+msgstr ""
+
+#: data/ui/style_editor.blp:110
+msgid "Triangle left"
+msgstr ""
+
+#: data/ui/style_editor.blp:111
+msgid "Triangle right"
+msgstr ""
+
+#: data/ui/style_editor.blp:113
+msgid "x"
+msgstr ""
+
+#: data/ui/style_editor.blp:114
+msgid "Thin diamond"
+msgstr ""
+
+#: data/ui/style_editor.blp:114
+msgid "Vertical line"
+msgstr ""
+
+#: data/ui/style_editor.blp:114
+msgid "Horizontal line"
+msgstr ""
+
+#: data/ui/style_editor.blp:115
+msgid "Filled plus"
+msgstr ""
+
+#: data/ui/style_editor.blp:115
+msgid "Filled x"
 msgstr ""
 
 #: data/ui/style_editor.blp:138


### PR DESCRIPTION
Fixes issue #717 

I was thinking of maybe pushing the 1.7.1 update already after merging this, but in principle I can wait until tomorrow so we could update the last localization for the languages that are at 99% now. 

It's okay to do it for the 1.7.2 patch, but if you have time maybe @sabriunal could update the last five strings or so in Turkish? Changed some of the strings close to release which didn't get updated. 

Same with German @cmkohnen.  Also, just a hand full of strings, would be nice to have those in the next update as well. My idea was to release the patch before the next TWIG release, as I notice in the statistics that that always brings a measurable wave in installs.