### PR TITLE
Do not optimise limits for hidden items

### DIFF
--- a/src/data.py
+++ b/src/data.py
@@ -537,7 +537,7 @@ class Data(GObject.Object, Graphs.DataInterface):
         for item_ in self:
             if not isinstance(item_, item.DataItem) or (
                     not item_.get_selected()
-                    and figure_settings.get_property("hide-unselected")):
+                    and figure_settings.get_hide_unselected()):
                 continue
             for index in \
                     item_.get_xposition() * 2, 1 + item_.get_yposition() * 2:

--- a/src/data.py
+++ b/src/data.py
@@ -535,7 +535,9 @@ class Data(GObject.Object, Graphs.DataInterface):
             for direction in ("bottom", "left", "top", "right")
         ]
         for item_ in self:
-            if not isinstance(item_, item.DataItem):
+            if not isinstance(item_, item.DataItem) or (
+                    not item_.get_selected()
+                    and figure_settings.get_property("hide-unselected")):
                 continue
             for index in \
                     item_.get_xposition() * 2, 1 + item_.get_yposition() * 2:


### PR DESCRIPTION
Does not optimise limits for items that are hidden. I found it unintuitive if items are hidden, that these are still taken into account when doing optimise limits. Skipping those items make the following possible:

[Skärminspelning från 2024-01-17 08-17-17.webm](https://github.com/Sjoerd1993/Graphs/assets/68477016/bf0557ee-461e-4c41-b6cb-062bad58579e)

Which is thus useful if you have a bunch of datasets in the same project with different limits, and just want to toggle between them. When items are not hidden, but non-active, then they are still used when optimising the limits.