### PR TITLE
Hide highlight after operation

### DIFF
--- a/src/operations.py
+++ b/src/operations.py
@@ -135,7 +135,10 @@ def perform_operation(self, callback, *args):
                 item.xdata, item.ydata = sort_data(item.xdata, item.ydata)
         item.notify("xdata")
         item.notify("ydata")
-        self.get_window().get_canvas().highlight.extents = (0, 0)
+        canvas = self.get_window().get_canvas()
+        canvas.highlight.extents = (0, 0)
+        canvas.set_property("min_selected", 0)
+        canvas.set_property("max_selected", 0)
     if not data_selected:
         self.get_window().add_toast_string(
             _("No data found within the highlighted area"))

--- a/src/operations.py
+++ b/src/operations.py
@@ -135,6 +135,7 @@ def perform_operation(self, callback, *args):
                 item.xdata, item.ydata = sort_data(item.xdata, item.ydata)
         item.notify("xdata")
         item.notify("ydata")
+        self.get_window().get_canvas().highlight.extents = (0, 0)
     if not data_selected:
         self.get_window().add_toast_string(
             _("No data found within the highlighted area"))


### PR DESCRIPTION
Closes #719

[Skärminspelning från 2024-01-11 14-23-19.webm](https://github.com/Sjoerd1993/Graphs/assets/68477016/9d7250d6-f5bd-4007-8054-b72e194c4919)

Hides highlight after performing an operation by setting its extents to an infinitesimally small area of (0,0). Data points located at x=0 do fall in between this infinitesimally small span either, I have tested that.