### PR TITLE
Remove filename from subtitle

### DIFF
--- a/src/data.py
+++ b/src/data.py
@@ -125,7 +125,7 @@ class Data(GObject.Object, Graphs.DataInterface):
         if self.project_file is None:
             return _("Draft")
         uri_parse = urlparse(self.project_file.get_uri())
-        filepath = os.path.realpath(
+        filepath = os.path.dirname(
             os.path.join(uri_parse.netloc, unquote(uri_parse.path)))
         if filepath.startswith("/var"):
             # Fix for rpm-ostree distros, where home is placed in /var/home


### PR DESCRIPTION
Removes the filename from the subtitle, only shows the path there. The filename is redundant because it's in the main title, and this (path in subtitle, filename in regular title) is also exactly like GNOME Text Editor does it.

![image](https://github.com/Sjoerd1993/Graphs/assets/68477016/5b95cb3a-276f-478f-965d-53ab04732881)
